### PR TITLE
refactor: add pyright strict type checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,17 +10,21 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
         with:
           args: "check"
 
   pyright:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - run: pip install -e ".[dev]"
-      - uses: jakebailey/pyright-action@v2
+      - uses: jakebailey/pyright-action@6cabc0f01c4994be48fd45cd9dbacdd6e1ee6e5e # v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,13 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           args: "check"
+
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev]"
+      - uses: jakebailey/pyright-action@v2

--- a/docs/plans/2026-07-01-001-refactor-pyright-strict-type-checking-plan.md
+++ b/docs/plans/2026-07-01-001-refactor-pyright-strict-type-checking-plan.md
@@ -1,0 +1,314 @@
+---
+title: Add pyright strict type checking
+type: refactor
+status: active
+date: 2026-07-01
+---
+
+# Add pyright strict type checking
+
+## Summary
+
+Add pyright in strict mode as a static type checker for the orchid codebase. This involves configuring pyright, adding it to dev dependencies and CI, then incrementally fixing type errors across 59 Python source files to achieve a clean strict-mode pass.
+
+---
+
+## Problem Frame
+
+The orchid codebase has no static type checking configured. While many domain dataclasses have reasonable annotations, there is pervasive `Any` usage, missing return types on some methods, and untyped parameters in key files (`llm/client.py`, `app.py`, `config.py`, `agents/manager.py`). Without a type checker, type errors propagate silently and refactoring is riskier. Adding pyright strict mode establishes a safety net and improves code quality.
+
+---
+
+## Requirements
+
+- R1. Pyright strict mode is configured and runs cleanly on the codebase
+- R2. Pyright runs in CI on every push/PR to main
+- R3. Type annotations are added or tightened where pyright reports errors
+- R4. Legitimate dynamic patterns that cannot be statically typed use targeted `# type: ignore[...]` comments with specific error codes
+
+---
+
+## Scope Boundaries
+
+- Not rewriting `dict[str, Any]` patterns into typed dataclasses unless needed to satisfy pyright errors
+- Not changing runtime behavior — all fixes are annotation-only or type-ignore additions
+- Not adding runtime type validation (e.g., pydantic, beartype)
+
+### Deferred to Follow-Up Work
+
+- Tightening `Any` usage beyond what strict mode requires: separate follow-up
+- Adding typed dicts or Protocol types for litellm/stream chunk shapes: separate PR
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `pyproject.toml` — existing project config, ruff config, dev dependencies
+- `.github/workflows/lint.yml` — existing lint CI workflow to extend
+- `src/orchid/domain/message.py` — well-typed example with dataclasses
+- `src/orchid/llm/client.py` — heaviest `Any` usage, monkey-patching, will need most work
+- `src/orchid/app.py` — Textual App subclass with dynamic patterns
+- `src/orchid/config.py` — dynamic getattr/setattr patterns
+- `src/orchid/agents/manager.py` — complex async callback signatures
+
+### External References
+
+- [Pyright configuration docs](https://microsoft.github.io/pyright/#/configuration)
+- [Pyright strict mode](https://microsoft.github.io/pyright/#/configuration?id=type-check-rule-overrides)
+
+---
+
+## Key Technical Decisions
+
+- **Use `pyproject.toml` `[tool.pyright]` section** rather than `pyrightconfig.json`: keeps all Python tool config in one place alongside ruff and pytest.
+- **Start with `typeCheckingMode = "basic"` then escalate to `"strict"`**: fix errors incrementally rather than all at once, reducing risk of large broken diffs.
+- **Use specific `# type: ignore[error-code]` comments**: avoid blanket `# type: ignore` so future errors in nearby code are still caught.
+- **Add pyright to `[project.optional-dependencies] dev`**: keeps it alongside ruff and pytest as a dev tool.
+
+---
+
+## Implementation Units
+
+- U1. **Add pyright configuration and dev dependency**
+
+**Goal:** Configure pyright in strict mode and add it as a dev dependency.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `pyproject.toml`
+
+**Approach:**
+- Add `pyright` to `[project.optional-dependencies] dev` list
+- Add `[tool.pyright]` section with `typeCheckingMode = "strict"`, `pythonVersion = "3.11"`, `include = ["src"]`, `exclude = [".venv"]`
+- Set `reportMissingImports = true`, `reportMissingTypeStubs = false` (for third-party libs without stubs)
+
+**Patterns to follow:**
+- Existing ruff/pytest config in `pyproject.toml`
+
+**Test scenarios:**
+- Happy path: `pip install -e ".[dev]"` installs pyright
+- Happy path: `pyright` runs without config errors
+
+**Verification:**
+- `pyright --version` succeeds after install
+- `pyright` command runs (may have type errors at this stage)
+
+---
+
+- U2. **Fix type errors in domain layer (`src/orchid/domain/`)**
+
+**Goal:** Achieve clean pyright strict pass on domain dataclasses and models.
+
+**Requirements:** R3
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/orchid/domain/message.py`
+- Modify: `src/orchid/domain/agent.py`
+- Modify: `src/orchid/domain/tool.py`
+- Modify: `src/orchid/domain/session.py`
+- Modify: `src/orchid/domain/chain.py`
+- Modify: `src/orchid/domain/skill.py`
+- Modify: `src/orchid/domain/todo.py`
+
+**Approach:**
+- Run `pyright src/orchid/domain/` and fix errors
+- Add missing return type annotations
+- Replace bare `dict` with `dict[str, Any]` where needed
+- Add type annotations for untyped parameters
+
+**Test scenarios:**
+- Happy path: `pyright src/orchid/domain/` reports zero errors
+- Edge case: existing tests still pass (`pytest tests/`)
+
+**Verification:**
+- `pyright src/orchid/domain/` exits cleanly
+
+---
+
+- U3. **Fix type errors in config and storage (`config.py`, `storage.py`, `utils.py`)**
+
+**Goal:** Achieve clean pyright strict pass on config and utility modules.
+
+**Requirements:** R3
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/orchid/config.py`
+- Modify: `src/orchid/storage.py`
+- Modify: `src/orchid/utils.py`
+
+**Approach:**
+- Run `pyright src/orchid/config.py src/orchid/storage.py src/orchid/utils.py` and fix errors
+- Add type annotations for `_cast_value`'s `target_type` parameter
+- Add proper typing for dynamic getattr/setattr patterns where feasible
+- Use `# type: ignore[assignment]` for genuinely dynamic attribute access
+
+**Test scenarios:**
+- Happy path: `pyright src/orchid/config.py` reports zero errors
+- Happy path: `pyright src/orchid/storage.py` reports zero errors
+
+**Verification:**
+- `pyright src/orchid/config.py src/orchid/storage.py src/orchid/utils.py` exits cleanly
+
+---
+
+- U4. **Fix type errors in tools layer (`src/orchid/tools/`)**
+
+**Goal:** Achieve clean pyright strict pass on all tool implementations.
+
+**Requirements:** R3
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/orchid/tools/exec.py`
+- Modify: `src/orchid/tools/search.py`
+- Modify: `src/orchid/tools/file_manipulation.py`
+- Modify: `src/orchid/tools/web_fetch.py`
+- Modify: `src/orchid/tools/todo.py`
+- Modify: `src/orchid/tools/subagent.py`
+- Modify: `src/orchid/tools/skill.py`
+- Modify: `src/orchid/tools/rag.py`
+- Modify: `src/orchid/tools/mcp_resource.py`
+- Modify: `src/orchid/tools/ast.py`
+- Modify: `src/orchid/tools/_xml_utils.py`
+
+**Approach:**
+- Run `pyright src/orchid/tools/` and fix errors
+- Add missing return type and parameter annotations
+- Type tool function signatures precisely
+
+**Test scenarios:**
+- Happy path: `pyright src/orchid/tools/` reports zero errors
+
+**Verification:**
+- `pyright src/orchid/tools/` exits cleanly
+
+---
+
+- U5. **Fix type errors in LLM client (`src/orchid/llm/`)**
+
+**Goal:** Achieve clean pyright strict pass on LLM client — the most challenging module due to litellm interop.
+
+**Requirements:** R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/orchid/llm/client.py`
+- Modify: `src/orchid/llm/providers.py`
+- Modify: `src/orchid/llm/dynamic_system_prompt.py`
+- Modify: `src/orchid/llm/static_system_prompt.py`
+
+**Approach:**
+- Run `pyright src/orchid/llm/` and fix errors
+- For litellm interop that cannot be statically typed, use targeted `# type: ignore[arg-type]` or `# type: ignore[assignment]` with specific error codes
+- Tighten callback type signatures where possible
+- Add missing return type annotations
+
+**Test scenarios:**
+- Happy path: `pyright src/orchid/llm/` reports zero errors
+- Integration: existing LLM tests still pass
+
+**Verification:**
+- `pyright src/orchid/llm/` exits cleanly
+
+---
+
+- U6. **Fix type errors in remaining modules (app, agents, mcp, ast, rag, screens, widgets, themes, commands, skills, personality)**
+
+**Goal:** Achieve clean pyright strict pass on all remaining source modules.
+
+**Requirements:** R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/orchid/app.py`
+- Modify: `src/orchid/agents/manager.py`
+- Modify: `src/orchid/mcp/__init__.py`
+- Modify: `src/orchid/mcp/schema.py`
+- Modify: `src/orchid/ast/*.py`
+- Modify: `src/orchid/rag/*.py`
+- Modify: `src/orchid/screens/*.py`
+- Modify: `src/orchid/widgets/*.py`
+- Modify: `src/orchid/themes/*.py`
+- Modify: `src/orchid/commands/*.py`
+- Modify: `src/orchid/skills/*.py`
+- Modify: `src/orchid/personality/*.py`
+- Modify: `src/orchid/__init__.py`
+- Modify: `src/orchid/main.py`
+
+**Approach:**
+- Run `pyright src/orchid/` (full scan) and fix remaining errors
+- For MCP SDK, textual, and other third-party library interop that cannot be statically typed, use targeted `# type: ignore[...]` comments
+- Add missing annotations on callbacks and async functions
+
+**Test scenarios:**
+- Happy path: `pyright src/orchid/` reports zero errors
+- Integration: full test suite passes (`pytest`)
+
+**Verification:**
+- `pyright src/orchid/` exits cleanly with zero errors
+
+---
+
+- U7. **Add pyright to CI workflow**
+
+**Goal:** Run pyright in CI on every push/PR to main so type errors are caught before merge.
+
+**Requirements:** R2
+
+**Dependencies:** U6
+
+**Files:**
+- Modify: `.github/workflows/lint.yml`
+
+**Approach:**
+- Add a `pyright` job to the existing lint workflow
+- Use the `jakebailey/pyright-action` GitHub Action for consistent version pinning
+- Run on same triggers as ruff (push/PR to main)
+
+**Test scenarios:**
+- Happy path: CI workflow passes with pyright step
+- Error path: introducing a type error causes CI to fail
+
+**Verification:**
+- `act` or manual CI run shows pyright step passing
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** No runtime behavior changes — type annotations and type-ignore comments are additive
+- **Error propagation:** N/A — static analysis only
+- **State lifecycle risks:** None — no runtime changes
+- **API surface parity:** None
+- **Integration coverage:** N/A
+- **Unchanged invariants:** All existing functionality, tests, and runtime behavior remain identical
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Large number of type errors may be overwhelming to fix | Incremental approach: fix module-by-module, use type-ignore for genuinely dynamic code |
+| Third-party libraries (litellm, textual, mcp) may lack type stubs | Use `reportMissingTypeStubs = false` and targeted type-ignore comments |
+| Pyright version upgrades may introduce new errors | Pin pyright version in CI and dev dependencies |
+
+---
+
+## Sources & References
+
+- [Pyright configuration docs](https://microsoft.github.io/pyright/#/configuration)
+- Existing lint CI: `.github/workflows/lint.yml`
+- Project config: `pyproject.toml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest-asyncio",
     "pytest-timeout>=2.0",
     "ruff",
+    "pyright",
 ]
 
 [tool.ruff]
@@ -45,3 +46,10 @@ ignore = ["E501", "SIM105"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 timeout = 120
+
+[tool.pyright]
+typeCheckingMode = "strict"
+pythonVersion = "3.11"
+include = ["src"]
+exclude = [".venv"]
+reportMissingTypeStubs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "pytest-asyncio",
     "pytest-timeout>=2.0",
     "ruff",
-    "pyright",
+    "pyright==1.1.411",
 ]
 
 [tool.ruff]

--- a/src/orchid/agents/__init__.py
+++ b/src/orchid/agents/__init__.py
@@ -69,7 +69,7 @@ def _load_agents_from_dir(agents_dir: Path) -> dict[str, Agent]:
                 name=str(name),
                 type=AgentTypes.from_str(str(agent_type)),
                 tier=ModelTier.from_str(str(tier)),
-                description=description,
+                description=str(description),
                 system_prompt=body.strip(),
                 allowed_tools=allowed_tools,  # pyright: ignore[reportUnknownArgumentType]
                 allowed_skills=allowed_skills,  # pyright: ignore[reportUnknownArgumentType]

--- a/src/orchid/agents/__init__.py
+++ b/src/orchid/agents/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Any
 
 from orchid.config import HOME_AGENTS_DIR, PROJECT_AGENTS_DIR
 from orchid.domain.agent import Agent, AgentTypes, ModelTier
@@ -34,9 +35,9 @@ def _load_agents_from_dir(agents_dir: Path) -> dict[str, Agent]:
         name = metadata.get('name', path.name)
         agent_type = metadata.get('type', 'subagent')
         tier = metadata.get('tier', 'bloom')
-        description = metadata.get('description', '')
-        allowed_tools = metadata.get('allowed_tools')
-        allowed_skills = metadata.get('allowed_skills', [])
+        description: str = metadata.get('description', '')
+        allowed_tools: Any = metadata.get('allowed_tools')
+        allowed_skills: Any = metadata.get('allowed_skills', [])
         if isinstance(allowed_tools, str):
             if allowed_tools.strip() in ('[]', ''):
                 allowed_tools = []
@@ -47,7 +48,7 @@ def _load_agents_from_dir(agents_dir: Path) -> dict[str, Agent]:
                 allowed_skills = []
             else:
                 allowed_skills = [s.strip() for s in allowed_skills.split(',') if s.strip()]
-        if not isinstance(allowed_skills, list) or not all(isinstance(s, str) for s in allowed_skills):
+        if not isinstance(allowed_skills, list) or not all(isinstance(s, str) for s in allowed_skills):  # pyright: ignore[reportUnknownVariableType]
             log.warning("Skipping %s: allowed_skills must be a list of strings", agent_file)
             allowed_skills = []
 
@@ -59,7 +60,7 @@ def _load_agents_from_dir(agents_dir: Path) -> dict[str, Agent]:
             log.warning("Skipping %s: no allowed_tools in frontmatter", agent_file)
             continue
 
-        if not isinstance(allowed_tools, list) or not all(isinstance(t, str) for t in allowed_tools):
+        if not isinstance(allowed_tools, list) or not all(isinstance(t, str) for t in allowed_tools):  # pyright: ignore[reportUnknownVariableType]
             log.warning("Skipping %s: allowed_tools must be a list of strings", agent_file)
             continue
 
@@ -70,8 +71,8 @@ def _load_agents_from_dir(agents_dir: Path) -> dict[str, Agent]:
                 tier=ModelTier.from_str(str(tier)),
                 description=description,
                 system_prompt=body.strip(),
-                allowed_tools=allowed_tools,
-                allowed_skills=allowed_skills,
+                allowed_tools=allowed_tools,  # pyright: ignore[reportUnknownArgumentType]
+                allowed_skills=allowed_skills,  # pyright: ignore[reportUnknownArgumentType]
             )
         except (KeyError, ValueError, AttributeError) as e:
             log.warning("Skipping %s: %s", agent_file, e)
@@ -96,7 +97,7 @@ def load_agents() -> dict[str, Agent]:
     project_agents = _load_agents_from_dir(project_agents_dir)
 
     merged = {**home_agents, **project_agents}
-    AGENT_REGISTRY = merged
+    AGENT_REGISTRY = merged  # pyright: ignore[reportConstantRedefinition]
 
     from orchid.tools import reset_tool_registry
     reset_tool_registry()

--- a/src/orchid/agents/manager.py
+++ b/src/orchid/agents/manager.py
@@ -34,18 +34,12 @@ def set_current_chain_index(index: int | None) -> None:
     _current_chain_index.set(index)
 
 
-def _log_task_exception(task: asyncio.Task) -> None:
+def _log_task_exception(task: asyncio.Task[Any]) -> None:
     if task.cancelled():
         return
     exc = task.exception()
     if exc is not None:
         log.error("Unhandled exception in background task: %s", exc, exc_info=exc)
-
-
-def _fire_and_forget(coro: Coroutine) -> asyncio.Task:
-    task = asyncio.create_task(coro)
-    task.add_done_callback(_log_task_exception)
-    return task
 
 
 def get_subagent_manager() -> SubagentManager:
@@ -109,7 +103,7 @@ class SubagentRecord:
     state: SubagentState
     label: str = ""
     task: str = ""
-    async_task: asyncio.Task | None = None
+    async_task: asyncio.Task[None] | None = None
     result: str | None = None
     error: str | None = None
     start_time: float = 0.0
@@ -213,7 +207,7 @@ class SubagentRecord:
         # orphan-tool-result reconciliation once (R9). Old records persisted
         # a flat `messages` list rather than a nested `chain` dict; fall back
         # to that shape so legacy sessions keep loading.
-        chain_data = data.get("chain")
+        chain_data: dict[str, Any] | None = data.get("chain")
         if isinstance(chain_data, dict):
             chain = Chain.from_storage_dict(chain_data)
         else:
@@ -287,9 +281,9 @@ class SubagentManager:
         self._subagents: dict[str, SubagentRecord] = {}
         self.on_spawn: Callable[[SubagentRecord],
                                 Coroutine[Any, Any, None]] | None = None
-        self._pending_callback_tasks: set[asyncio.Task] = set()
+        self._pending_callback_tasks: set[asyncio.Task[Any]] = set()
 
-    def _fire_and_forget(self, coro: Coroutine) -> asyncio.Task:
+    def _fire_and_forget(self, coro: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
         task = asyncio.create_task(coro)
         self._pending_callback_tasks.add(task)
         task.add_done_callback(_log_task_exception)
@@ -325,7 +319,7 @@ class SubagentManager:
 
     def cancel_all(self) -> list[str]:
         """Cancel all running subagents. Returns list of cancelled IDs."""
-        cancelled = []
+        cancelled: list[str] = []
         for record in self._subagents.values():
             if self._cancel_record(record):
                 cancelled.append(record.id)
@@ -334,7 +328,7 @@ class SubagentManager:
 
     def cancel_running(self) -> list[str]:
         """Cancel all non-terminal subagents. Returns list of cancelled IDs."""
-        cancelled = []
+        cancelled: list[str] = []
         for record in self._subagents.values():
             if record.state in TERMINAL:
                 continue
@@ -438,7 +432,7 @@ class SubagentManager:
 
     async def wait(self, ids: list[str]) -> dict[str, SubagentRecord]:
         """Wait for all specified subagents to complete. Returns their records."""
-        tasks = []
+        tasks: list[asyncio.Task[None]] = []
         for sid in ids:
             record = self._subagents.get(sid)
             if record and record.async_task and not record.async_task.done():
@@ -449,9 +443,9 @@ class SubagentManager:
 
         return {sid: self._subagents[sid] for sid in ids if sid in self._subagents}
 
-    def get_states(self) -> list[dict]:
+    def get_states(self) -> list[dict[str, Any]]:
         """Return state info for all tracked subagents."""
-        states = []
+        states: list[dict[str, Any]] = []
         for record in self._subagents.values():
             states.append({
                 "id": record.id,

--- a/src/orchid/app.py
+++ b/src/orchid/app.py
@@ -2,10 +2,13 @@ import asyncio
 import logging
 from collections.abc import Callable
 from enum import Enum
+from typing import Any, cast
 
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, ScrollableContainer
+from textual.timer import Timer
 from textual.widgets import LoadingIndicator, Static, TabbedContent, TabPane, TextArea
+from textual.worker import Worker
 
 from orchid.agents import get_agent_registry
 from orchid.agents.manager import set_current_chain_index
@@ -37,7 +40,7 @@ from orchid.widgets.subagent_ui import SubagentUIManager
 log = logging.getLogger(__name__)
 
 
-def _sum_usage(messages: list) -> tuple[int, int, int, int] | None:
+def _sum_usage(messages: list[Message]) -> tuple[int, int, int, int] | None:
     """Sum token usage across all messages carrying ``usage``.
 
     Within a single agentic chain the model may make several LLM calls (think
@@ -150,7 +153,7 @@ def _chain_subagent_subtotals(
 
 
 def _make_subagent_subtotal_provider(
-    session: "Session", chain_index: int
+    session: "Session", chain_index: int | None
 ) -> "Callable[[], tuple[int, int, int, int] | None] | None":
     """Return a closure computing the attributed subagent subtotal for the
     given chain at render time.
@@ -181,10 +184,10 @@ class InputTextArea(TextArea):
     def _on_resize(self) -> None:
         super()._on_resize()
         if self._app_ref is not None:
-            self._app_ref._update_input_height(self)
+            self._app_ref._update_input_height(self)  # pyright: ignore[reportPrivateUsage]
 
 
-class Orchid(App):
+class Orchid(App[None]):
     CSS_PATH = "main.tcss"
     BINDINGS = [
         ("ctrl+p", "command_palette", "Commands"),
@@ -195,15 +198,15 @@ class Orchid(App):
     ]
     COMMANDS = {SessionCommands}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.sessions: SessionManager = SessionManager()
         self._interrupt_state: InterruptState = InterruptState.IDLE
-        self._active_worker: object | None = None
+        self._active_worker: Worker[None] | None = None
         self._subagent_ui = SubagentUIManager(self)
         self._current_chain: ChainContainer | None = None
-        self._footer_timer: object | None = None
-        self._interrupt_timer: object | None = None
+        self._footer_timer: Timer | None = None
+        self._interrupt_timer: Timer | None = None
         self.restart_requested: bool = False
         self._setup_themes()
 
@@ -254,10 +257,11 @@ class Orchid(App):
     async def on_mount(self) -> None:
         self.sessions.create()
         set_todo_refresh_callback(self.refresh_todos)
+        assert self.sessions.active is not None
         self.query_one("#title", Static).update(self.sessions.active.name)
         await self.mount_all_messages()
         text_area = self.query_one("#input", InputTextArea)
-        text_area._app_ref = self
+        text_area._app_ref = self  # pyright: ignore[reportPrivateUsage]
         text_area.display = True
         self._update_input_height(text_area)
         text_area.focus()
@@ -283,7 +287,7 @@ class Orchid(App):
 
     async def on_unmount(self) -> None:
         self._subagent_ui.stop()
-        if hasattr(self, '_mcp_manager') and self._mcp_manager is not None:
+        if hasattr(self, '_mcp_manager') and self._mcp_manager is not None:  # pyright: ignore[reportUnnecessaryComparison]
             try:
                 await self._mcp_manager.shutdown()
             except Exception:
@@ -334,7 +338,7 @@ class Orchid(App):
                 cancelled = self.sessions.active.subagent_manager.cancel_running()
                 await self.sessions.active.subagent_manager.flush_state_callbacks()
                 if cancelled:
-                    names = []
+                    names: list[str] = []
                     for sid in cancelled:
                         record = self.sessions.active.subagent_manager.get_record(sid)
                         if record:
@@ -388,6 +392,7 @@ class Orchid(App):
         text_area.clear()
         self._start_chain()
         msg = Message(role=MessageRole.USER, content=user_msg)
+        assert self._current_chain is not None
         self._current_chain.chain.messages.append(msg)
         await self.mount_message(msg)
         self._reset_interrupt_state()
@@ -421,7 +426,7 @@ class Orchid(App):
         self.query_one("#command-picker", CommandPicker).hide()
         await execute_command(self, event.command)
 
-    def watch_focused(self, focused) -> None:
+    def watch_focused(self, focused: Any) -> None:
         if focused and focused.id == "input":
             try:
                 picker = self.query_one("#command-picker", CommandPicker)
@@ -441,7 +446,7 @@ class Orchid(App):
         else:
             try:
                 sidebar = self.query_one("#sidebar", Sidebar)
-                entries = sidebar._get_focusable_entries()
+                entries = sidebar._get_focusable_entries()  # pyright: ignore[reportPrivateUsage]
                 if entries:
                     entries[0].focus()
             except Exception:
@@ -461,6 +466,7 @@ class Orchid(App):
         ws = StreamWidgetState()
         history_state = StreamHistoryState()
 
+        assert self.sessions.active is not None
         self._subagent_ui.setup(self.sessions.active.subagent_manager)
 
         try:
@@ -473,6 +479,7 @@ class Orchid(App):
                 system_prompt=system_prompt,
                 allowed_skills=general.allowed_skills,
             ):
+                assert self._current_chain is not None
                 record_streamed_message(self._current_chain.chain.messages, msg, history_state)
 
                 await mount_streamed_message(container, msg, ws)
@@ -536,11 +543,10 @@ class Orchid(App):
             self.sessions.active.chains.append(chain)
             chain_index = len(self.sessions.active.chains) - 1
             set_current_chain_index(chain_index)
-        subtotal_provider = (
-            _make_subagent_subtotal_provider(self.sessions.active, chain_index)
-            if chain_index is not None
-            else None
-        )
+        subtotal_provider = None
+        if chain_index is not None:
+            assert self.sessions.active is not None
+            subtotal_provider = _make_subagent_subtotal_provider(self.sessions.active, chain_index)
         container = self.query_one("#output", ScrollableContainer)
         self._current_chain = ChainContainer(chain, subagent_subtotal=subtotal_provider)
         container.mount(self._current_chain)
@@ -635,14 +641,18 @@ class Orchid(App):
                     model or get_config().default_model
                 )
                 litellm_model = qualify_model(litellm_provider, model_id)
-                response = await litellm.acompletion(
+                response = await litellm.acompletion(  # pyright: ignore[reportUnknownMemberType]
                     model=litellm_model,
                     messages=[{"role": "user", "content": prompt}],
                     base_url=base_url,
                     api_key=api_key,
                     timeout=60,
                 )
-                title = response.choices[0].message.content.strip().strip('"').strip("'")
+                result = cast(Any, response)
+                assert result.choices
+                title = result.choices[0].message.content
+                assert isinstance(title, str)
+                title = title.strip().strip('"').strip("'")
                 if title and len(title) < 80:
                     session.name = title
                     if self.sessions.active is session:
@@ -697,6 +707,7 @@ class Orchid(App):
                 )
                 widget = create_message_widget(msg, loaded=True, classes=classes)
                 if widget is not None:
+                    assert chain_container.messages_area is not None
                     await chain_container.messages_area.mount(widget)
                 if msg.type == MessageType.THINKING:
                     prev_was_thinking = True

--- a/src/orchid/app.py
+++ b/src/orchid/app.py
@@ -466,10 +466,10 @@ class Orchid(App[None]):
         ws = StreamWidgetState()
         history_state = StreamHistoryState()
 
-        assert self.sessions.active is not None
-        self._subagent_ui.setup(self.sessions.active.subagent_manager)
-
         try:
+            assert self.sessions.active is not None
+            self._subagent_ui.setup(self.sessions.active.subagent_manager)
+
             general = get_agent_registry()["general"]
             system_prompt = append_personality(general.system_prompt)
             async for msg in stream_response(

--- a/src/orchid/ast/indexer.py
+++ b/src/orchid/ast/indexer.py
@@ -39,7 +39,7 @@ class IndexResult:
     files_skipped: int = 0
     files_deleted: int = 0
     symbols_extracted: int = 0
-    errors: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list[str])
     duration_seconds: float = 0.0
 
 
@@ -91,7 +91,7 @@ async def update_file(file_path: str, project_path: str | None = None) -> None:
 async def index_project(
     project_path: str | None = None,
     force: bool = False,
-    progress_callback: Callable | None = None,
+    progress_callback: Callable[[str, int, int], None] | None = None,
 ) -> IndexResult:
     """Run a full AST indexing scan of the project.
 
@@ -123,7 +123,7 @@ async def index_project(
 async def _index_project_impl(
     project_path: str | None = None,
     force: bool = False,
-    progress_callback: Callable | None = None,
+    progress_callback: Callable[[str, int, int], None] | None = None,
 ) -> IndexResult:
     global _session_initialized
 

--- a/src/orchid/ast/parser.py
+++ b/src/orchid/ast/parser.py
@@ -56,7 +56,7 @@ def _load_language(lang_name: str) -> tree_sitter.Language:
                 lib = ctypes.cdll.LoadLibrary(str(candidate))
                 func = getattr(lib, f"tree_sitter_{so_name}")
                 func.restype = ctypes.c_void_p
-                _grammars[lang_name] = tree_sitter.Language(func())
+                _grammars[lang_name] = tree_sitter.Language(func())  # type: ignore[reportDeprecated]
                 break
         else:
             raise RuntimeError(

--- a/src/orchid/ast/store.py
+++ b/src/orchid/ast/store.py
@@ -4,6 +4,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from orchid.ast.symbols import Symbol
 from orchid.config import AST_INDEX_DB, PROJECT_AST_DIR
@@ -159,7 +160,7 @@ class ASTStore:
 
     def get_symbols_by_name(
         self, name: str, type_filter: str = "both"
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         conn = self._get_conn()
         try:
             if type_filter == "both":

--- a/src/orchid/commands/session_commands.py
+++ b/src/orchid/commands/session_commands.py
@@ -130,7 +130,7 @@ def _build_model_picker_items(cfg: Config, mode: str = "chat") -> list[PickerIte
     """
     items: list[PickerItem] = []
     for alias, provider_entry in cfg.providers.items():
-        if not isinstance(provider_entry, dict):  # type: ignore[reportUnnecessaryIsInstance]
+        if not isinstance(provider_entry, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
             log.warning(
                 "Skipping provider %r: entry must be a dict, got %s",
                 alias,
@@ -138,7 +138,7 @@ def _build_model_picker_items(cfg: Config, mode: str = "chat") -> list[PickerIte
             )
             continue
         models: dict[str, Any] = provider_entry.get("models", {})
-        if not isinstance(models, dict):  # type: ignore[reportUnnecessaryIsInstance]
+        if not isinstance(models, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
             log.warning(
                 "Skipping provider %r: 'models' must be a dict, got %s",
                 alias,
@@ -300,12 +300,12 @@ async def execute_command(app: App[Any], cmd: str) -> None:
                 # mcp_servers changes that warrant a restart prompt. Only short
                 # -circuit when result is None AND mcp_servers are unchanged.
                 if result is None:
-                    current = ConfigManager._instance  # type: ignore[reportPrivateUsage]
+                    current = ConfigManager._instance  # pyright: ignore[reportPrivateUsage]
                     if current is None or current.mcp_servers == cfg.mcp_servers:
                         return
                     saved = current
                 else:
-                    ConfigManager._instance = result  # type: ignore[reportPrivateUsage]
+                    ConfigManager._instance = result  # pyright: ignore[reportPrivateUsage]
                     ConfigManager.save()
                     saved = result
                 needs_restart = saved.mcp_servers != cfg.mcp_servers

--- a/src/orchid/commands/session_commands.py
+++ b/src/orchid/commands/session_commands.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 import logging
 from functools import partial
+from typing import TYPE_CHECKING, Any, cast
 
 from textual.app import App
 from textual.command import DiscoveryHit, Hit, Hits, Matcher, Provider
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from orchid.app import Orchid
 
 from orchid.config import (
     Config,
@@ -62,7 +69,7 @@ _MODEL_PICKER_HEADER = (
 )
 
 
-def _format_model_label(alias: str, model_id: str, metadata: dict) -> str:
+def _format_model_label(alias: str, model_id: str, metadata: dict[str, Any]) -> str:
     """Render a tabular label for the `/model` picker.
 
     Each label is a single padded row with four fixed-width columns so multiple
@@ -123,15 +130,15 @@ def _build_model_picker_items(cfg: Config, mode: str = "chat") -> list[PickerIte
     """
     items: list[PickerItem] = []
     for alias, provider_entry in cfg.providers.items():
-        if not isinstance(provider_entry, dict):
+        if not isinstance(provider_entry, dict):  # type: ignore[reportUnnecessaryIsInstance]
             log.warning(
                 "Skipping provider %r: entry must be a dict, got %s",
                 alias,
                 type(provider_entry).__name__,
             )
             continue
-        models = provider_entry.get("models", {})
-        if not isinstance(models, dict):
+        models: dict[str, Any] = provider_entry.get("models", {})
+        if not isinstance(models, dict):  # type: ignore[reportUnnecessaryIsInstance]
             log.warning(
                 "Skipping provider %r: 'models' must be a dict, got %s",
                 alias,
@@ -171,7 +178,8 @@ def _build_model_picker_items(cfg: Config, mode: str = "chat") -> list[PickerIte
     return items
 
 
-async def execute_command(app: App, cmd: str) -> None:
+async def execute_command(app: App[Any], cmd: str) -> None:
+    app = cast("Orchid", app)
     match cmd:
         case "/new":
             app.sessions.create()
@@ -239,8 +247,9 @@ async def execute_command(app: App, cmd: str) -> None:
 
             async def on_rename_result(result: str | None):
                 if result and result.strip():
+                    assert app.sessions.active is not None
                     app.sessions.active.name = result.strip()
-                    app.query_one("#title").update(result.strip())
+                    cast(Static, app.query_one("#title")).update(result.strip())
                     app.sessions.save_active()
 
             app.push_screen(
@@ -291,19 +300,19 @@ async def execute_command(app: App, cmd: str) -> None:
                 # mcp_servers changes that warrant a restart prompt. Only short
                 # -circuit when result is None AND mcp_servers are unchanged.
                 if result is None:
-                    current = ConfigManager._instance
+                    current = ConfigManager._instance  # type: ignore[reportPrivateUsage]
                     if current is None or current.mcp_servers == cfg.mcp_servers:
                         return
                     saved = current
                 else:
-                    ConfigManager._instance = result
+                    ConfigManager._instance = result  # type: ignore[reportPrivateUsage]
                     ConfigManager.save()
                     saved = result
                 needs_restart = saved.mcp_servers != cfg.mcp_servers
                 if needs_restart:
                     from orchid.screens.settings import ConfirmScreen
 
-                    async def on_restart_confirm(confirmed: bool | None) -> None:
+                    async def on_restart_confirm(confirmed: str | None) -> None:
                         if confirmed:
                             app.request_restart()
                         else:
@@ -402,6 +411,8 @@ async def execute_command(app: App, cmd: str) -> None:
             clear_index()
             app.notify("RAG index cleared.", severity="information")
             await app.refresh_index_status()
+        case _:
+            pass
 
 
 class SessionCommands(Provider):

--- a/src/orchid/config.py
+++ b/src/orchid/config.py
@@ -110,9 +110,9 @@ class Config:
         nested dataclass instances. This fix-up converts the dict to a ``RAGConfig``
         when the constructor receives a dict.
         """
-        if isinstance(self.rag, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: dict from JSON deserialization
-            rag_as_dict: dict[str, Any] = self.rag  # type: ignore[assignment]
-            object.__setattr__(self, "rag", RAGConfig(**rag_as_dict))  # type: ignore[reportUnknownArgumentType]
+        if isinstance(self.rag, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: dict from JSON deserialization
+            rag_as_dict: dict[str, Any] = self.rag  # pyright: ignore[reportAssignmentType]
+            object.__setattr__(self, "rag", RAGConfig(**rag_as_dict))  # pyright: ignore[reportUnknownArgumentType]
 
 
 _ENV_MAP = {
@@ -185,14 +185,14 @@ def _merge_from_env(cfg: Config) -> Config:
     for env_key, field_name in _ENV_MAP.items():
         raw = os.environ.get(env_key)
         if raw is not None:
-            target_type: type[Any] = type(values[field_name])  # type: ignore[reportUnknownVariableType]
+            target_type: type[Any] = type(values[field_name])  # pyright: ignore[reportUnknownVariableType]
             values[field_name] = _cast_value(raw, target_type)
     # Nested RAG env overrides
     rag_values: dict[str, Any] = dict(values["rag"])
     for env_key, field_name in _RAG_ENV_MAP.items():
         raw = os.environ.get(env_key)
         if raw is not None:
-            rag_target_type: type[Any] = type(rag_values[field_name])  # type: ignore[reportUnknownVariableType]
+            rag_target_type: type[Any] = type(rag_values[field_name])  # pyright: ignore[reportUnknownVariableType]
             rag_values[field_name] = _cast_value(raw, rag_target_type)
     values["rag"] = RAGConfig(**rag_values)
     return Config(**values)
@@ -213,21 +213,21 @@ def validate_config(cfg: Config) -> list[str]:
 
     for field_name in _NON_EMPTY_STRINGS:
         val = getattr(cfg, field_name)
-        if not val or not isinstance(val, str):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+        if not val or not isinstance(val, str):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
             errors.append(f"'{field_name}' must be a non-empty string, got {type(val).__name__}")
 
     # Validate tier_models
-    if not isinstance(cfg.tier_models, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+    if not isinstance(cfg.tier_models, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'tier_models' must be a dict")
     else:
         for tier, model in cfg.tier_models.items():
-            if not isinstance(tier, str) or not tier:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if not isinstance(tier, str) or not tier:  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'tier_models' key must be a non-empty string, got {tier!r}")
-            if not isinstance(model, str) or not model:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if not isinstance(model, str) or not model:  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'tier_models.{tier}' must be a non-empty string, got {model!r}")
 
     # Validate ignored_dirs
-    if not isinstance(cfg.ignored_dirs, list):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+    if not isinstance(cfg.ignored_dirs, list):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'ignored_dirs' must be a list")
 
     # Validate int fields
@@ -244,28 +244,28 @@ def validate_config(cfg: Config) -> list[str]:
     _check_positive_float(cfg, "mcp_per_server_timeout", errors)
 
     # Validate RAG
-    if not isinstance(cfg.rag, RAGConfig):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+    if not isinstance(cfg.rag, RAGConfig):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'rag' must be a RAGConfig object")
     else:
         _check_positive_int(cfg.rag, "chunk_size", errors, prefix="rag")
         _check_nonneg_int(cfg.rag, "chunk_overlap", errors, prefix="rag")
-        if isinstance(cfg.rag.chunk_size, int) and isinstance(cfg.rag.chunk_overlap, int) and cfg.rag.chunk_overlap >= cfg.rag.chunk_size:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+        if isinstance(cfg.rag.chunk_size, int) and isinstance(cfg.rag.chunk_overlap, int) and cfg.rag.chunk_overlap >= cfg.rag.chunk_size:  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
             errors.append("'rag.chunk_overlap' must be less than 'rag.chunk_size'")
         _check_positive_int(cfg.rag, "top_k", errors, prefix="rag")
         _check_positive_int(cfg.rag, "max_file_size", errors, prefix="rag")
-        if not isinstance(cfg.rag.embedding_model, str) or not cfg.rag.embedding_model:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+        if not isinstance(cfg.rag.embedding_model, str) or not cfg.rag.embedding_model:  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
             errors.append("'rag.embedding_model' must be a non-empty string")
 
     # Validate providers
-    if not isinstance(cfg.providers, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+    if not isinstance(cfg.providers, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'providers' must be a dict")
     else:
         for alias, entry in cfg.providers.items():
-            if not isinstance(alias, str) or not _PROVIDER_ALIAS_RE.match(alias):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if not isinstance(alias, str) or not _PROVIDER_ALIAS_RE.match(alias):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'providers.{alias}': alias must match [a-z0-9-]+ (no '/')")
             if alias in _RESERVED_PROVIDER_ALIASES:
                 errors.append(f"'providers.{alias}': alias is reserved (built-in pseudo-provider)")
-            if not isinstance(entry, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if not isinstance(entry, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'providers.{alias}': must be a dict, got {type(entry).__name__}")
                 continue
             base_url: Any = entry.get("base_url")
@@ -283,22 +283,22 @@ def validate_config(cfg: Config) -> list[str]:
             if litellm_provider is not None and (not isinstance(litellm_provider, str) or not litellm_provider):
                 errors.append(f"'providers.{alias}.litellm_provider': must be a non-empty string")
             models: Any = entry.get("models", {})
-            if not isinstance(models, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if not isinstance(models, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'providers.{alias}.models': must be a dict")
             else:
-                models_dict: dict[str, Any] = models  # type: ignore[assignment]
+                models_dict: dict[str, Any] = models  # pyright: ignore[reportAssignmentType,reportUnknownVariableType]
                 for model_id, override in models_dict.items():
-                    if override is not None and not isinstance(override, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+                    if override is not None and not isinstance(override, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                         errors.append(f"'providers.{alias}.models.{model_id}': override must be a dict")
 
     # Validate mcp_servers
-    if not isinstance(cfg.mcp_servers, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+    if not isinstance(cfg.mcp_servers, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'mcp_servers' must be a dict")
     else:
         for name, server_cfg in cfg.mcp_servers.items():
-            if not isinstance(name, str) or not _MCP_SERVER_NAME_RE.match(name):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if not isinstance(name, str) or not _MCP_SERVER_NAME_RE.match(name):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'mcp_servers.{name}': name must match [a-z0-9-]+")
-            if not isinstance(server_cfg, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if not isinstance(server_cfg, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'mcp_servers.{name}': must be a dict, got {type(server_cfg).__name__}")
                 continue
             if "url" not in server_cfg:
@@ -306,16 +306,16 @@ def validate_config(cfg: Config) -> list[str]:
                 if not isinstance(cmd, str) or not cmd:
                     errors.append(f"'mcp_servers.{name}.command': must be a non-empty string")
                 args: Any = server_cfg.get("args", [])
-                if not isinstance(args, list):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+                if not isinstance(args, list):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                     errors.append(f"'mcp_servers.{name}.args': must be a list")
             env: Any = server_cfg.get("env")
-            if env is not None and not isinstance(env, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+            if env is not None and not isinstance(env, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'mcp_servers.{name}.env': must be a dict")
 
     # Validate theme and personality (basic existence check — full validation done at load time)
-    if not isinstance(cfg.theme, str) or not cfg.theme:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+    if not isinstance(cfg.theme, str) or not cfg.theme:  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'theme' must be a non-empty string")
-    if not isinstance(cfg.personality, str) or not cfg.personality:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
+    if not isinstance(cfg.personality, str) or not cfg.personality:  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'personality' must be a non-empty string")
 
     return errors
@@ -324,7 +324,7 @@ def validate_config(cfg: Config) -> list[str]:
 def _check_positive_int(obj: Any, field: str, errors: list[str], prefix: str | None = None) -> None:
     val = getattr(obj, field)
     key = f"{prefix}.{field}" if prefix else f"'{field}'"
-    if not isinstance(val, int) or isinstance(val, bool):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
+    if not isinstance(val, int) or isinstance(val, bool):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
         errors.append(f"{key} must be a positive integer, got {type(val).__name__}")
     elif val <= 0:
         errors.append(f"{key} must be a positive integer, got {val}")
@@ -333,7 +333,7 @@ def _check_positive_int(obj: Any, field: str, errors: list[str], prefix: str | N
 def _check_nonneg_int(obj: Any, field: str, errors: list[str], prefix: str | None = None) -> None:
     val = getattr(obj, field)
     key = f"{prefix}.{field}" if prefix else f"'{field}'"
-    if not isinstance(val, int) or isinstance(val, bool):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
+    if not isinstance(val, int) or isinstance(val, bool):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
         errors.append(f"{key} must be a non-negative integer, got {type(val).__name__}")
     elif val < 0:
         errors.append(f"{key} must be a non-negative integer, got {val}")
@@ -342,7 +342,7 @@ def _check_nonneg_int(obj: Any, field: str, errors: list[str], prefix: str | Non
 def _check_positive_float(obj: Any, field: str, errors: list[str], prefix: str | None = None) -> None:
     val = getattr(obj, field)
     key = f"{prefix}.{field}" if prefix else f"'{field}'"
-    if not isinstance(val, (int, float)) or isinstance(val, bool):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
+    if not isinstance(val, (int, float)) or isinstance(val, bool):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
         errors.append(f"{key} must be a positive number, got {type(val).__name__}")
     elif val <= 0:
         errors.append(f"{key} must be a positive number, got {val}")
@@ -372,13 +372,13 @@ def _deep_merge_provider_dict(home: dict[str, Any], project: dict[str, Any]) -> 
             continue
         home_entry: Any = home[alias]
         project_entry: Any = project[alias]
-        if not isinstance(home_entry, dict) or not isinstance(project_entry, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: values from JSON may be any type
+        if not isinstance(home_entry, dict) or not isinstance(project_entry, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: values from JSON may be any type
             result[alias] = project_entry
             continue
         merged_entry: dict[str, Any] = {**home_entry, **project_entry}
-        home_models: Any = home_entry.get("models")  # type: ignore[reportUnknownMemberType]
-        project_models: Any = project_entry.get("models")  # type: ignore[reportUnknownMemberType]
-        if isinstance(home_models, dict) and isinstance(project_models, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: values from JSON may be any type
+        home_models: Any = home_entry.get("models")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        project_models: Any = project_entry.get("models")  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        if isinstance(home_models, dict) and isinstance(project_models, dict):  # pyright: ignore[reportUnnecessaryIsInstance]  # defensive: values from JSON may be any type
             merged_entry["models"] = {**home_models, **project_models}
         result[alias] = merged_entry
     return result

--- a/src/orchid/config.py
+++ b/src/orchid/config.py
@@ -4,6 +4,7 @@ import os
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Any, cast
 
 log = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ class Config:
     ast_max_file_size: int = 1_048_576
     mcp_startup_timeout: float = 60.0
     mcp_per_server_timeout: float = 10.0
-    mcp_servers: dict[str, dict] = field(
+    mcp_servers: dict[str, dict[str, Any]] = field(
         default_factory=lambda: {
             "context7": {
                 "command": "npx",
@@ -89,7 +90,7 @@ class Config:
             },
         }
     )
-    providers: dict[str, dict] = field(
+    providers: dict[str, dict[str, Any]] = field(
         default_factory=lambda: {
             "default": {
                 "base_url": "https://opencode.ai/zen/go/v1",
@@ -109,8 +110,9 @@ class Config:
         nested dataclass instances. This fix-up converts the dict to a ``RAGConfig``
         when the constructor receives a dict.
         """
-        if isinstance(self.rag, dict):
-            object.__setattr__(self, "rag", RAGConfig(**self.rag))
+        if isinstance(self.rag, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: dict from JSON deserialization
+            rag_as_dict: dict[str, Any] = self.rag  # type: ignore[assignment]
+            object.__setattr__(self, "rag", RAGConfig(**rag_as_dict))  # type: ignore[reportUnknownArgumentType]
 
 
 _ENV_MAP = {
@@ -138,15 +140,16 @@ _RAG_ENV_MAP = {
 }
 
 
-def _load_json(path: Path) -> dict:
+def _load_json(path: Path) -> dict[str, Any]:
     try:
         with open(path) as f:
-            return json.load(f)
+            result: dict[str, Any] = json.load(f)
+            return result
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 
 
-def _convert_from_dict(data: dict) -> dict:
+def _convert_from_dict(data: dict[str, Any]) -> dict[str, Any]:
     """Normalize a raw dict before constructing Config.
 
     Strips None values so they don't shadow dataclass defaults. Legacy
@@ -156,7 +159,7 @@ def _convert_from_dict(data: dict) -> dict:
     defaults (unknown top-level keys are ignored by ``ConfigManager.load``).
     Never mutates the input.
     """
-    result = dict(data)
+    result: dict[str, Any] = dict(data)
 
     for k in list(result.keys()):
         if result[k] is None:
@@ -165,7 +168,7 @@ def _convert_from_dict(data: dict) -> dict:
     return result
 
 
-def _cast_value(value: str, target_type):
+def _cast_value(value: str, target_type: type[Any]) -> Any:
     if target_type is bool:
         return value.lower() in ("true", "1", "yes")
     if target_type is int:
@@ -178,19 +181,19 @@ def _cast_value(value: str, target_type):
 
 
 def _merge_from_env(cfg: Config) -> Config:
-    values = asdict(cfg)
+    values: dict[str, Any] = asdict(cfg)
     for env_key, field_name in _ENV_MAP.items():
         raw = os.environ.get(env_key)
         if raw is not None:
-            target_type = type(values[field_name])
+            target_type: type[Any] = type(values[field_name])  # type: ignore[reportUnknownVariableType]
             values[field_name] = _cast_value(raw, target_type)
     # Nested RAG env overrides
-    rag_values = dict(values["rag"])
+    rag_values: dict[str, Any] = dict(values["rag"])
     for env_key, field_name in _RAG_ENV_MAP.items():
         raw = os.environ.get(env_key)
         if raw is not None:
-            target_type = type(rag_values[field_name])
-            rag_values[field_name] = _cast_value(raw, target_type)
+            rag_target_type: type[Any] = type(rag_values[field_name])  # type: ignore[reportUnknownVariableType]
+            rag_values[field_name] = _cast_value(raw, rag_target_type)
     values["rag"] = RAGConfig(**rag_values)
     return Config(**values)
 
@@ -210,21 +213,21 @@ def validate_config(cfg: Config) -> list[str]:
 
     for field_name in _NON_EMPTY_STRINGS:
         val = getattr(cfg, field_name)
-        if not val or not isinstance(val, str):
+        if not val or not isinstance(val, str):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
             errors.append(f"'{field_name}' must be a non-empty string, got {type(val).__name__}")
 
     # Validate tier_models
-    if not isinstance(cfg.tier_models, dict):
+    if not isinstance(cfg.tier_models, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'tier_models' must be a dict")
     else:
         for tier, model in cfg.tier_models.items():
-            if not isinstance(tier, str) or not tier:
+            if not isinstance(tier, str) or not tier:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'tier_models' key must be a non-empty string, got {tier!r}")
-            if not isinstance(model, str) or not model:
+            if not isinstance(model, str) or not model:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'tier_models.{tier}' must be a non-empty string, got {model!r}")
 
     # Validate ignored_dirs
-    if not isinstance(cfg.ignored_dirs, list):
+    if not isinstance(cfg.ignored_dirs, list):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'ignored_dirs' must be a list")
 
     # Validate int fields
@@ -241,110 +244,111 @@ def validate_config(cfg: Config) -> list[str]:
     _check_positive_float(cfg, "mcp_per_server_timeout", errors)
 
     # Validate RAG
-    if not isinstance(cfg.rag, RAGConfig):
+    if not isinstance(cfg.rag, RAGConfig):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'rag' must be a RAGConfig object")
     else:
         _check_positive_int(cfg.rag, "chunk_size", errors, prefix="rag")
         _check_nonneg_int(cfg.rag, "chunk_overlap", errors, prefix="rag")
-        if isinstance(cfg.rag.chunk_size, int) and isinstance(cfg.rag.chunk_overlap, int) and cfg.rag.chunk_overlap >= cfg.rag.chunk_size:
+        if isinstance(cfg.rag.chunk_size, int) and isinstance(cfg.rag.chunk_overlap, int) and cfg.rag.chunk_overlap >= cfg.rag.chunk_size:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
             errors.append("'rag.chunk_overlap' must be less than 'rag.chunk_size'")
         _check_positive_int(cfg.rag, "top_k", errors, prefix="rag")
         _check_positive_int(cfg.rag, "max_file_size", errors, prefix="rag")
-        if not isinstance(cfg.rag.embedding_model, str) or not cfg.rag.embedding_model:
+        if not isinstance(cfg.rag.embedding_model, str) or not cfg.rag.embedding_model:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
             errors.append("'rag.embedding_model' must be a non-empty string")
 
     # Validate providers
-    if not isinstance(cfg.providers, dict):
+    if not isinstance(cfg.providers, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'providers' must be a dict")
     else:
         for alias, entry in cfg.providers.items():
-            if not isinstance(alias, str) or not _PROVIDER_ALIAS_RE.match(alias):
+            if not isinstance(alias, str) or not _PROVIDER_ALIAS_RE.match(alias):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'providers.{alias}': alias must match [a-z0-9-]+ (no '/')")
             if alias in _RESERVED_PROVIDER_ALIASES:
                 errors.append(f"'providers.{alias}': alias is reserved (built-in pseudo-provider)")
-            if not isinstance(entry, dict):
+            if not isinstance(entry, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'providers.{alias}': must be a dict, got {type(entry).__name__}")
                 continue
-            base_url = entry.get("base_url")
+            base_url: Any = entry.get("base_url")
             if base_url is not None and (not isinstance(base_url, str) or not base_url):
                 errors.append(f"'providers.{alias}.base_url': must be a non-empty string")
-            api_key = entry.get("api_key")
+            api_key: Any = entry.get("api_key")
             if api_key is not None and (not isinstance(api_key, str) or not api_key):
                 errors.append(f"'providers.{alias}.api_key': must be a non-empty string")
-            api_key_env = entry.get("api_key_env")
+            api_key_env: Any = entry.get("api_key_env")
             if api_key_env is not None and (not isinstance(api_key_env, str) or not api_key_env):
                 errors.append(f"'providers.{alias}.api_key_env': must be a non-empty string")
             if api_key and api_key_env:
                 errors.append(f"'providers.{alias}': both 'api_key' and 'api_key_env' set; use only one")
-            litellm_provider = entry.get("litellm_provider")
+            litellm_provider: Any = entry.get("litellm_provider")
             if litellm_provider is not None and (not isinstance(litellm_provider, str) or not litellm_provider):
                 errors.append(f"'providers.{alias}.litellm_provider': must be a non-empty string")
-            models = entry.get("models", {})
-            if not isinstance(models, dict):
+            models: Any = entry.get("models", {})
+            if not isinstance(models, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'providers.{alias}.models': must be a dict")
             else:
-                for model_id, override in models.items():
-                    if override is not None and not isinstance(override, dict):
+                models_dict: dict[str, Any] = models  # type: ignore[assignment]
+                for model_id, override in models_dict.items():
+                    if override is not None and not isinstance(override, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                         errors.append(f"'providers.{alias}.models.{model_id}': override must be a dict")
 
     # Validate mcp_servers
-    if not isinstance(cfg.mcp_servers, dict):
+    if not isinstance(cfg.mcp_servers, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'mcp_servers' must be a dict")
     else:
         for name, server_cfg in cfg.mcp_servers.items():
-            if not isinstance(name, str) or not _MCP_SERVER_NAME_RE.match(name):
+            if not isinstance(name, str) or not _MCP_SERVER_NAME_RE.match(name):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'mcp_servers.{name}': name must match [a-z0-9-]+")
-            if not isinstance(server_cfg, dict):
+            if not isinstance(server_cfg, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'mcp_servers.{name}': must be a dict, got {type(server_cfg).__name__}")
                 continue
             if "url" not in server_cfg:
-                cmd = server_cfg.get("command")
+                cmd: Any = server_cfg.get("command")
                 if not isinstance(cmd, str) or not cmd:
                     errors.append(f"'mcp_servers.{name}.command': must be a non-empty string")
-                args = server_cfg.get("args", [])
-                if not isinstance(args, list):
+                args: Any = server_cfg.get("args", [])
+                if not isinstance(args, list):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                     errors.append(f"'mcp_servers.{name}.args': must be a list")
-            env = server_cfg.get("env")
-            if env is not None and not isinstance(env, dict):
+            env: Any = server_cfg.get("env")
+            if env is not None and not isinstance(env, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
                 errors.append(f"'mcp_servers.{name}.env': must be a dict")
 
     # Validate theme and personality (basic existence check — full validation done at load time)
-    if not isinstance(cfg.theme, str) or not cfg.theme:
+    if not isinstance(cfg.theme, str) or not cfg.theme:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'theme' must be a non-empty string")
-    if not isinstance(cfg.personality, str) or not cfg.personality:
+    if not isinstance(cfg.personality, str) or not cfg.personality:  # type: ignore[reportUnnecessaryIsInstance]  # defensive: validating runtime input
         errors.append("'personality' must be a non-empty string")
 
     return errors
 
 
-def _check_positive_int(obj, field: str, errors: list[str], prefix: str | None = None) -> None:
+def _check_positive_int(obj: Any, field: str, errors: list[str], prefix: str | None = None) -> None:
     val = getattr(obj, field)
     key = f"{prefix}.{field}" if prefix else f"'{field}'"
-    if not isinstance(val, int) or isinstance(val, bool):
+    if not isinstance(val, int) or isinstance(val, bool):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
         errors.append(f"{key} must be a positive integer, got {type(val).__name__}")
     elif val <= 0:
         errors.append(f"{key} must be a positive integer, got {val}")
 
 
-def _check_nonneg_int(obj, field: str, errors: list[str], prefix: str | None = None) -> None:
+def _check_nonneg_int(obj: Any, field: str, errors: list[str], prefix: str | None = None) -> None:
     val = getattr(obj, field)
     key = f"{prefix}.{field}" if prefix else f"'{field}'"
-    if not isinstance(val, int) or isinstance(val, bool):
+    if not isinstance(val, int) or isinstance(val, bool):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
         errors.append(f"{key} must be a non-negative integer, got {type(val).__name__}")
     elif val < 0:
         errors.append(f"{key} must be a non-negative integer, got {val}")
 
 
-def _check_positive_float(obj, field: str, errors: list[str], prefix: str | None = None) -> None:
+def _check_positive_float(obj: Any, field: str, errors: list[str], prefix: str | None = None) -> None:
     val = getattr(obj, field)
     key = f"{prefix}.{field}" if prefix else f"'{field}'"
-    if not isinstance(val, (int, float)) or isinstance(val, bool):
+    if not isinstance(val, (int, float)) or isinstance(val, bool):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: bool is subclass of int
         errors.append(f"{key} must be a positive number, got {type(val).__name__}")
     elif val <= 0:
         errors.append(f"{key} must be a positive number, got {val}")
 
 
-def _deep_merge_provider_dict(home: dict, project: dict) -> dict:
+def _deep_merge_provider_dict(home: dict[str, Any], project: dict[str, Any]) -> dict[str, Any]:
     """Recursively merge two provider-dict-shaped values (`providers` or `mcp_servers`).
 
     For each alias present in either side:
@@ -358,7 +362,7 @@ def _deep_merge_provider_dict(home: dict, project: dict) -> dict:
     Anything other than a dict on either side falls back to the project value
     (matches the prior `mcp_servers` merge behavior).
     """
-    result: dict[str, dict] = {}
+    result: dict[str, Any] = {}
     for alias in set(home) | set(project):
         if alias not in project:
             result[alias] = home[alias]
@@ -366,15 +370,15 @@ def _deep_merge_provider_dict(home: dict, project: dict) -> dict:
         if alias not in home:
             result[alias] = project[alias]
             continue
-        home_entry = home[alias]
-        project_entry = project[alias]
-        if not isinstance(home_entry, dict) or not isinstance(project_entry, dict):
+        home_entry: Any = home[alias]
+        project_entry: Any = project[alias]
+        if not isinstance(home_entry, dict) or not isinstance(project_entry, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: values from JSON may be any type
             result[alias] = project_entry
             continue
-        merged_entry = {**home_entry, **project_entry}
-        home_models = home_entry.get("models")
-        project_models = project_entry.get("models")
-        if isinstance(home_models, dict) and isinstance(project_models, dict):
+        merged_entry: dict[str, Any] = {**home_entry, **project_entry}
+        home_models: Any = home_entry.get("models")  # type: ignore[reportUnknownMemberType]
+        project_models: Any = project_entry.get("models")  # type: ignore[reportUnknownMemberType]
+        if isinstance(home_models, dict) and isinstance(project_models, dict):  # type: ignore[reportUnnecessaryIsInstance]  # defensive: values from JSON may be any type
             merged_entry["models"] = {**home_models, **project_models}
         result[alias] = merged_entry
     return result
@@ -398,36 +402,36 @@ class ConfigManager:
             return cls._instance
 
         defaults = Config()
-        merged = asdict(defaults)
+        merged: dict[str, Any] = asdict(defaults)
 
-        home = _load_json(HOME_CONFIG_PATH)
+        home: dict[str, Any] = _load_json(HOME_CONFIG_PATH)
         home = _convert_from_dict(home)
         for k, v in home.items():
             if k not in merged:
                 continue
             if k in _DEEP_MERGE_KEYS and isinstance(v, dict) and isinstance(merged.get(k), dict):
-                merged[k] = _deep_merge_provider_dict(merged[k], v)
+                merged[k] = _deep_merge_provider_dict(merged[k], cast(dict[str, Any], v))
             elif isinstance(v, dict) and isinstance(merged.get(k), dict):
                 # Deep-merge nested dicts even outside _DEEP_MERGE_KEYS so
                 # partial nested configs (e.g. project setting only `rag.top_k`)
                 # merge with home-level values instead of replacing them wholesale.
-                merged[k] = _deep_merge_provider_dict(merged[k], v)
+                merged[k] = _deep_merge_provider_dict(merged[k], cast(dict[str, Any], v))
             else:
                 merged[k] = v
 
         project_path = Path.cwd() / PROJECT_CONFIG_NAME
-        project = _load_json(project_path)
+        project: dict[str, Any] = _load_json(project_path)
         project = _convert_from_dict(project)
         for k, v in project.items():
             if k not in merged:
                 continue
             if k in _DEEP_MERGE_KEYS and isinstance(v, dict) and isinstance(merged.get(k), dict):
-                merged[k] = _deep_merge_provider_dict(merged[k], v)
+                merged[k] = _deep_merge_provider_dict(merged[k], cast(dict[str, Any], v))
             elif isinstance(v, dict) and isinstance(merged.get(k), dict):
                 # Deep-merge nested dicts even outside _DEEP_MERGE_KEYS so
                 # partial nested configs (e.g. project setting only `rag.top_k`)
                 # merge with home-level values instead of replacing them wholesale.
-                merged[k] = _deep_merge_provider_dict(merged[k], v)
+                merged[k] = _deep_merge_provider_dict(merged[k], cast(dict[str, Any], v))
             else:
                 merged[k] = v
 

--- a/src/orchid/domain/agent.py
+++ b/src/orchid/domain/agent.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 
 class AgentTypes(Enum):
@@ -69,10 +70,10 @@ class Agent:
     tier: ModelTier
     description: str
     system_prompt: str
-    allowed_tools: list[str] = field(default_factory=list)
-    allowed_skills: list[str] = field(default_factory=list)
+    allowed_tools: list[str] = field(default_factory=list[str])
+    allowed_skills: list[str] = field(default_factory=list[str])
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "type": self.type.value.lower(),
@@ -84,7 +85,7 @@ class Agent:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> "Agent":
+    def from_dict(cls, data: dict[str, Any]) -> "Agent":
         return cls(
             name=data["name"],
             type=AgentTypes.from_str(data["type"]),

--- a/src/orchid/domain/chain.py
+++ b/src/orchid/domain/chain.py
@@ -19,7 +19,7 @@ class ChainStatus(Enum):
 @dataclass
 class Chain:
     model: str | None = None
-    messages: list[Message] = field(default_factory=list)
+    messages: list[Message] = field(default_factory=list[Message])
     start_time: float = field(default_factory=time.monotonic)
     end_time: float | None = None
     status: ChainStatus = ChainStatus.RUNNING

--- a/src/orchid/domain/message.py
+++ b/src/orchid/domain/message.py
@@ -33,7 +33,7 @@ class Message:
     content: str
     type: MessageType = MessageType.TEXT
     display: str | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict[str, Any])
     usage: Usage | None = None
     tool_call_id: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
@@ -88,8 +88,8 @@ class Message:
             # corruption. Explicitly extract the known fields with .get()
             # defaults so a drifted usage dict never raises TypeError and
             # aborts the whole session load (session.py:56/130).
-            src = data["usage"]
-            if not isinstance(src, dict):
+            src: dict[str, Any] = data["usage"]
+            if not isinstance(src, dict):  # type: ignore[reportUnnecessaryIsInstance]
                 usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
             else:
                 usage = Usage(

--- a/src/orchid/domain/message.py
+++ b/src/orchid/domain/message.py
@@ -88,15 +88,15 @@ class Message:
             # corruption. Explicitly extract the known fields with .get()
             # defaults so a drifted usage dict never raises TypeError and
             # aborts the whole session load (session.py:56/130).
-            src: dict[str, Any] = data["usage"]
-            if not isinstance(src, dict):  # type: ignore[reportUnnecessaryIsInstance]
+            src: Any = data["usage"]
+            if not isinstance(src, dict):
                 usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
             else:
                 usage = Usage(
-                    prompt_tokens=src.get("prompt_tokens", 0),
-                    completion_tokens=src.get("completion_tokens", 0),
-                    total_tokens=src.get("total_tokens", 0),
-                    cached_tokens=src.get("cached_tokens", 0),
+                    prompt_tokens=src.get("prompt_tokens", 0),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                    completion_tokens=src.get("completion_tokens", 0),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                    total_tokens=src.get("total_tokens", 0),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+                    cached_tokens=src.get("cached_tokens", 0),  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
                 )
         metadata = dict(data.get("metadata", {}))
         warnings: list[str] = []

--- a/src/orchid/domain/session.py
+++ b/src/orchid/domain/session.py
@@ -28,7 +28,7 @@ def set_current_session_id(session_id: str | None) -> None:
 class Session:
     name: str
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    chains: list[Chain] = field(default_factory=list)
+    chains: list[Chain] = field(default_factory=list[Chain])
     model: str | None = None
     subagent_manager: SubagentManager = field(default_factory=SubagentManager)
     todo_store: TodoStore = field(default_factory=TodoStore)
@@ -38,7 +38,7 @@ class Session:
         return [msg for chain in self.chains for msg in chain.messages]
 
     def to_storage_dict(self) -> dict[str, Any]:
-        subagent_records = []
+        subagent_records: list[dict[str, Any]] = []
         for record in self.subagent_manager.all_records():
             subagent_records.append(record.to_storage_dict())
         return {
@@ -70,7 +70,7 @@ class Session:
         for sd in data.get("subagent_chains", []):
             try:
                 record = SubagentRecord.from_storage_dict(sd)
-                session.subagent_manager._subagents[record.id] = record
+                session.subagent_manager._subagents[record.id] = record  # type: ignore[reportPrivateUsage]
             except Exception:
                 log.warning("Failed to restore subagent record %s", sd, exc_info=True)
         return session
@@ -158,7 +158,7 @@ class SessionManager:
         self._bind_context(session)
         return session
 
-    def list_saved(self) -> list[dict]:
+    def list_saved(self) -> list[dict[str, Any]]:
         """List all saved sessions from disk."""
         from orchid.storage import list_saved_sessions
         return list_saved_sessions()

--- a/src/orchid/domain/skill.py
+++ b/src/orchid/domain/skill.py
@@ -31,11 +31,11 @@ class Skill:
     assets: list[SkillResource] = field(default_factory=list[SkillResource])
 
     def validate(self) -> str | None:
-        if not self.name or len(self.name) > _MAX_NAME_LEN:
+        if not isinstance(self.name, str) or not self.name or len(self.name) > _MAX_NAME_LEN:  # pyright: ignore[reportUnnecessaryIsInstance]
             return f"Name must be a string of 1-{_MAX_NAME_LEN} characters"
         if not _NAME_PATTERN.match(self.name):
             return "Name must be lowercase letters, numbers, hyphens; no leading/trailing hyphens"
-        if not self.description or len(self.description) > _MAX_DESC_LEN:
+        if not isinstance(self.description, str) or not self.description or len(self.description) > _MAX_DESC_LEN:  # pyright: ignore[reportUnnecessaryIsInstance]
             return f"Description must be a string of 1-{_MAX_DESC_LEN} characters"
         return None
 

--- a/src/orchid/domain/skill.py
+++ b/src/orchid/domain/skill.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass, field
+from typing import Any
 
 _NAME_PATTERN = re.compile(r'^[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
 _MAX_NAME_LEN = 64
@@ -11,7 +12,7 @@ class SkillResource:
     path: str
     description: str = ""
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str]:
         d: dict[str, str] = {"path": self.path}
         if self.description:
             d["description"] = self.description
@@ -24,22 +25,22 @@ class Skill:
     description: str
     location: str
     content: str = ""
-    requires: list[str] = field(default_factory=list)
-    scripts: list[SkillResource] = field(default_factory=list)
-    references: list[SkillResource] = field(default_factory=list)
-    assets: list[SkillResource] = field(default_factory=list)
+    requires: list[str] = field(default_factory=list[str])
+    scripts: list[SkillResource] = field(default_factory=list[SkillResource])
+    references: list[SkillResource] = field(default_factory=list[SkillResource])
+    assets: list[SkillResource] = field(default_factory=list[SkillResource])
 
     def validate(self) -> str | None:
-        if not isinstance(self.name, str) or not self.name or len(self.name) > _MAX_NAME_LEN:
+        if not self.name or len(self.name) > _MAX_NAME_LEN:
             return f"Name must be a string of 1-{_MAX_NAME_LEN} characters"
         if not _NAME_PATTERN.match(self.name):
             return "Name must be lowercase letters, numbers, hyphens; no leading/trailing hyphens"
-        if not isinstance(self.description, str) or not self.description or len(self.description) > _MAX_DESC_LEN:
+        if not self.description or len(self.description) > _MAX_DESC_LEN:
             return f"Description must be a string of 1-{_MAX_DESC_LEN} characters"
         return None
 
-    def to_dict(self) -> dict:
-        d: dict[str, object] = {
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
             "name": self.name,
             "description": self.description,
             "location": self.location,

--- a/src/orchid/domain/tool.py
+++ b/src/orchid/domain/tool.py
@@ -30,8 +30,8 @@ class Tool:
     type: str = "function"
     strict: bool = True
 
-    def to_dict(self) -> dict:
-        properties = {}
+    def to_dict(self) -> dict[str, Any]:
+        properties: dict[str, dict[str, Any]] = {}
         for k, v in self.parameters.properties.items():
             prop: dict[str, Any] = {"description": v.description}
             if v.type:

--- a/src/orchid/llm/client.py
+++ b/src/orchid/llm/client.py
@@ -11,10 +11,22 @@ import time
 import traceback
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import litellm
+from litellm import (  # type: ignore[reportPrivateImportUsage]
+    REPEATED_STREAMING_CHUNK_LIMIT,  # type: ignore[reportPrivateImportUsage]
+    APIConnectionError,  # type: ignore[reportPrivateImportUsage]
+    APIError,  # type: ignore[reportPrivateImportUsage]
+    AuthenticationError,  # type: ignore[reportPrivateImportUsage]
+    BadGatewayError,  # type: ignore[reportPrivateImportUsage]
+    BadRequestError,  # type: ignore[reportPrivateImportUsage]
+    InternalServerError,  # type: ignore[reportPrivateImportUsage]
+    RateLimitError,  # type: ignore[reportPrivateImportUsage]
+    ServiceUnavailableError,  # type: ignore[reportPrivateImportUsage]
+    Timeout,  # type: ignore[reportPrivateImportUsage]
+)
 from litellm.exceptions import MidStreamFallbackError
 
 from orchid.config import HOME_CONFIG_DIR, get_config
@@ -51,23 +63,23 @@ def classify_error(exc: Exception) -> tuple[str, str]:
             "Unknown Provider",
             detail or "The model reference could not be resolved. Check your providers config.",
         )
-    if isinstance(exc, litellm.AuthenticationError):
+    if isinstance(exc, AuthenticationError):
         return "Authentication Failed", "Invalid or missing API key. Check your configuration."
-    if isinstance(exc, litellm.RateLimitError):
+    if isinstance(exc, RateLimitError):
         return "Rate Limit Exceeded", "Too many requests. Please wait and try again."
-    if isinstance(exc, litellm.Timeout):
+    if isinstance(exc, Timeout):
         return "Request Timed Out", "The API did not respond in time. Try again later."
-    if isinstance(exc, litellm.APIConnectionError):
+    if isinstance(exc, APIConnectionError):
         return "Connection Failed", "Could not reach the API server. Check your network and base_url."
-    if isinstance(exc, litellm.BadRequestError):
+    if isinstance(exc, BadRequestError):
         return "Invalid Request", detail or "The request was rejected by the API."
-    if isinstance(exc, litellm.InternalServerError):
+    if isinstance(exc, InternalServerError):
         return "Server Error", detail or "The API server encountered an internal error."
-    if isinstance(exc, litellm.ServiceUnavailableError):
+    if isinstance(exc, ServiceUnavailableError):
         return "Service Unavailable", detail or "The API service is temporarily unavailable."
-    if isinstance(exc, litellm.BadGatewayError):
+    if isinstance(exc, BadGatewayError):
         return "Bad Gateway", detail or "The API server returned a bad gateway error."
-    if isinstance(exc, litellm.APIError):
+    if isinstance(exc, APIError):
         return "API Error", detail or "The API returned an error."
     if isinstance(exc, httpx.TimeoutException):
         return "Request Timed Out", "The API did not respond in time. Try again later."
@@ -86,19 +98,19 @@ def _raise_first_task_exception(results: tuple[Any, ...]) -> None:
 def _is_transient_error(exc: Exception) -> bool:
     """Check if an exception is a transient provider error worth retrying."""
     transient_types = (
-        litellm.RateLimitError,
-        litellm.Timeout,
-        litellm.APIConnectionError,
-        litellm.InternalServerError,
-        litellm.ServiceUnavailableError,
-        litellm.BadGatewayError,
+        RateLimitError,
+        Timeout,
+        APIConnectionError,
+        InternalServerError,
+        ServiceUnavailableError,
+        BadGatewayError,
     )
     if isinstance(exc, transient_types):
         return True
     if isinstance(exc, httpx.TimeoutException):
         return True
     if isinstance(exc, httpx.HTTPStatusError):
-        status = exc.response.status_code if exc.response is not None else None
+        status = exc.response.status_code
         return status in (408, 429, 500, 502, 503, 504)
     status = getattr(exc, "status_code", None)
     if isinstance(status, int):
@@ -131,7 +143,7 @@ def _patch_litellm_raise_on_model_repetition() -> None:
 
     _orig = CustomStreamWrapper.raise_on_model_repetition
 
-    def _safe_raise_on_model_repetition(self) -> None:
+    def _safe_raise_on_model_repetition(self: Any) -> None:
         if len(self.chunks) < 2:
             return
         last = None
@@ -154,8 +166,8 @@ def _patch_litellm_raise_on_model_repetition() -> None:
             self._repeated_messages_count += 1
         else:
             self._repeated_messages_count = 1
-        if self._repeated_messages_count >= litellm.REPEATED_STREAMING_CHUNK_LIMIT:
-            raise litellm.InternalServerError(
+        if self._repeated_messages_count >= REPEATED_STREAMING_CHUNK_LIMIT:
+            raise InternalServerError(
                 message=f"The model is repeating the same chunk = {last_content}.",
                 model="",
                 llm_provider="",
@@ -202,7 +214,7 @@ def _is_benign_midstream_litellm_error(exc: MidStreamFallbackError) -> bool:
     return orig is not None and _MID_STREAM_BENIGN_SIGNATURE in str(orig)
 
 
-def _validate_tool_args(tool: Tool, args: dict) -> str | None:
+def _validate_tool_args(tool: Tool, args: dict[str, Any]) -> str | None:
     """Return error message if args are invalid, None if ok."""
     known = set(tool.parameters.properties.keys())
     unknown = set(args.keys()) - known
@@ -335,7 +347,7 @@ def _history_to_api_messages(messages: list[Message]) -> list[dict[str, Any]]:
         # An emitted non-tool message breaks the sequence: results from a
         # later turn can no longer legitimately pair with earlier tool_calls.
         # A new assistant tool_calls block resets pending to its own ids.
-        pending_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")} if msg.tool_calls else set()
+        pending_tool_call_ids = {x for x in (tc.get("id") for tc in msg.tool_calls) if x is not None} if msg.tool_calls else set()
 
     api_messages: list[dict[str, Any]] = []
     last_assistant_tool_call_ids: set[str] = set()
@@ -395,14 +407,14 @@ def _history_to_api_messages(messages: list[Message]) -> list[dict[str, Any]]:
                     continue
         api_messages.append(d)
         if msg.tool_calls:
-            last_assistant_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
+            last_assistant_tool_call_ids = {x for x in (tc.get("id") for tc in msg.tool_calls) if x is not None}
         else:
             last_assistant_tool_call_ids = set()
     return api_messages
 
 
 async def _execute_tool(
-    tc: dict,
+    tc: dict[str, Any],
     filtered_tools: dict[str, dict[str, Any]],
 ) -> Message:
     """Execute a single tool call and return the result message."""
@@ -428,7 +440,7 @@ async def _execute_tool(
             )
         else:
             tool_def = filtered_tools[name]["tool"]
-            validation_error = _validate_tool_args(tool_def, args)
+            validation_error = _validate_tool_args(tool_def, cast(dict[str, Any], args))
             if validation_error:
                 result = ExecutorResult(
                     display=f"Invalid args for {name}",
@@ -584,7 +596,7 @@ def _log_stream_termination(
     chunk_count: int,
     content: str,
     thinking: str,
-    tool_calls: list[dict],
+    tool_calls: list[dict[str, Any]],
 ) -> None:
     """Log a diagnostic summary at stream end to catch silent truncation.
 
@@ -659,7 +671,7 @@ def _log_stream_termination(
 async def _stream_task(
     response: Any,
     msg_q: asyncio.Queue[Message | None],
-    ready_q: asyncio.Queue[dict | None],
+    ready_q: asyncio.Queue[dict[str, Any] | None],
     api_messages: list[dict[str, Any]],
     assistant_appended: asyncio.Event,
     tool_calls_started: asyncio.Event,
@@ -668,7 +680,7 @@ async def _stream_task(
     try:
         thinking = ""
         content = ""
-        tool_calls: list[dict] = []
+        tool_calls: list[dict[str, Any]] = []
         emitted_tool_calls: set[int] = set()
         enqueued_tool_calls: set[int] = set()
         usage = None
@@ -686,7 +698,7 @@ async def _stream_task(
         # well-formed are appended here so the persisted assistant message and
         # the anchored api_messages entry both see them (shared list ref),
         # without mutating the raw `tool_calls` working buffer.
-        committed_tool_calls: list[dict] | None = None
+        committed_tool_calls: list[dict[str, Any]] | None = None
         committed_indices: set[int] = set()
 
         async def flush_thinking() -> None:
@@ -970,7 +982,7 @@ async def _stream_task(
 
 async def _executor_task(
     msg_q: asyncio.Queue[Message | None],
-    ready_q: asyncio.Queue[dict | None],
+    ready_q: asyncio.Queue[dict[str, Any] | None],
     api_messages: list[dict[str, Any]],
     filtered_tools: dict[str, dict[str, Any]],
     assistant_appended: asyncio.Event,
@@ -1020,10 +1032,10 @@ async def stream_response(
         [system_msg.to_dict()] + _history_to_api_messages(messages) + [dynamic_prompt.to_dict()]
     )
 
-    registry = get_tool_registry()
+    registry: dict[str, dict[str, Any]] = get_tool_registry()
     from fnmatch import fnmatch
 
-    filtered_tools = {k: v for k, v in registry.items() if any(fnmatch(k, p) for p in allowed_tools)}
+    filtered_tools: dict[str, dict[str, Any]] = {k: v for k, v in registry.items() if any(fnmatch(k, p) for p in allowed_tools)}
 
     from orchid.mcp import get_mcp_manager
 
@@ -1052,7 +1064,7 @@ async def stream_response(
 
             try:
                 response = await asyncio.wait_for(
-                    litellm.acompletion(
+                    litellm.acompletion(  # type: ignore[reportUnknownMemberType]
                         model=litellm_model,
                         messages=api_messages,
                         tools=tools_list,
@@ -1091,7 +1103,7 @@ async def stream_response(
                 raise
 
             msg_q: asyncio.Queue[Message | None] = asyncio.Queue(maxsize=1)
-            ready_q: asyncio.Queue[dict | None] = asyncio.Queue()
+            ready_q: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
             assistant_appended = asyncio.Event()
             tool_calls_started = asyncio.Event()
 

--- a/src/orchid/llm/dynamic_system_prompt.py
+++ b/src/orchid/llm/dynamic_system_prompt.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import time
 from datetime import datetime
+from typing import Any
 from xml.sax.saxutils import escape
 
 from orchid.agents.manager import format_subagent_attrs, get_subagent_manager
@@ -25,7 +26,7 @@ async def build_dynamic_system_prompt() -> Message:
     else:
         loop = asyncio.get_running_loop()
         tree = await loop.run_in_executor(None, directory_tree, cwd, cfg.directory_tree_depth)
-        _TREE_CACHE = (cwd, now + _TREE_TTL, tree)
+        _TREE_CACHE = (cwd, now + _TREE_TTL, tree)  # type: ignore[reportConstantRedefinition]
 
     esc_cwd = escape(cwd)
     esc_tree = escape(tree)
@@ -38,9 +39,9 @@ async def build_dynamic_system_prompt() -> Message:
 """
 
     subagent_manager = get_subagent_manager()
-    states = subagent_manager.get_states()
+    states: list[dict[str, Any]] = subagent_manager.get_states()  # type: ignore[reportUnknownVariableType,reportUnknownMemberType]
     if states:
-        parts = []
+        parts: list[str] = []
         for s in states:
             e = escape
             attrs = format_subagent_attrs(s["id"], s["name"], s["type"], s["state"], s["elapsed"])
@@ -53,7 +54,7 @@ async def build_dynamic_system_prompt() -> Message:
     store = get_todo_store()
     tasks = store.list()
     if tasks:
-        lines = []
+        lines: list[str] = []
         for t in tasks:
             line = f"  <todo id=\"{escape(t.id)}\" status=\"{escape(t.status.value)}\">"
             line += f"\n    <title>{escape(t.title)}</title>"

--- a/src/orchid/llm/providers.py
+++ b/src/orchid/llm/providers.py
@@ -14,6 +14,7 @@ docs/plans/2026-06-18-001-feat-multi-provider-support-plan.md (unit U2).
 
 import logging
 import os
+from typing import Any
 
 # litellm fetches `model_prices_and_context_window.json` over the network at
 # import time unless this flag is set first. Set it before the `import litellm`
@@ -34,14 +35,14 @@ def qualify_model(provider: str | None, model_id: str) -> str:
 
 
 _SUPPORTED_FIELDS = ("max_input_tokens", "max_output_tokens", "supports_vision", "mode")
-_DEFAULT_METADATA: dict = {
+_DEFAULT_METADATA: dict[str, Any] = {
     "max_input_tokens": None,
     "max_output_tokens": None,
     "supports_vision": False,
     "mode": "chat",
 }
 
-_metadata_cache: dict[tuple[str, str], dict] = {}
+_metadata_cache: dict[tuple[str, str], dict[str, Any]] = {}
 _discovery_cache: dict[str, list[str]] = {}
 _DISCOVERY_TIMEOUT = 2.0
 _DISABLE_DISCOVERY_VALUES = {"1", "true", "yes"}
@@ -51,7 +52,7 @@ class ProviderResolutionError(Exception):
     """Raised when an `alias/model` reference cannot be resolved to a provider."""
 
 
-def get_provider(alias: str) -> dict:
+def get_provider(alias: str) -> dict[str, Any]:
     """Return the provider entry for `alias`, or raise `ProviderResolutionError`."""
     cfg = get_config()
     provider = cfg.providers.get(alias)
@@ -62,7 +63,7 @@ def get_provider(alias: str) -> dict:
     return provider
 
 
-def _resolve_api_key(provider: dict, alias: str) -> str | None:
+def _resolve_api_key(provider: dict[str, Any], alias: str) -> str | None:
     """Resolve an API key for a provider entry.
 
     Prefers a literal `api_key`; falls back to the env var named by
@@ -117,12 +118,12 @@ def resolve_model_ref(alias_model: str) -> tuple[str, str, str, str | None]:
         )
     provider = get_provider(alias)
     api_key = _resolve_api_key(provider, alias)
-    base_url = provider.get("base_url") or ""
-    litellm_provider = provider.get("litellm_provider") or ""
+    base_url: str = provider.get("base_url") or ""
+    litellm_provider: str = provider.get("litellm_provider") or ""
     return litellm_provider, model_id, base_url, api_key
 
 
-def resolve_model_metadata(alias: str, model_id: str) -> dict:
+def resolve_model_metadata(alias: str, model_id: str) -> dict[str, Any]:
     """Resolve capability metadata for a (provider alias, model id) pair.
 
     Field-level merge: text-only default <- litellm registry <- user override
@@ -142,14 +143,14 @@ def resolve_model_metadata(alias: str, model_id: str) -> dict:
 
     cfg = get_config()
     provider = cfg.providers.get(alias, {})
-    override = provider.get("models", {}).get(model_id, {})
+    override: dict[str, Any] = provider.get("models", {}).get(model_id, {})
 
     # A model-scoped litellm_provider override takes precedence over the
     # provider entry's litellm_provider when forming the litellm query.
-    effective_provider = override.get("litellm_provider") or provider.get("litellm_provider")
+    effective_provider: str | None = override.get("litellm_provider") or provider.get("litellm_provider")
     qualified = qualify_model(effective_provider, model_id)
 
-    registry: dict = {}
+    registry: dict[str, Any] = {}
     try:
         info = litellm.get_model_info(qualified)
         if info:
@@ -217,7 +218,7 @@ def discover_provider_models(alias: str, force: bool = False) -> list[str]:
         return _discovery_cache[alias]
 
     provider = get_provider(alias)
-    base_url = provider.get("base_url") or ""
+    base_url: str = provider.get("base_url") or ""
     if not base_url:
         _discovery_cache[alias] = []
         return []
@@ -229,12 +230,12 @@ def discover_provider_models(alias: str, force: bool = False) -> list[str]:
         with httpx.Client(timeout=_DISCOVERY_TIMEOUT) as client:
             response = client.get(f"{base_url.rstrip('/')}/models", headers=headers)
             response.raise_for_status()
-            data = response.json()
-            model_ids = [
+            data: Any = response.json()
+            model_ids: list[str] = [
                 m["id"]
                 for m in data.get("data", [])
                 if isinstance(m, dict)
-                and isinstance(m.get("id"), str)
+                and isinstance(m.get("id"), str)  # type: ignore[reportUnknownMemberType]
                 and m["id"]
             ]
     except Exception as e:  # noqa: BLE001 -- network is best-effort

--- a/src/orchid/mcp/__init__.py
+++ b/src/orchid/mcp/__init__.py
@@ -4,13 +4,14 @@ import asyncio
 import contextlib
 import logging
 from contextvars import ContextVar
+from typing import Any
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.types import BlobResourceContents, TextResourceContents
 
-from orchid.config import _MCP_SERVER_NAME_RE
+from orchid.config import _MCP_SERVER_NAME_RE  # type: ignore[reportPrivateUsage]
 from orchid.domain.tool import ExecutorResult
 
 logger = logging.getLogger(__name__)
@@ -57,10 +58,10 @@ class MCPManager:
     def __init__(self):
         self._exit_stack = contextlib.AsyncExitStack()
         self._sessions: dict[str, ClientSession] = {}
-        self._tools: dict[str, dict] = {}
+        self._tools: dict[str, dict[str, Any]] = {}
         self._uri_map: dict[str, str] = {}  # uri -> server_name
-        self._server_status: dict[str, dict] = {}  # name -> {status, tool_count, error}
-        self._runner: asyncio.Task | None = None
+        self._server_status: dict[str, dict[str, Any]] = {}  # name -> {status, tool_count, error}
+        self._runner: asyncio.Task[None] | None = None
         self._ready: asyncio.Event = asyncio.Event()
         self._stop: asyncio.Event = asyncio.Event()
         self._start_error: BaseException | None = None
@@ -72,7 +73,7 @@ class MCPManager:
 
     async def start_all(
         self,
-        servers: dict[str, dict],
+        servers: dict[str, dict[str, Any]],
         *,
         per_server_timeout: float | None = None,
         startup_timeout: float | None = None,
@@ -132,7 +133,7 @@ class MCPManager:
             # don't keep advertising dead tool entries to the LLM.
             if self._sessions:
                 await asyncio.gather(
-                    *[_close_session(s) for s in self._sessions.values() if s is not None],
+                    *[_close_session(s) for s in self._sessions.values() if s is not None],  # type: ignore[reportUnnecessaryComparison]
                     return_exceptions=True,
                 )
             self._sessions.clear()
@@ -144,7 +145,7 @@ class MCPManager:
             await self._await_runner()
             raise self._start_error
 
-    async def _run(self, servers: dict[str, dict]) -> None:
+    async def _run(self, servers: dict[str, dict[str, Any]]) -> None:
         try:
             await self._exit_stack.__aenter__()
             for server_name, config in servers.items():
@@ -200,7 +201,7 @@ class MCPManager:
                 logger.warning("MCP runner task ended with an error", exc_info=True)
         self._runner = None
 
-    async def _start_server(self, server_name: str, config: dict) -> None:
+    async def _start_server(self, server_name: str, config: dict[str, Any]) -> None:
         if not _MCP_SERVER_NAME_RE.match(server_name):
             logger.warning(
                 "Skipping MCP server '%s': name does not match [a-z0-9-]+",
@@ -232,7 +233,7 @@ class MCPManager:
                 f"MCP server '{server_name}' startup timed out after {self._per_server_timeout}s"
             ) from e
 
-    async def _connect_server(self, server_name: str, config: dict) -> None:
+    async def _connect_server(self, server_name: str, config: dict[str, Any]) -> None:
         from orchid.mcp.schema import convert_mcp_tool, make_mcp_executor
 
         if "url" in config:
@@ -273,16 +274,16 @@ class MCPManager:
         self._tools.clear()
         self._uri_map.clear()
 
-    def get_tools(self) -> dict[str, dict]:
+    def get_tools(self) -> dict[str, dict[str, Any]]:
         return dict(self._tools)
 
-    def get_server_statuses(self) -> dict[str, dict]:
+    def get_server_statuses(self) -> dict[str, dict[str, Any]]:
         return dict(self._server_status)
 
     def get_resource_server(self, uri: str) -> str | None:
         return self._uri_map.get(uri)
 
-    async def call_tool(self, server_name: str, tool_name: str, arguments: dict) -> ExecutorResult:
+    async def call_tool(self, server_name: str, tool_name: str, arguments: dict[str, Any]) -> ExecutorResult:
         session = self._sessions.get(server_name)
         if session is None:
             return ExecutorResult(
@@ -326,7 +327,7 @@ class MCPManager:
         for item in result.contents:
             if isinstance(item, TextResourceContents):
                 parts.append(item.text)
-            elif isinstance(item, BlobResourceContents):
+            elif isinstance(item, BlobResourceContents):  # type: ignore[reportUnnecessaryIsInstance]
                 mime = getattr(item, "mimeType", None) or "application/octet-stream"
                 parts.append(f"[binary resource: {mime}, {len(item.blob)} base64 chars]")
                 logger.debug(

--- a/src/orchid/personality/__init__.py
+++ b/src/orchid/personality/__init__.py
@@ -52,9 +52,9 @@ _REGISTRY: PersonalityRegistry | None = None
 
 
 def get_personality_registry() -> PersonalityRegistry:
-    global _REGISTRY  # noqa: reportConstantRedefinition
+    global _REGISTRY  # pyright: ignore[reportConstantRedefinition]
     if _REGISTRY is None:
-        _REGISTRY = PersonalityRegistry()  # type: ignore[reportConstantRedefinition]
+        _REGISTRY = PersonalityRegistry()  # pyright: ignore[reportConstantRedefinition]
     return _REGISTRY
 
 

--- a/src/orchid/personality/__init__.py
+++ b/src/orchid/personality/__init__.py
@@ -52,9 +52,9 @@ _REGISTRY: PersonalityRegistry | None = None
 
 
 def get_personality_registry() -> PersonalityRegistry:
-    global _REGISTRY
+    global _REGISTRY  # noqa: reportConstantRedefinition
     if _REGISTRY is None:
-        _REGISTRY = PersonalityRegistry()
+        _REGISTRY = PersonalityRegistry()  # type: ignore[reportConstantRedefinition]
     return _REGISTRY
 
 

--- a/src/orchid/rag/__init__.py
+++ b/src/orchid/rag/__init__.py
@@ -1,6 +1,11 @@
 from orchid.rag.chunker import Chunk, chunk_file
 from orchid.rag.embedder import Embedder
-from orchid.rag.indexer import IndexResult, clear_index, get_status, index_project
+from orchid.rag.indexer import (  # type: ignore[reportUnknownVariableType]
+    IndexResult,
+    clear_index,
+    get_status,
+    index_project,
+)
 from orchid.rag.store import RAGStore, SearchResult, StoreStatus
 
 __all__ = [

--- a/src/orchid/rag/chunker.py
+++ b/src/orchid/rag/chunker.py
@@ -32,7 +32,7 @@ def _line_break_offsets(lines: list[str]) -> list[int]:
 
 def _find_break_points(lines: list[str]) -> list[int]:
     """Find natural break points (blank lines) for smarter chunking."""
-    breaks = []
+    breaks: list[int] = []
     for i, line in enumerate(lines):
         if not line.strip():
             breaks.append(i)

--- a/src/orchid/rag/embedder.py
+++ b/src/orchid/rag/embedder.py
@@ -87,7 +87,7 @@ class Embedder:
         for attempt in range(MAX_RETRIES):
             try:
                 def _run() -> list[list[float]]:
-                    return [v.tolist() for v in embedder.embed(texts)]
+                    return [v.tolist() for v in embedder.embed(texts)]  # type: ignore[reportAttributeAccessIssue]
 
                 return await asyncio.to_thread(_run)
             except _NON_RETRYABLE as e:
@@ -118,7 +118,7 @@ class Embedder:
         api_key: str | None,
     ) -> list[list[float]]:
         try:
-            from litellm import aembedding
+            from litellm import aembedding  # type: ignore[reportUnknownVariableType]
         except ImportError as err:
             raise EmbeddingError(
                 "litellm is required for embeddings. "
@@ -135,11 +135,11 @@ class Embedder:
                     base_url=base_url or None,
                     api_key=api_key,
                 )
-                if not response.data:
+                if not response.data:  # type: ignore[reportUnknownMemberType]
                     raise EmbeddingError(
                         f"Embedding provider returned empty response.data for model: {model}"
                     )
-                return [item["embedding"] for item in response.data]
+                return [item["embedding"] for item in response.data]  # type: ignore[reportUnknownVariableType,reportUnknownMemberType]
             except EmbeddingError:
                 raise
             except _NON_RETRYABLE as e:

--- a/src/orchid/rag/indexer.py
+++ b/src/orchid/rag/indexer.py
@@ -39,7 +39,7 @@ class IndexResult:
     files_skipped: int = 0
     files_deleted: int = 0
     chunks_created: int = 0
-    errors: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list[str])
     duration_seconds: float = 0.0
 
 
@@ -104,7 +104,7 @@ async def index_project(
     paths: list[str] | None = None,
     force: bool = False,
     embedder: Embedder | None = None,
-    progress_callback: Callable | None = None,
+    progress_callback: Callable[[str, int, int], None] | None = None,
 ) -> IndexResult:
     """Run the full RAG indexing pipeline.
 
@@ -140,7 +140,7 @@ async def _index_project_impl(
     paths: list[str] | None = None,
     force: bool = False,
     embedder: Embedder | None = None,
-    progress_callback: Callable | None = None,
+    progress_callback: Callable[[str, int, int], None] | None = None,
 ) -> IndexResult:
     cfg = get_config()
     if project_path is None:

--- a/src/orchid/rag/store.py
+++ b/src/orchid/rag/store.py
@@ -5,6 +5,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -79,7 +80,7 @@ class VectorState:
 class RAGStore:
     # Process-level search cache: str(db_path) -> (vectors_ndarray, chunks_list).
     # Invalidated by any mutation method on any store instance for that path.
-    _search_cache: dict[str, tuple[np.ndarray, list[dict]]] = {}
+    _search_cache: dict[str, tuple[np.ndarray, list[dict[str, Any]]]] = {}
 
     def __init__(self, project_path: str):
         self.project_path = project_path
@@ -207,7 +208,7 @@ class RAGStore:
         )
         os.close(tmp_fd)
         try:
-            np.save(tmp_path, arr, allow_pickle=False)
+            np.save(tmp_path, arr, allow_pickle=False)  # type: ignore[reportUnknownMemberType]
             actual = tmp_path + ".npy"
             os.replace(actual, str(self.vectors_file))
             self._invalidate_cache(self.db_path)
@@ -255,7 +256,7 @@ class RAGStore:
             self.clear()
             return None
 
-    def _get_all_chunks(self) -> list[dict]:
+    def _get_all_chunks(self) -> list[dict[str, Any]]:
         conn = self._get_conn()
         try:
             cursor = conn.execute(
@@ -275,7 +276,7 @@ class RAGStore:
         finally:
             conn.close()
 
-    def _load_search_data(self) -> tuple[np.ndarray | None, list[dict] | None]:
+    def _load_search_data(self) -> tuple[np.ndarray | None, list[dict[str, Any]] | None]:
         """Load vectors (as ndarray) and chunks, using the process cache when valid."""
         cache_key = str(self.db_path)
         if cache_key in RAGStore._search_cache:
@@ -348,8 +349,8 @@ class RAGStore:
     ) -> list[float]:
         q = np.asarray(query, dtype=np.float32)
         v = np.asarray(vectors, dtype=np.float32)
-        norms = np.linalg.norm(v, axis=1) * np.linalg.norm(q)
-        norms = np.where(norms == 0, 1, norms)
+        norms = np.linalg.norm(v, axis=1) * np.linalg.norm(q)  # type: ignore[reportUnknownMemberType]
+        norms = np.where(norms == 0, 1, norms)  # type: ignore[reportUnknownMemberType]
         return (v @ q / norms).tolist()
 
     def clear(self) -> None:

--- a/src/orchid/screens/settings.py
+++ b/src/orchid/screens/settings.py
@@ -2,13 +2,15 @@
 
 from dataclasses import asdict
 from functools import partial
+from typing import Any, cast
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, ScrollableContainer, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select, Static, Tab, Tabs
 
-from orchid.commands.session_commands import _build_model_picker_items
+from orchid.app import Orchid
+from orchid.commands.session_commands import _build_model_picker_items  # pyright: ignore[reportPrivateUsage]
 from orchid.config import (
     Config,
     RAGConfig,
@@ -26,7 +28,7 @@ def _list_fastembed_models() -> list[str]:
         return []
 
 
-class NewProviderForm(ModalScreen[dict | None]):
+class NewProviderForm(ModalScreen[dict[str, Any] | None]):
     """Modal form to add or edit a provider entry.
 
     Per-model attributes are edited inline in a table-like grid.
@@ -122,11 +124,11 @@ class NewProviderForm(ModalScreen[dict | None]):
     }
     """
 
-    def __init__(self, title: str, initial: dict | None = None) -> None:
+    def __init__(self, title: str, initial: dict[str, Any] | None = None) -> None:
         super().__init__()
         self._title = title
-        self._initial = initial or {}
-        self._model_entries: list[dict] = []
+        self._initial: dict[str, Any] = initial or {}
+        self._model_entries: list[dict[str, Any]] = []
         self._model_seq = 0
 
     def compose(self) -> ComposeResult:
@@ -181,12 +183,11 @@ class NewProviderForm(ModalScreen[dict | None]):
                 yield Button("Cancel", variant="default", id="pf-cancel")
 
     def on_mount(self) -> None:
-        initial_models = self._initial.get("models", {}) if isinstance(self._initial, dict) else {}
-        if isinstance(initial_models, dict):
-            for model_id, overrides in initial_models.items():
-                if not isinstance(overrides, dict):
-                    overrides = {}
-                self._add_model_entry(model_id=model_id, overrides=overrides)
+        initial_models: dict[str, Any] = self._initial.get("models", {})
+        for model_id, overrides in initial_models.items():
+            if not isinstance(overrides, dict):
+                overrides = {}
+            self._add_model_entry(model_id=model_id, overrides=overrides)  # type: ignore[arg-type]
         if not self._model_entries:
             self._add_model_entry()
         self.query_one("#pf-alias", Input).focus()
@@ -194,7 +195,7 @@ class NewProviderForm(ModalScreen[dict | None]):
     def _add_model_entry(
         self,
         model_id: str = "",
-        overrides: dict | None = None,
+        overrides: dict[str, Any] | None = None,
     ) -> None:
         overrides = overrides or {}
         idx = self._model_seq
@@ -220,8 +221,8 @@ class NewProviderForm(ModalScreen[dict | None]):
         except Exception:
             pass
 
-    def _build_model_row(self, entry: dict) -> Horizontal:
-        idx = entry["idx"]
+    def _build_model_row(self, entry: dict[str, Any]) -> Horizontal:
+        idx: int = entry["idx"]
         vision_select = Select(
             [("false", False), ("true", True)],
             value=entry["supports_vision"],
@@ -287,7 +288,7 @@ class NewProviderForm(ModalScreen[dict | None]):
     def on_input_changed(self, event: Input.Changed) -> None:
         input_id = event.input.id or ""
         for entry in self._model_entries:
-            i = entry["idx"]
+            i: int = entry["idx"]
             if input_id == f"pf-model-id-{i}":
                 entry["model_id"] = event.value
             elif input_id == f"pf-model-mit-{i}":
@@ -298,7 +299,7 @@ class NewProviderForm(ModalScreen[dict | None]):
     def on_select_changed(self, event: Select.Changed) -> None:
         select_id = event.select.id or ""
         for entry in self._model_entries:
-            i = entry["idx"]
+            i: int = entry["idx"]
             if select_id == f"pf-model-vision-{i}":
                 entry["supports_vision"] = bool(event.value)
             elif select_id == f"pf-model-mode-{i}":
@@ -321,7 +322,7 @@ class NewProviderForm(ModalScreen[dict | None]):
         api_key_env = self.query_one("#pf-api-key-env", Input).value.strip()
         litellm_provider = self.query_one("#pf-litellm-provider", Input).value.strip()
 
-        entry: dict = {}
+        entry: dict[str, Any] = {}
         if base_url:
             entry["base_url"] = base_url
         if api_key:
@@ -331,18 +332,18 @@ class NewProviderForm(ModalScreen[dict | None]):
         if litellm_provider:
             entry["litellm_provider"] = litellm_provider
 
-        models: dict[str, dict] = {}
+        models: dict[str, dict[str, Any]] = {}
         seen_ids: set[str] = set()
         for entry_data in self._model_entries:
-            model_id = entry_data["model_id"].strip()
+            model_id: str = entry_data["model_id"].strip()
             if not model_id:
                 continue
             if model_id in seen_ids:
                 self.query_one("#provider-form-error", Static).update(f"Duplicate model id: {model_id}")
                 return
             seen_ids.add(model_id)
-            overrides: dict = {}
-            mit = entry_data["max_input_tokens"].strip()
+            overrides: dict[str, Any] = {}
+            mit: str = entry_data["max_input_tokens"].strip()
             if mit:
                 try:
                     overrides["max_input_tokens"] = int(mit)
@@ -351,7 +352,7 @@ class NewProviderForm(ModalScreen[dict | None]):
                         f"max_input_tokens must be an integer for {model_id!r}."
                     )
                     return
-            mot = entry_data["max_output_tokens"].strip()
+            mot: str = entry_data["max_output_tokens"].strip()
             if mot:
                 try:
                     overrides["max_output_tokens"] = int(mot)
@@ -362,18 +363,18 @@ class NewProviderForm(ModalScreen[dict | None]):
                     return
             if entry_data["supports_vision"]:
                 overrides["supports_vision"] = True
-            mode = entry_data["mode"].strip()
+            mode: str = entry_data["mode"].strip()
             if mode:
                 overrides["mode"] = mode
             models[model_id] = overrides
         if models:
             entry["models"] = models
 
-        result = {"_alias": alias, **entry}
+        result: dict[str, Any] = {"_alias": alias, **entry}
         self.dismiss(result)
 
 
-class NewMCPServerForm(ModalScreen[dict | None]):
+class NewMCPServerForm(ModalScreen[dict[str, Any] | None]):
     """Modal form to add or edit an MCP server entry."""
 
     CSS = """
@@ -411,10 +412,10 @@ class NewMCPServerForm(ModalScreen[dict | None]):
     }
     """
 
-    def __init__(self, title: str, initial: dict | None = None) -> None:
+    def __init__(self, title: str, initial: dict[str, Any] | None = None) -> None:
         super().__init__()
         self._title = title
-        self._initial = initial or {}
+        self._initial: dict[str, Any] = initial or {}
 
     def compose(self) -> ComposeResult:
         with Vertical(id="mcp-form-container"):
@@ -470,7 +471,7 @@ class NewMCPServerForm(ModalScreen[dict | None]):
         args_str = self.query_one("#mf-args", Input).value.strip()
         url = self.query_one("#mf-url", Input).value.strip()
 
-        entry: dict = {}
+        entry: dict[str, Any] = {}
         if url:
             entry["url"] = url
         elif command:
@@ -483,7 +484,7 @@ class NewMCPServerForm(ModalScreen[dict | None]):
             self.query_one("#mcp-form-error", Static).update("Either command or url is required.")
             return
 
-        result = {"_name": name, **entry}
+        result: dict[str, Any] = {"_name": name, **entry}
         self.dismiss(result)
 
 
@@ -766,6 +767,10 @@ class SettingsScreen(ModalScreen[Config | None]):
         self._original = self._clone_config(config)
         self._items_cache: list[tuple[str, str]] = []
 
+    @property
+    def orchid_app(self) -> Orchid:
+        return cast(Orchid, self.app)  # type: ignore[arg-type]
+
     def compose(self) -> ComposeResult:
         with Vertical(id="settings-container"):
             yield Static("Settings", id="settings-header")
@@ -796,7 +801,9 @@ class SettingsScreen(ModalScreen[Config | None]):
             field = self._RAG_INT_FIELDS[wid]
             try:
                 intval = int(val) if val else 0
-                self._config.rag = RAGConfig(**{**asdict(self._config.rag), field: intval})
+                rag_dict = asdict(self._config.rag)
+                rag_dict[field] = intval
+                self._config.rag = RAGConfig(**rag_dict)  # type: ignore[arg-type]
             except ValueError:
                 pass
             self._mark_dirty("rag")
@@ -820,7 +827,7 @@ class SettingsScreen(ModalScreen[Config | None]):
         container.mount(Static("Providers", classes="settings-section-title"))
         container.mount(Static("Configure API providers and their models.", classes="settings-list-item-detail"))
 
-        items = []
+        items: list[tuple[str, str]] = []
         for alias, entry in self._config.providers.items():
             models = list(entry.get("models", {}).keys())[:3]
             models_str = ", ".join(models) if models else "no models"
@@ -838,9 +845,9 @@ class SettingsScreen(ModalScreen[Config | None]):
 
     def _on_provider_action(self, alias: str, action: str) -> None:
         if action == "edit":
-            entry = self._config.providers.get(alias, {})
-            initial = {"_alias": alias, **entry}
-            self.app.push_screen(
+            entry: dict[str, Any] = self._config.providers.get(alias, {})
+            initial: dict[str, Any] = {"_alias": alias, **entry}
+            self.orchid_app.push_screen(
                 NewProviderForm(f"Edit Provider: {alias}", initial),
                 partial(self._on_edit_provider_result, original_alias=alias),
             )
@@ -849,7 +856,7 @@ class SettingsScreen(ModalScreen[Config | None]):
             self._refresh_tab()
             self._mark_dirty("providers")
 
-    def _on_edit_provider_result(self, result: dict | None, original_alias: str | None = None) -> None:
+    def _on_edit_provider_result(self, result: dict[str, Any] | None, original_alias: str | None = None) -> None:
         if result is not None:
             alias = result.pop("_alias")
             if original_alias and original_alias != alias:
@@ -905,11 +912,11 @@ class SettingsScreen(ModalScreen[Config | None]):
             return
 
         if btn_id == "providers-add":
-            self.app.push_screen(NewProviderForm("Add Provider"), self._on_add_provider_result)
+            self.orchid_app.push_screen(NewProviderForm("Add Provider"), self._on_add_provider_result)
         elif btn_id == "mcp-add":
-            self.app.push_screen(NewMCPServerForm("Add MCP Server"), self._on_add_mcp_result)
+            self.orchid_app.push_screen(NewMCPServerForm("Add MCP Server"), self._on_add_mcp_result)
 
-    def _on_add_provider_result(self, result: dict | None) -> None:
+    def _on_add_provider_result(self, result: dict[str, Any] | None) -> None:
         if result is not None:
             alias = result.pop("_alias")
             self._config.providers[alias] = result
@@ -939,7 +946,7 @@ class SettingsScreen(ModalScreen[Config | None]):
         )
 
     def _render_mcp_list(self, container: ScrollableContainer) -> None:
-        items = []
+        items: list[tuple[str, str]] = []
         for name, entry in self._config.mcp_servers.items():
             if "url" in entry:
                 detail = f"SSE: {entry['url']}"
@@ -964,9 +971,9 @@ class SettingsScreen(ModalScreen[Config | None]):
 
     def _on_mcp_action(self, name: str, action: str) -> None:
         if action == "edit":
-            entry = self._config.mcp_servers.get(name, {})
-            initial = {"_name": name, **entry}
-            self.app.push_screen(
+            entry: dict[str, Any] = self._config.mcp_servers.get(name, {})
+            initial: dict[str, Any] = {"_name": name, **entry}
+            self.orchid_app.push_screen(
                 NewMCPServerForm(f"Edit MCP Server: {name}", initial),
                 partial(self._on_edit_mcp_result, original_name=name),
             )
@@ -975,7 +982,7 @@ class SettingsScreen(ModalScreen[Config | None]):
             self._refresh_tab()
             self._mark_dirty("mcp_servers")
 
-    def _on_edit_mcp_result(self, result: dict | None, original_name: str | None = None) -> None:
+    def _on_edit_mcp_result(self, result: dict[str, Any] | None, original_name: str | None = None) -> None:
         if result is not None:
             name = result.pop("_name")
             if original_name and original_name != name:
@@ -992,7 +999,7 @@ class SettingsScreen(ModalScreen[Config | None]):
             self._refresh_tab()
             self._mark_dirty("mcp_servers")
 
-    def _on_add_mcp_result(self, result: dict | None) -> None:
+    def _on_add_mcp_result(self, result: dict[str, Any] | None) -> None:
         if result is not None:
             name = result.pop("_name")
             self._config.mcp_servers[name] = result
@@ -1045,7 +1052,7 @@ class SettingsScreen(ModalScreen[Config | None]):
             self._refresh_tab()
             self._mark_dirty("tier_models")
 
-        self.app.push_screen(OptionPicker(items), _on_picked)
+        self.orchid_app.push_screen(OptionPicker(items), _on_picked)
 
     # ── RAG tab ───────────────────────────────────────────────────────
 
@@ -1107,11 +1114,13 @@ class SettingsScreen(ModalScreen[Config | None]):
         def _on_picked(selected: str | None) -> None:
             if not selected:
                 return
-            self._config.rag = RAGConfig(**{**asdict(self._config.rag), "embedding_model": selected})
+            rag_dict = asdict(self._config.rag)
+            rag_dict["embedding_model"] = selected
+            self._config.rag = RAGConfig(**rag_dict)  # type: ignore[arg-type]
             self._refresh_tab()
             self._mark_dirty("rag")
 
-        self.app.push_screen(OptionPicker(items, header="Embedding Models"), _on_picked)
+        self.orchid_app.push_screen(OptionPicker(items, header="Embedding Models"), _on_picked)
 
     # ── General tab ───────────────────────────────────────────────────
 
@@ -1189,7 +1198,7 @@ class SettingsScreen(ModalScreen[Config | None]):
             self._refresh_tab()
             self._mark_dirty("general")
 
-        self.app.push_screen(OptionPicker(items), _on_picked)
+        self.orchid_app.push_screen(OptionPicker(items), _on_picked)
 
     def _open_theme_picker(self) -> None:
         from orchid.themes import get_theme_registry
@@ -1208,7 +1217,7 @@ class SettingsScreen(ModalScreen[Config | None]):
             self._refresh_tab()
             self._mark_dirty("general")
 
-        self.app.push_screen(OptionPicker(items, header="Themes"), _on_picked)
+        self.orchid_app.push_screen(OptionPicker(items, header="Themes"), _on_picked)
 
     def _open_personality_picker(self) -> None:
         from orchid.personality import load_personalities
@@ -1224,13 +1233,13 @@ class SettingsScreen(ModalScreen[Config | None]):
             self._refresh_tab()
             self._mark_dirty("general")
 
-        self.app.push_screen(OptionPicker(items, header="Personalities"), _on_picked)
+        self.orchid_app.push_screen(OptionPicker(items, header="Personalities"), _on_picked)
 
     # ── Helpers ───────────────────────────────────────────────────────
 
     @staticmethod
     def _clone_config(config: Config) -> Config:
-        return Config(**asdict(config))
+        return Config(**asdict(config))  # type: ignore[arg-type]
 
     def _render_keyed_list(
         self,
@@ -1279,11 +1288,11 @@ class SettingsScreen(ModalScreen[Config | None]):
 
         from orchid.config import ConfigManager
 
-        ConfigManager._instance = config
+        ConfigManager._instance = config  # pyright: ignore[reportPrivateUsage]
         ConfigManager.save()
 
         if config.theme != self._original.theme:
-            self.app.switch_theme(config.theme)
+            self.orchid_app.switch_theme(config.theme)
 
         self._config = self._clone_config(config)
         self._original = self._clone_config(config)
@@ -1293,7 +1302,7 @@ class SettingsScreen(ModalScreen[Config | None]):
         if close:
             self.dismiss(self._config)
         else:
-            self.app.notify("Settings saved.", severity="information")
+            self.orchid_app.notify("Settings saved.", severity="information")
 
     def key_ctrl_s(self) -> None:
         self._do_save(close=False)
@@ -1313,6 +1322,7 @@ class SettingsScreen(ModalScreen[Config | None]):
         cur = getattr(self._config, field, None)
         orig = getattr(self._original, field, None)
         if field == "rag":
+            assert cur is not None and orig is not None
             return asdict(cur) != asdict(orig)
         return cur != orig
 
@@ -1344,7 +1354,7 @@ class SettingsScreen(ModalScreen[Config | None]):
     def _push_confirm_discard(self) -> None:
         tabs = self._dirty_tab_names()
         summary = ", ".join(tabs) if tabs else "settings"
-        self.app.push_screen(
+        self.orchid_app.push_screen(
             ConfirmScreen(
                 "Unsaved changes",
                 f"You have unsaved changes to: {summary}.",

--- a/src/orchid/skills/__init__.py
+++ b/src/orchid/skills/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Any
 
 from orchid.config import HOME_SKILLS_DIR, PROJECT_SKILLS_DIR
 from orchid.domain.skill import Skill, SkillResource
@@ -29,8 +30,8 @@ def _scan_resource_dir(skill_dir: Path, dirname: str) -> list[SkillResource]:
         if file_path.suffix in (".md", ".txt", ".sh", ".py", ".rb", ".js", ".ts", ".yaml", ".yml", ".json", ".toml", ".cfg", ".ini", ".bash", ".zsh", ".fish"):
             try:
                 text = file_path.read_text()
-                metadata, _ = parse_frontmatter(text)
-                description = metadata.get("description", "")
+                metadata: dict[str, Any] = parse_frontmatter(text)[0]
+                description = str(metadata.get("description", ""))
             except (OSError, UnicodeDecodeError):
                 pass
 
@@ -58,10 +59,11 @@ def _load_skills_from_dir(skills_dir: Path) -> dict[str, Skill]:
             log.warning("Skipping %s: %s", skill_file, e)
             continue
 
-        metadata, body = parse_frontmatter(content)
+        metadata: dict[str, Any] = parse_frontmatter(content)[0]
+        body = parse_frontmatter(content)[1]
 
-        name = metadata.get("name", path.name)
-        description = metadata.get("description", "")
+        name = str(metadata.get("name", path.name))
+        description = str(metadata.get("description", ""))
 
         if not description:
             log.warning("Skipping %s: no description in frontmatter", skill_file)
@@ -69,7 +71,7 @@ def _load_skills_from_dir(skills_dir: Path) -> dict[str, Skill]:
 
         requires_raw = metadata.get("requires", [])
         if isinstance(requires_raw, list):
-            requires = requires_raw
+            requires: list[str] = requires_raw  # type: ignore[reportUnknownVariableType]
         else:
             if requires_raw:
                 log.warning("%s: 'requires' must be a list, got %s — ignoring", skill_file, type(requires_raw).__name__)
@@ -106,7 +108,7 @@ def seed_skills_dir(skills_dir: Path) -> None:
 
 
 def load_skills() -> dict[str, Skill]:
-    global SKILL_REGISTRY
+    global SKILL_REGISTRY  # noqa: reportConstantRedefinition
 
     home_skills = _load_skills_from_dir(HOME_SKILLS_DIR)
 
@@ -114,7 +116,7 @@ def load_skills() -> dict[str, Skill]:
     project_skills = _load_skills_from_dir(project_skills_dir)
 
     merged = {**home_skills, **project_skills}
-    SKILL_REGISTRY = merged
+    SKILL_REGISTRY = merged  # type: ignore[reportConstantRedefinition]
 
     from orchid.tools import reset_tool_registry
     reset_tool_registry()

--- a/src/orchid/skills/__init__.py
+++ b/src/orchid/skills/__init__.py
@@ -71,7 +71,7 @@ def _load_skills_from_dir(skills_dir: Path) -> dict[str, Skill]:
 
         requires_raw = metadata.get("requires", [])
         if isinstance(requires_raw, list):
-            requires: list[str] = requires_raw  # type: ignore[reportUnknownVariableType]
+            requires: list[str] = requires_raw  # pyright: ignore[reportUnknownVariableType]
         else:
             if requires_raw:
                 log.warning("%s: 'requires' must be a list, got %s — ignoring", skill_file, type(requires_raw).__name__)
@@ -108,7 +108,7 @@ def seed_skills_dir(skills_dir: Path) -> None:
 
 
 def load_skills() -> dict[str, Skill]:
-    global SKILL_REGISTRY  # noqa: reportConstantRedefinition
+    global SKILL_REGISTRY  # pyright: ignore[reportConstantRedefinition]
 
     home_skills = _load_skills_from_dir(HOME_SKILLS_DIR)
 
@@ -116,7 +116,7 @@ def load_skills() -> dict[str, Skill]:
     project_skills = _load_skills_from_dir(project_skills_dir)
 
     merged = {**home_skills, **project_skills}
-    SKILL_REGISTRY = merged  # type: ignore[reportConstantRedefinition]
+    SKILL_REGISTRY = merged  # pyright: ignore[reportConstantRedefinition]
 
     from orchid.tools import reset_tool_registry
     reset_tool_registry()

--- a/src/orchid/storage.py
+++ b/src/orchid/storage.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
+from typing import Any
 
 from orchid.config import HOME_CONFIG_DIR
 
@@ -16,9 +17,9 @@ def ensure_sessions_dir() -> Path:
     return SESSIONS_DIR
 
 
-def save_session(data: dict) -> None:
+def save_session(data: dict[str, Any]) -> None:
     """Save a session dict to ~/.orchid/sessions/<uuid>.json atomically."""
-    session_id = data["id"]
+    session_id: str = data["id"]
     ensure_sessions_dir()
     path = SESSIONS_DIR / f"{session_id}.json"
     tmp = path.with_suffix(".tmp")
@@ -38,7 +39,7 @@ def save_session(data: dict) -> None:
         raise
 
 
-def load_session(session_id: str) -> dict | None:
+def load_session(session_id: str) -> dict[str, Any] | None:
     """Load a session dict from disk by ID. Returns None if not found."""
     path = SESSIONS_DIR / f"{session_id}.json"
     if not path.exists():
@@ -51,14 +52,14 @@ def load_session(session_id: str) -> dict | None:
         return None
 
 
-def list_saved_sessions() -> list[dict]:
+def list_saved_sessions() -> list[dict[str, Any]]:
     """Return metadata for all saved sessions (id, name, model) sorted by most recent chains."""
     ensure_sessions_dir()
-    sessions = []
+    sessions: list[dict[str, Any]] = []
     for path in SESSIONS_DIR.glob("*.json"):
         try:
             with open(path) as f:
-                data = json.load(f)
+                data: dict[str, Any] = json.load(f)
             # Extract just the metadata we need for listing
             sessions.append({
                 "id": data["id"],

--- a/src/orchid/themes/registry.py
+++ b/src/orchid/themes/registry.py
@@ -68,7 +68,7 @@ _REGISTRY: ThemeRegistry | None = None
 
 
 def get_theme_registry() -> ThemeRegistry:
-    global _REGISTRY  # noqa: reportConstantRedefinition
+    global _REGISTRY  # pyright: ignore[reportConstantRedefinition]
     if _REGISTRY is None:
-        _REGISTRY = ThemeRegistry()  # type: ignore[reportConstantRedefinition]
+        _REGISTRY = ThemeRegistry()  # pyright: ignore[reportConstantRedefinition]
     return _REGISTRY

--- a/src/orchid/themes/registry.py
+++ b/src/orchid/themes/registry.py
@@ -68,7 +68,7 @@ _REGISTRY: ThemeRegistry | None = None
 
 
 def get_theme_registry() -> ThemeRegistry:
-    global _REGISTRY
+    global _REGISTRY  # noqa: reportConstantRedefinition
     if _REGISTRY is None:
-        _REGISTRY = ThemeRegistry()
+        _REGISTRY = ThemeRegistry()  # type: ignore[reportConstantRedefinition]
     return _REGISTRY

--- a/src/orchid/tools/__init__.py
+++ b/src/orchid/tools/__init__.py
@@ -55,14 +55,14 @@ from orchid.tools.todo import (
 )
 from orchid.tools.web_fetch import execute_web_fetch, web_fetch_tool
 
-_TOOL_REGISTRY: dict[str, dict] | None = None
+_tool_registry: dict[str, dict[str, object]] | None = None
 
 
-def get_tool_registry() -> dict[str, dict]:
-    global _TOOL_REGISTRY
-    if _TOOL_REGISTRY is not None:
-        return _TOOL_REGISTRY
-    _TOOL_REGISTRY = {
+def get_tool_registry() -> dict[str, dict[str, object]]:
+    global _tool_registry
+    if _tool_registry is not None:
+        return _tool_registry
+    _tool_registry = {
         "read": {"tool": read_tool, "executor": execute_read_tool},
         "edit": {"tool": edit_tool, "executor": execute_edit_tool},
         "read_directory": {"tool": read_directory, "executor": execute_read_directory_tool},
@@ -88,10 +88,10 @@ def get_tool_registry() -> dict[str, dict]:
         "replace_symbol": {"tool": replace_symbol_tool, "executor": execute_replace_symbol},
         "rename_symbol": {"tool": rename_symbol_tool, "executor": execute_rename_symbol},
     }
-    return _TOOL_REGISTRY
+    return _tool_registry
 
 
 def reset_tool_registry() -> None:
     """Call after agents/skills change to rebuild on next access."""
-    global _TOOL_REGISTRY
-    _TOOL_REGISTRY = None
+    global _tool_registry
+    _tool_registry = None

--- a/src/orchid/tools/_xml_utils.py
+++ b/src/orchid/tools/_xml_utils.py
@@ -1,4 +1,4 @@
-def _xml_attr(value: object) -> str:
+def xml_attr(value: object) -> str:
     return (
         str(value)
         .replace("&", "&amp;")
@@ -8,11 +8,11 @@ def _xml_attr(value: object) -> str:
     )
 
 
-def _cdata_text(value: str) -> str:
+def cdata_text(value: str) -> str:
     return value.replace("]]>", "]]]]><![CDATA[>")
 
 
-def _count_diff_changes(diff_text: str) -> tuple[int, int]:
+def count_diff_changes(diff_text: str) -> tuple[int, int]:
     added = 0
     removed = 0
     for line in diff_text.splitlines():

--- a/src/orchid/tools/ast.py
+++ b/src/orchid/tools/ast.py
@@ -6,6 +6,7 @@ import stat
 import tempfile
 from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
 from xml.sax.saxutils import escape
 
 import tree_sitter
@@ -14,7 +15,7 @@ from orchid.ast.indexer import ensure_indexed
 from orchid.ast.parser import lang_for_extension, load_query_file, parse_file, run_query
 from orchid.ast.store import ASTStore
 from orchid.domain.tool import ExecutorResult, Tool, ToolParameter, ToolParameterProperties
-from orchid.tools._xml_utils import _cdata_text, _count_diff_changes, _xml_attr
+from orchid.tools._xml_utils import cdata_text, count_diff_changes, xml_attr
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ def _generate_diff(old: str, new: str, path: str) -> str:
     return "\n".join(diff)
 
 
-def _format_edit_result(
+def format_edit_result(
     file_path: str,
     *,
     success: bool,
@@ -118,7 +119,7 @@ def _format_edit_result(
     replace_all: bool = False,
 ) -> str:
     attrs = [
-        f'path="{_xml_attr(file_path)}"',
+        f'path="{xml_attr(file_path)}"',
         f'success="{str(success).lower()}"',
         f'replacements="{replacements}"',
         f'replace_all="{str(replace_all).lower()}"',
@@ -126,13 +127,13 @@ def _format_edit_result(
         f'removed="{removed}"',
     ]
     if error:
-        attrs.append(f'error="{_xml_attr(error)}"')
+        attrs.append(f'error="{xml_attr(error)}"')
 
     lines = [f"<edit_result {' '.join(attrs)}>"]
     if message:
-        lines.extend(["<message><![CDATA[", _cdata_text(message), "]]></message>"])
+        lines.extend(["<message><![CDATA[", cdata_text(message), "]]></message>"])
     if diff_text:
-        lines.extend(['<diff format="unified"><![CDATA[', _cdata_text(diff_text), "]]></diff>"])
+        lines.extend(['<diff format="unified"><![CDATA[', cdata_text(diff_text), "]]></diff>"])
     else:
         lines.append('<diff format="unified" />')
     lines.append("</edit_result>")
@@ -229,7 +230,7 @@ def _atomic_write(file_path: str, content: str) -> None:
 atomic_write = _atomic_write
 
 
-async def _trigger_post_write_callbacks(file_path: str) -> list[str]:
+async def trigger_post_write_callbacks(file_path: str) -> list[str]:
     """Run all post-write callbacks and return a list of failure messages."""
     failures: list[str] = []
     for cb in post_write_callbacks:
@@ -375,7 +376,7 @@ async def execute_get_file_skeleton(file_path: str) -> ExecutorResult:
         if not filepath.exists():
             return ExecutorResult(
                 display=f"File not found: {file_path}",
-                content=f'<ast_error tool="get_file_skeleton" file="{_xml_attr(file_path)}">'
+                content=f'<ast_error tool="get_file_skeleton" file="{xml_attr(file_path)}">'
                 f"File not found: {escape(file_path)}</ast_error>",
             )
 
@@ -386,7 +387,7 @@ async def execute_get_file_skeleton(file_path: str) -> ExecutorResult:
         captures = run_query(tree, lang_name, query_text, content)
 
         content_bytes = content.encode("utf-8")
-        definitions = []
+        definitions: list[tuple[int, str, tree_sitter.Node | None]] = []
         for cap_name, results in captures.items():
             if cap_name.startswith("name.definition."):
                 for r in results:
@@ -396,15 +397,15 @@ async def execute_get_file_skeleton(file_path: str) -> ExecutorResult:
         if not definitions:
             return ExecutorResult(
                 display=f"No definitions in {file_path}",
-                content=f'<file_skeleton file="{_xml_attr(file_path)}" definitions="0">\n'
+                content=f'<file_skeleton file="{xml_attr(file_path)}" definitions="0">\n'
                 "No definitions found.\n</file_skeleton>",
             )
 
         definitions.sort(key=lambda x: x[0])
 
-        lines_buf = []
+        lines_buf: list[str] = []
         lines_buf.append(
-            f'<file_skeleton file="{_xml_attr(file_path)}" definitions="{len(definitions)}">'
+            f'<file_skeleton file="{xml_attr(file_path)}" definitions="{len(definitions)}">'
         )
         prev_line = None
         for line_num, name, parent_node in definitions:
@@ -440,14 +441,14 @@ async def execute_get_file_skeleton(file_path: str) -> ExecutorResult:
     except ValueError as e:
         return ExecutorResult(
             display=f"Unsupported file type: {file_path}",
-            content=f'<ast_error tool="get_file_skeleton" file="{_xml_attr(file_path)}">'
+            content=f'<ast_error tool="get_file_skeleton" file="{xml_attr(file_path)}">'
             f"{escape(str(e))}</ast_error>",
         )
     except Exception as e:
         logger.warning("get_file_skeleton error: %s", e)
         return ExecutorResult(
             display=f"Error: {file_path}",
-            content=f'<ast_error tool="get_file_skeleton" file="{_xml_attr(file_path)}">'
+            content=f'<ast_error tool="get_file_skeleton" file="{xml_attr(file_path)}">'
             f"{escape(str(e))}</ast_error>",
         )
 
@@ -460,7 +461,7 @@ async def execute_get_function(
         if not filepath.exists():
             return ExecutorResult(
                 display=f"File not found: {file_path}",
-                content=f'<ast_error tool="get_function" file="{_xml_attr(file_path)}">'
+                content=f'<ast_error tool="get_function" file="{xml_attr(file_path)}">'
                 f"File not found: {escape(file_path)}</ast_error>",
             )
 
@@ -489,7 +490,7 @@ async def execute_get_function(
         name_caps = captures.get("name.definition.function", [])
         method_caps = captures.get("name.definition.method", [])
 
-        found_functions = []
+        found_functions: list[str] = []
         for target_name in names:
             matched = False
             for r in name_caps + method_caps:
@@ -538,16 +539,16 @@ async def execute_get_function(
 
                 if last_hash is not None and last_hash == current_hash:
                     found_functions.append(
-                        f'<function name="{_xml_attr(target_name)}" '
-                        f'file="{_xml_attr(file_path)}" '
+                        f'<function name="{xml_attr(target_name)}" '
+                        f'file="{xml_attr(file_path)}" '
                         f'start_line="{start_line}" end_line="{end_line}">\n'
                         "No changes have been made since last retrieval.\n</function>"
                     )
                 else:
-                    parts = []
+                    parts: list[str] = []
                     parts.append(
-                        f'<function name="{_xml_attr(target_name)}" '
-                        f'file="{_xml_attr(file_path)}" '
+                        f'<function name="{xml_attr(target_name)}" '
+                        f'file="{xml_attr(file_path)}" '
                         f'start_line="{start_line}" end_line="{end_line}">'
                     )
                     if imports_text:
@@ -569,13 +570,13 @@ async def execute_get_function(
 
             if not matched:
                 found_functions.append(
-                    f'<function name="{_xml_attr(target_name)}" '
-                    f'file="{_xml_attr(file_path)}" status="not_found">\n'
+                    f'<function name="{xml_attr(target_name)}" '
+                    f'file="{xml_attr(file_path)}" status="not_found">\n'
                     f"Function '{escape(target_name)}' not found.\n</function>"
                 )
 
         content_xml = (
-            f'<functions file="{_xml_attr(file_path)}" count="{len(found_functions)}">\n'
+            f'<functions file="{xml_attr(file_path)}" count="{len(found_functions)}">\n'
             + "\n".join(found_functions)
             + "\n</functions>"
         )
@@ -588,14 +589,14 @@ async def execute_get_function(
     except ValueError as e:
         return ExecutorResult(
             display=f"Unsupported file type: {file_path}",
-            content=f'<ast_error tool="get_function" file="{_xml_attr(file_path)}">'
+            content=f'<ast_error tool="get_function" file="{xml_attr(file_path)}">'
             f"{escape(str(e))}</ast_error>",
         )
     except Exception as e:
         logger.warning("get_function error: %s", e)
         return ExecutorResult(
             display=f"Error: {file_path}",
-            content=f'<ast_error tool="get_function" file="{_xml_attr(file_path)}">'
+            content=f'<ast_error tool="get_function" file="{xml_attr(file_path)}">'
             f"{escape(str(e))}</ast_error>",
         )
 
@@ -625,24 +626,24 @@ async def execute_find_symbol_references(
         project_path = str(Path.cwd())
         store = ASTStore(project_path)
 
-        symbols = await loop.run_in_executor(
+        symbols: list[dict[str, Any]] = await loop.run_in_executor(
             None, store.get_symbols_by_name, name, type_filter
         )
 
         if not symbols:
             return ExecutorResult(
                 display=f"No references for '{name}'",
-                content=f'<symbol_references name="{_xml_attr(name)}" count="0" />',
+                content=f'<symbol_references name="{xml_attr(name)}" count="0" />',
             )
 
         e = escape
-        parts = []
+        parts: list[str] = []
         for s in symbols:
             parts.append(
-                f'  <symbol name="{_xml_attr(s["name"])}" '
+                f'  <symbol name="{xml_attr(s["name"])}" '
                 f'type="{s["type"]}" '
                 f'kind="{s["kind"]}" '
-                f'file="{_xml_attr(s["file_path"])}" '
+                f'file="{xml_attr(s["file_path"])}" '
                 f'start_line="{s["start_line"] + 1}" '
                 f'start_column="{s["start_column"]}" '
                 f'end_line="{s["end_line"] + 1}" '
@@ -650,7 +651,7 @@ async def execute_find_symbol_references(
             )
 
         result_xml = (
-            f'<symbol_references name="{_xml_attr(name)}" '
+            f'<symbol_references name="{xml_attr(name)}" '
             f'type_filter="{type_filter}" count="{len(symbols)}">\n'
             + "\n".join(parts)
             + "\n</symbol_references>"
@@ -680,7 +681,7 @@ async def execute_replace_symbol(
         if not filepath.exists():
             return ExecutorResult(
                 display=f"File not found: {file_path}",
-                content=_format_edit_result(
+                content=format_edit_result(
                     file_path,
                     success=False,
                     replacements=0,
@@ -707,7 +708,7 @@ async def execute_replace_symbol(
         if not target_caps:
             return ExecutorResult(
                 display=f"Symbol '{name}' not found in {file_path}",
-                content=_format_edit_result(
+                content=format_edit_result(
                     file_path,
                     success=False,
                     replacements=0,
@@ -718,7 +719,7 @@ async def execute_replace_symbol(
                 ),
             )
 
-        replacements_list = []
+        replacements_list: list[tuple[int, int]] = []
         parent_contexts: list[str] = []
         for r in target_caps:
             if r.node.parent is None:
@@ -766,7 +767,7 @@ async def execute_replace_symbol(
         if not replacements_list:
             return ExecutorResult(
                 display=f"Symbol '{name}' not found in {file_path}",
-                content=_format_edit_result(
+                content=format_edit_result(
                     file_path,
                     success=False,
                     replacements=0,
@@ -781,7 +782,7 @@ async def execute_replace_symbol(
         # ask the user to disambiguate rather than silently replacing all.
         unique_contexts = set(parent_contexts)
         if len(replacements_list) > 1 and len(unique_contexts) > 1:
-            locations = []
+            locations: list[str] = []
             for ctx, (_, end) in zip(parent_contexts, replacements_list, strict=False):
                 # Compute line number from byte offset.
                 line_num = content_bytes[:end].count(b"\n") + 1
@@ -789,7 +790,7 @@ async def execute_replace_symbol(
             ctx_list = "\n".join(locations)
             return ExecutorResult(
                 display=f"Multiple '{name}' definitions found — disambiguate",
-                content=_format_edit_result(
+                content=format_edit_result(
                     file_path,
                     success=False,
                     replacements=0,
@@ -820,7 +821,7 @@ async def execute_replace_symbol(
         if new_content == content:
             return ExecutorResult(
                 display=f"No changes for '{name}' in {file_path}",
-                content=_format_edit_result(
+                content=format_edit_result(
                     file_path,
                     success=True,
                     replacements=0,
@@ -833,9 +834,9 @@ async def execute_replace_symbol(
         _atomic_write(file_path, new_content)
 
         diff_text = _generate_diff(content, new_content, file_path)
-        added, removed = _count_diff_changes(diff_text)
+        added, removed = count_diff_changes(diff_text)
 
-        cb_failures = await _trigger_post_write_callbacks(file_path)
+        cb_failures = await trigger_post_write_callbacks(file_path)
 
         msg = f"Replaced '{name}' in {file_path} (+{added} -{removed})"
         if cb_failures:
@@ -843,7 +844,7 @@ async def execute_replace_symbol(
 
         return ExecutorResult(
             display=msg,
-            content=_format_edit_result(
+            content=format_edit_result(
                 file_path,
                 success=True,
                 replacements=len(replacements_list),
@@ -857,7 +858,7 @@ async def execute_replace_symbol(
     except ValueError as e:
         return ExecutorResult(
             display=f"Unsupported file type: {file_path}",
-            content=_format_edit_result(
+            content=format_edit_result(
                 file_path,
                 success=False,
                 replacements=0,
@@ -871,7 +872,7 @@ async def execute_replace_symbol(
         logger.warning("replace_symbol error: %s", e)
         return ExecutorResult(
             display=f"Error replacing '{name}'",
-            content=_format_edit_result(
+            content=format_edit_result(
                 file_path,
                 success=False,
                 replacements=0,
@@ -905,7 +906,7 @@ async def execute_rename_symbol(name: str, new_name: str) -> ExecutorResult:
         project_path = str(Path.cwd())
         store = ASTStore(project_path)
 
-        symbols = await loop.run_in_executor(
+        symbols: list[dict[str, Any]] = await loop.run_in_executor(
             None, store.get_symbols_by_name, name, "both"
         )
 
@@ -917,7 +918,7 @@ async def execute_rename_symbol(name: str, new_name: str) -> ExecutorResult:
                 f"No files modified.</ast_error>",
             )
 
-        by_file: dict[str, list[dict]] = {}
+        by_file: dict[str, list[dict[str, Any]]] = {}
         for s in symbols:
             by_file.setdefault(s["file_path"], []).append(s)
 
@@ -950,14 +951,14 @@ async def execute_rename_symbol(name: str, new_name: str) -> ExecutorResult:
 
             file_replacements = 0
             for s in sorted_syms:
-                line_idx = s["start_line"]
-                byte_col = s["start_column"]
+                line_idx: int = s["start_line"]
+                byte_col: int = s["start_column"]
                 if line_idx >= len(lines):
                     continue
-                line = lines[line_idx]
+                line: str = lines[line_idx]
 
                 # P0 #2: Convert byte-based column to character-based column.
-                line_bytes = line.encode("utf-8")
+                line_bytes: bytes = line.encode("utf-8")
                 if byte_col > len(line_bytes):
                     continue
                 char_col = len(line_bytes[:byte_col].decode("utf-8", errors="replace"))
@@ -992,7 +993,7 @@ async def execute_rename_symbol(name: str, new_name: str) -> ExecutorResult:
         # Phase 2: write all files. Track successes and failures.
         total_added = 0
         total_removed = 0
-        edit_results = []
+        edit_results: list[str] = []
 
         for rel_path, abs_path, content, new_content, file_replacements in planned:
             try:
@@ -1001,19 +1002,19 @@ async def execute_rename_symbol(name: str, new_name: str) -> ExecutorResult:
                 failed_files.append(rel_path)
                 logger.warning("rename_symbol write failed for %s: %s", rel_path, write_err)
                 edit_results.append(
-                    f'<edit_result path="{_xml_attr(rel_path)}" success="false" '
+                    f'<edit_result path="{xml_attr(rel_path)}" success="false" '
                     f'replacements="0" replace_all="false" '
                     f'added="0" removed="0" '
-                    f'error="{_xml_attr(str(write_err))}" />'
+                    f'error="{xml_attr(str(write_err))}" />'
                 )
                 continue
 
             diff_text = _generate_diff(content, new_content, rel_path)
-            added, removed = _count_diff_changes(diff_text)
+            added, removed = count_diff_changes(diff_text)
             total_added += added
             total_removed += removed
 
-            cb_failures = await _trigger_post_write_callbacks(rel_path)
+            cb_failures = await trigger_post_write_callbacks(rel_path)
             if cb_failures:
                 failed_files.append(rel_path)
                 logger.warning(
@@ -1023,10 +1024,10 @@ async def execute_rename_symbol(name: str, new_name: str) -> ExecutorResult:
                 )
 
             edit_results.append(
-                f'<edit_result path="{_xml_attr(rel_path)}" success="true" '
+                f'<edit_result path="{xml_attr(rel_path)}" success="true" '
                 f'replacements="{file_replacements}" replace_all="false" '
                 f'added="{added}" removed="{removed}">\n'
-                f'<diff format="unified"><![CDATA[{_cdata_text(diff_text)}]]></diff>\n'
+                f'<diff format="unified"><![CDATA[{cdata_text(diff_text)}]]></diff>\n'
                 f"</edit_result>"
             )
 
@@ -1039,8 +1040,8 @@ async def execute_rename_symbol(name: str, new_name: str) -> ExecutorResult:
 
         overall_success = len(failed_files) == 0
         result_xml = (
-            f'<rename_result name="{_xml_attr(name)}" '
-            f'new_name="{_xml_attr(new_name)}" '
+            f'<rename_result name="{xml_attr(name)}" '
+            f'new_name="{xml_attr(new_name)}" '
             f'files="{len(edit_results)}" '
             f'total_added="{total_added}" total_removed="{total_removed}" '
             f'success="{str(overall_success).lower()}">\n'

--- a/src/orchid/tools/exec.py
+++ b/src/orchid/tools/exec.py
@@ -5,7 +5,7 @@ import signal
 
 from orchid.config import get_config
 from orchid.domain.tool import ExecutorResult, Tool, ToolParameter, ToolParameterProperties
-from orchid.tools._xml_utils import _cdata_text, _xml_attr
+from orchid.tools._xml_utils import cdata_text, xml_attr
 
 MAX_OUTPUT_BYTES = 1 * 1024 * 1024
 
@@ -124,7 +124,7 @@ async def execute_command(
             return ExecutorResult(
                 display=f"{description} - Timed out after {timeout} seconds",
                 content=(
-                    f'<command_result command="{_xml_attr(command)}" exit_code="-1" '
+                    f'<command_result command="{xml_attr(command)}" exit_code="-1" '
                     f'timed_out="true">\n'
                     f"  <error><![CDATA[Command timed out after {timeout} seconds.]]></error>\n"
                     f"</command_result>"
@@ -144,10 +144,10 @@ async def execute_command(
         stderr = stderr_bytes.decode("utf-8", errors="replace").strip() if stderr_bytes else ""
 
         stdout_section = (
-            f"  <stdout><![CDATA[{_cdata_text(stdout)}]]></stdout>\n" if stdout else ""
+            f"  <stdout><![CDATA[{cdata_text(stdout)}]]></stdout>\n" if stdout else ""
         )
         stderr_section = (
-            f"  <stderr><![CDATA[{_cdata_text(stderr)}]]></stderr>\n" if stderr else ""
+            f"  <stderr><![CDATA[{cdata_text(stderr)}]]></stderr>\n" if stderr else ""
         )
         truncation_section = (
             "  <truncated>true</truncated>\n" if truncated else ""
@@ -156,7 +156,7 @@ async def execute_command(
         return ExecutorResult(
             display=f"{description} (exit code: {process.returncode})",
             content=(
-                f'<command_result command="{_xml_attr(command)}" '
+                f'<command_result command="{xml_attr(command)}" '
                 f'exit_code="{process.returncode}">\n'
                 f"{stdout_section}{stderr_section}{truncation_section}"
                 f"</command_result>"
@@ -167,9 +167,9 @@ async def execute_command(
         return ExecutorResult(
             display=f"{description} - Execution error",
             content=(
-                f'<command_result command="{_xml_attr(command)}" exit_code="-1" '
+                f'<command_result command="{xml_attr(command)}" exit_code="-1" '
                 f'error="true">\n'
-                f"  <error><![CDATA[{_cdata_text(str(e))}]]></error>\n"
+                f"  <error><![CDATA[{cdata_text(str(e))}]]></error>\n"
                 f"</command_result>"
             ),
         )

--- a/src/orchid/tools/file_manipulation.py
+++ b/src/orchid/tools/file_manipulation.py
@@ -9,8 +9,8 @@ import aiofiles
 
 from orchid.config import get_config
 from orchid.domain.tool import ExecutorResult, Tool, ToolParameter, ToolParameterProperties
-from orchid.tools._xml_utils import _count_diff_changes
-from orchid.tools.ast import _format_edit_result, _trigger_post_write_callbacks, atomic_write
+from orchid.tools._xml_utils import count_diff_changes
+from orchid.tools.ast import atomic_write, format_edit_result, trigger_post_write_callbacks
 from orchid.utils import directory_tree
 
 logger = logging.getLogger(__name__)
@@ -119,7 +119,7 @@ async def execute_edit_tool(
         if old_string not in content:
             return ExecutorResult(
                 display=f"String not found in {file_path}",
-                content=_format_edit_result(
+                content=format_edit_result(
                     file_path,
                     success=False,
                     replacements=0,
@@ -135,7 +135,7 @@ async def execute_edit_tool(
         if not replace_all and match_count > 1:
             return ExecutorResult(
                 display=f"Multiple matches in {file_path}",
-                content=_format_edit_result(
+                content=format_edit_result(
                     file_path,
                     success=False,
                     replacements=0,
@@ -168,17 +168,17 @@ async def execute_edit_tool(
         )
         diff_text = "\n".join(_normalize_diff_lines(diff))
 
-        cb_failures = await _trigger_post_write_callbacks(file_path)
+        cb_failures = await trigger_post_write_callbacks(file_path)
 
         display = f"Edited {file_path}"
         added = 0
         removed = 0
         if diff_text:
-            added, removed = _count_diff_changes(diff_text)
+            added, removed = count_diff_changes(diff_text)
             display = f"{display} (+{added} -{removed})"
         if cb_failures:
             display += f" [warnings: {len(cb_failures)} callback(s) failed]"
-        result = _format_edit_result(
+        result = format_edit_result(
             file_path,
             success=True,
             replacements=replacements,
@@ -191,7 +191,7 @@ async def execute_edit_tool(
     except Exception as e:
         return ExecutorResult(
             display=f"Edit error {file_path}",
-            content=_format_edit_result(
+            content=format_edit_result(
                 file_path,
                 success=False,
                 replacements=0,
@@ -332,7 +332,7 @@ async def execute_write_tool(file_path: str, content: str) -> ExecutorResult:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, atomic_write, str(path), content)
 
-        cb_failures = await _trigger_post_write_callbacks(str(path))
+        cb_failures = await trigger_post_write_callbacks(str(path))
 
         lines = content.splitlines()
         display = f"Wrote {len(lines)} lines to {path}"

--- a/src/orchid/tools/rag.py
+++ b/src/orchid/tools/rag.py
@@ -117,7 +117,7 @@ async def execute_rag_search(
         )
 
     e = escape
-    parts = []
+    parts: list[str] = []
     for r in results:
         parts.append(
             f'<result file="{e(r.file_path)}" lines="{r.start_line}-{r.end_line}" '

--- a/src/orchid/tools/search.py
+++ b/src/orchid/tools/search.py
@@ -95,8 +95,8 @@ async def execute_grep_tool(
             file_regex = re.compile(glob_regex, re.IGNORECASE)
 
         # Collect all file paths using os.walk (blocking) in executor
-        def _collect_files():
-            collected = []
+        def _collect_files() -> list[str]:
+            collected: list[str] = []
             for root, dirs, files in os.walk(base_path):
                 dirs[:] = [d for d in dirs if not _should_skip_dir(d)]
                 for filename in sorted(files):
@@ -112,7 +112,7 @@ async def execute_grep_tool(
         semaphore = asyncio.Semaphore(32)
         results: list[str] = []
 
-        def _search_file_sync(file_path: str, regex, max_results: int) -> list[str] | None:
+        def _search_file_sync(file_path: str, regex: re.Pattern[str], max_results: int) -> list[str] | None:
             try:
                 relative_path = os.path.relpath(file_path, base_path)
                 matches: list[str] = []

--- a/src/orchid/tools/skill.py
+++ b/src/orchid/tools/skill.py
@@ -2,7 +2,7 @@ from contextvars import ContextVar
 from fnmatch import fnmatch
 from xml.sax.saxutils import escape
 
-from orchid.domain.skill import Skill
+from orchid.domain.skill import Skill, SkillResource
 from orchid.domain.tool import ExecutorResult, Tool, ToolParameter, ToolParameterProperties
 from orchid.skills import get_skill_registry
 
@@ -72,10 +72,10 @@ def _format_resource_listing(skill: Skill) -> str:
     sections: list[str] = []
 
     for attr, label in [("references", "references"), ("scripts", "scripts"), ("assets", "assets")]:
-        resources = getattr(skill, attr)
+        resources: list[SkillResource] = getattr(skill, attr)
         if not resources:
             continue
-        lines = []
+        lines: list[str] = []
         for r in resources:
             if r.description:
                 lines.append(f"- {r.path} — {r.description}")

--- a/src/orchid/tools/subagent.py
+++ b/src/orchid/tools/subagent.py
@@ -111,7 +111,7 @@ async def execute_wait_for_subagent(subagent_ids: list[str]) -> ExecutorResult:
     if not records:
         return ExecutorResult(display="No subagents found", content=f"No subagents found for IDs: {', '.join(subagent_ids)}")
 
-    parts = []
+    parts: list[str] = []
     for sid, record in records.items():
         status = record.state.value
         elapsed = record.elapsed_seconds
@@ -176,9 +176,9 @@ async def execute_interrupt_subagents(subagent_ids: list[str]) -> ExecutorResult
             content=f"Interrupted subagents: {', '.join(cancelled)}",
         )
 
-    cancelled = []
-    not_found = []
-    already_done = []
+    cancelled: list[str] = []
+    not_found: list[str] = []
+    already_done: list[str] = []
 
     for sid in subagent_ids:
         record = manager.get_record(sid)
@@ -190,7 +190,7 @@ async def execute_interrupt_subagents(subagent_ids: list[str]) -> ExecutorResult
         else:
             already_done.append(sid)
 
-    parts = []
+    parts: list[str] = []
     if cancelled:
         parts.append(f"Interrupted: {', '.join(cancelled)}")
     if already_done:

--- a/src/orchid/tools/todo.py
+++ b/src/orchid/tools/todo.py
@@ -9,7 +9,7 @@ from orchid.domain.tool import ExecutorResult, Tool, ToolParameter, ToolParamete
 
 _STATUSES = ", ".join(s.value for s in TodoStatus)
 
-_TRANSITION_LINES = []
+_TRANSITION_LINES: list[str] = []
 for _src, _dsts in VALID_TRANSITIONS.items():
     _TRANSITION_LINES.append(f"  {_src.value} → {{{', '.join(d.value for d in _dsts)}}}")
 for _terminal in TERMINAL_STATUSES:
@@ -149,9 +149,10 @@ async def execute_todo_update(
     if error:
         return ExecutorResult(display="Update failed", content=f"Error: {error}")
 
+    assert task is not None
     await notify_todo_changed()
 
-    changes = []
+    changes: list[str] = []
     if title is not None:
         changes.append(f"Title: {task.title}")
     if description is not None:

--- a/src/orchid/tools/web_fetch.py
+++ b/src/orchid/tools/web_fetch.py
@@ -3,6 +3,7 @@ import os
 import re
 from html.parser import HTMLParser
 from pathlib import Path
+from typing import Any, cast
 from urllib.parse import urlparse
 from xml.sax.saxutils import escape, quoteattr
 
@@ -74,7 +75,7 @@ class _TitleParser(HTMLParser):
 
 
 def _xml_attrs(**attrs: object) -> str:
-    parts = []
+    parts: list[str] = []
     for key, value in attrs.items():
         if value is None:
             continue
@@ -232,15 +233,21 @@ def _raw_result(url: str, title: str, content_type: str, content: str) -> Execut
     )
 
 
-def _choice_content(response: object) -> str:
+def _choice_content(response: Any) -> str:
     try:
-        choices = response["choices"] if isinstance(response, dict) else response.choices
-        choice = choices[0]
-        message = choice["message"] if isinstance(choice, dict) else choice.message
-        content = message.get("content") if isinstance(message, dict) else message.content
-        return (content or "").strip()
+        if isinstance(response, dict):
+            choices = cast(list[Any], response["choices"])
+            choice = choices[0]
+            message = cast(dict[str, Any], choice["message"])
+            content_val = message.get("content")
+        else:
+            choices = response.choices
+            choice = choices[0]
+            message = choice.message
+            content_val = message.content
+        return str(content_val or "").strip()
     except (AttributeError, KeyError, IndexError, TypeError):
-        return str(response).strip()
+        return str(cast(Any, response)).strip()
 
 
 async def _summarize_result(url: str, title: str, content_type: str, content: str, query: str) -> ExecutorResult:
@@ -273,7 +280,7 @@ async def _summarize_result(url: str, title: str, content_type: str, content: st
     )
 
     try:
-        response = await litellm.acompletion(
+        response = await litellm.acompletion(  # type: ignore[reportUnknownMemberType]
             model=qualify_model(litellm_provider, model_id),
             messages=[
                 {"role": "system", "content": agent.system_prompt},

--- a/src/orchid/utils.py
+++ b/src/orchid/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 from orchid.config import get_config
 
@@ -10,7 +11,7 @@ _FRONTMATTER_PATTERN = re.compile(
 )
 
 
-def parse_frontmatter(content: str) -> tuple[dict, str]:
+def parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     """Parse YAML frontmatter from markdown content.
 
     Returns (metadata_dict, body_content).
@@ -105,7 +106,7 @@ def directory_tree(path: str, max_depth: int, include_hidden: bool = False, _dep
     if _depth >= max_depth:
         return ""
 
-    lines = []
+    lines: list[str] = []
     try:
         entries = sorted(os.listdir(path))
     except PermissionError:

--- a/src/orchid/widgets/command_picker.py
+++ b/src/orchid/widgets/command_picker.py
@@ -55,12 +55,12 @@ class CommandPicker(OptionList):
         self._filtered = []
         self.clear_options()
         try:
-            self.app.query_one("#input", TextArea).focus()
+            self.app.query_one("#input", TextArea).focus()  # type: ignore[union-attr]
         except Exception:
             pass
 
     def on_key(self, event: events.Key) -> None:
-        text_area = self.app.query_one("#input", TextArea)
+        text_area = self.app.query_one("#input", TextArea)  # type: ignore[union-attr]
 
         if event.key == "escape":
             self.hide()

--- a/src/orchid/widgets/command_picker.py
+++ b/src/orchid/widgets/command_picker.py
@@ -55,12 +55,12 @@ class CommandPicker(OptionList):
         self._filtered = []
         self.clear_options()
         try:
-            self.app.query_one("#input", TextArea).focus()  # type: ignore[union-attr]
+            self.app.query_one("#input", TextArea).focus()  # pyright: ignore[reportOptionalMemberAccess,reportUnknownMemberType]
         except Exception:
             pass
 
     def on_key(self, event: events.Key) -> None:
-        text_area = self.app.query_one("#input", TextArea)  # type: ignore[union-attr]
+        text_area = self.app.query_one("#input", TextArea)  # pyright: ignore[reportOptionalMemberAccess,reportUnknownMemberType]
 
         if event.key == "escape":
             self.hide()

--- a/src/orchid/widgets/message_widget.py
+++ b/src/orchid/widgets/message_widget.py
@@ -53,8 +53,8 @@ _DIFF_LEXER_BY_EXTENSION = {
 
 
 def get_tool_action_label(tool_name: str) -> str:
-    registry = get_tool_registry()
-    entry = registry.get(tool_name)
+    registry: dict[str, dict[str, Any]] = get_tool_registry()
+    entry: dict[str, Any] | None = registry.get(tool_name)
     if entry and entry["tool"].action_label:
         return entry["tool"].action_label
     return f"Using {tool_name}..."
@@ -183,7 +183,7 @@ def _highlight_diff_content(content: str, style: str, lexer: str) -> Text:
 
 
 class UserMessageWidget(TextualMarkdown):
-    def __init__(self, msg: Message, **kwargs):
+    def __init__(self, msg: Message, **kwargs: Any):
         self.msg = msg
         super().__init__(msg.content, **kwargs)
 
@@ -191,7 +191,7 @@ class UserMessageWidget(TextualMarkdown):
 class ThinkingMessageWidget(Static):
     """A collapsible widget that shows 'Thinking...' when collapsed and full thinking when expanded."""
 
-    def __init__(self, msg: Message, *, loaded: bool = False, **kwargs):
+    def __init__(self, msg: Message, *, loaded: bool = False, **kwargs: Any):
         self.msg = msg
         self._last_render_time: float = 0
         self._flush_scheduled: bool = False
@@ -263,7 +263,7 @@ class ThinkingMessageWidget(Static):
         if self._collapsible is not None:
             self._collapsible.title = f"Thought: {label}"
 
-    def on_collapsible_toggle(self, event) -> None:
+    def on_collapsible_toggle(self, event: Any) -> None:
         if not event.collapsed:
             self._do_update()
 
@@ -275,7 +275,7 @@ class AssistantMessageWidget(TextualMarkdown):
     and back-pressure internally.
     """
 
-    def __init__(self, msg: Message, *, loaded: bool = False, **kwargs):
+    def __init__(self, msg: Message, *, loaded: bool = False, **kwargs: Any):
         self.msg = msg
         super().__init__(msg.content, **kwargs)
         self._stream = TextualMarkdown.get_stream(self)
@@ -303,7 +303,7 @@ class ChainFooterWidget(Static):
         self,
         chain: Chain,
         subagent_subtotal: Callable[[], tuple[int, int, int, int] | None] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         self._chain = chain
         self._subagent_subtotal = subagent_subtotal
@@ -391,7 +391,7 @@ class ChainContainer(Static):
         self,
         chain: Chain,
         subagent_subtotal: Callable[[], tuple[int, int, int, int] | None] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         self.chain = chain
         self._subagent_subtotal = subagent_subtotal
@@ -448,12 +448,12 @@ class ErrorMessageWidget(Static):
     }
     """
 
-    def __init__(self, msg: Message, **kwargs):
+    def __init__(self, msg: Message, **kwargs: Any):
         self.msg = msg
         super().__init__(**kwargs)
 
     def compose(self) -> ComposeResult:
-        title = self.msg.metadata.get("error_title", "Error")
+        title: str = self.msg.metadata.get("error_title", "Error")
         yield Static(title, classes="error-title")
         yield Static(self.msg.content, classes="error-detail")
 
@@ -461,7 +461,7 @@ class ErrorMessageWidget(Static):
 class ToolResultMessageWidget(Static):
     """A collapsible widget that shows the display summary when collapsed and full content when expanded."""
 
-    def __init__(self, msg: Message, **kwargs):
+    def __init__(self, msg: Message, **kwargs: Any):
         self.msg = msg
         super().__init__(**kwargs)
 
@@ -499,10 +499,10 @@ class StreamWidgetState:
 
     thinking: Any = None
     content: Any = None
-    temp: list[Static] = field(default_factory=list)
+    temp: list[Any] = field(default_factory=list[Any])
 
 
-async def mount_streamed_message(container, msg: Message, state: StreamWidgetState) -> None:
+async def mount_streamed_message(container: Any, msg: Message, state: StreamWidgetState) -> None:
     """Mount or update widgets for a streamed message."""
     if msg.type == MessageType.ERROR:
         w = ErrorMessageWidget(msg)

--- a/src/orchid/widgets/sidebar.py
+++ b/src/orchid/widgets/sidebar.py
@@ -1,6 +1,7 @@
 import os
 import time
 from datetime import UTC, datetime
+from typing import Any
 
 from textual.containers import Vertical
 from textual.message import Message
@@ -61,7 +62,7 @@ class NavEntry(Static):
         def control(self) -> "NavEntry":
             return self.nav_entry
 
-    def __init__(self, label: str, view_id: str, **kwargs) -> None:
+    def __init__(self, label: str, view_id: str, **kwargs: Any) -> None:
         self.view_id = view_id
         super().__init__(label, **kwargs)
 
@@ -209,10 +210,10 @@ class Sidebar(Vertical):
     _last_token_update: float = 0
     _token_flush_scheduled: bool = False
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._usage_by_view: dict = {}
-        self._subagent_records: list = []
+        self._usage_by_view: dict[str, Any] = {}
+        self._subagent_records: list[SubagentRecord] = []
 
     def compose(self):
         yield Static("Tokens", id="sidebar-tokens-label")
@@ -241,12 +242,11 @@ class Sidebar(Vertical):
         return f"  {cwd}"
 
     def on_nav_entry_pressed(self, event: NavEntry.Pressed) -> None:
-        if isinstance(event.control, NavEntry):
-            if event.control.view_id == "main":
-                self.post_message(SidebarMainSelected())
-            else:
-                self.post_message(
-                    SidebarSubagentSelected(event.control.view_id))
+        if event.control.view_id == "main":
+            self.post_message(SidebarMainSelected())
+        else:
+            self.post_message(
+                SidebarSubagentSelected(event.control.view_id))
 
     def _get_focusable_entries(self) -> list[NavEntry | Collapsible]:
         entries: list[NavEntry | Collapsible] = []
@@ -272,8 +272,9 @@ class Sidebar(Vertical):
         entries = self._get_focusable_entries()
         if not entries:
             return
-        focused = self.app.focused
+        focused = self.app.focused  # type: ignore[union-attr]
         if focused in entries:
+            assert isinstance(focused, (NavEntry, Collapsible))
             idx = entries.index(focused)
             entries[(idx - 1) % len(entries)].focus()
         else:
@@ -283,8 +284,9 @@ class Sidebar(Vertical):
         entries = self._get_focusable_entries()
         if not entries:
             return
-        focused = self.app.focused
+        focused = self.app.focused  # type: ignore[union-attr]
         if focused in entries:
+            assert isinstance(focused, (NavEntry, Collapsible))
             idx = entries.index(focused)
             entries[(idx + 1) % len(entries)].focus()
         else:
@@ -326,6 +328,7 @@ class Sidebar(Vertical):
         try:
             entries = self.query_one("#subagent-entries", Vertical)
             for entry in entries.query(".subagent-entry"):
+                assert isinstance(entry, NavEntry)
                 if entry.view_id == self._active_view:
                     entry.add_class("-active")
                 else:
@@ -521,7 +524,7 @@ class Sidebar(Vertical):
         else:
             return f"{elapsed / 3600:.1f}h"
 
-    async def update_mcp_servers(self, statuses: dict[str, dict]) -> None:
+    async def update_mcp_servers(self, statuses: dict[str, dict[str, Any]]) -> None:
         try:
             container = self.query_one("#mcp-entries", Vertical)
         except Exception:
@@ -541,10 +544,10 @@ class Sidebar(Vertical):
             await container.mount(*entries)
 
     @staticmethod
-    def _format_mcp_server(name: str, info: dict) -> str:
-        status = info.get("status", "unknown")
-        tool_count = info.get("tool_count", 0)
-        error = info.get("error")
+    def _format_mcp_server(name: str, info: dict[str, Any]) -> str:
+        status: str = info.get("status", "unknown")
+        tool_count: int = info.get("tool_count", 0)
+        error: str | None = info.get("error")
 
         indicator = {
             "connected": "●",

--- a/src/orchid/widgets/subagent_ui.py
+++ b/src/orchid/widgets/subagent_ui.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from textual.containers import ScrollableContainer
 from textual.timer import Timer
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 class SubagentUIManager:
     """Manages subagent tabs, widgets, and sidebar updates."""
 
-    def __init__(self, app: App) -> None:
+    def __init__(self, app: App[Any]) -> None:
         self.app = app
         self._widgets: dict[str, dict[str, Any]] = {}
         self._timer: Timer | None = None
@@ -35,16 +35,16 @@ class SubagentUIManager:
         self._sidebar_refresh_pending: bool = False
         self._mount_locks: dict[str, asyncio.Lock] = {}
 
-    def setup(self, manager) -> None:
+    def setup(self, manager: Any) -> None:
         """Wire callbacks on the subagent manager."""
         manager.on_spawn = self.on_spawn
         self._set_manager(manager)
 
-    def _set_manager(self, manager) -> None:
+    def _set_manager(self, manager: Any) -> None:
         from orchid.agents.manager import set_subagent_manager
         set_subagent_manager(manager)
 
-    def has_running(self, manager) -> bool:
+    def has_running(self, manager: Any) -> bool:
         terminal = {SubagentState.COMPLETED, SubagentState.FAILED, SubagentState.INTERRUPTED}
         return any(r.state not in terminal for r in manager.all_records())
 
@@ -92,8 +92,8 @@ class SubagentUIManager:
                 await pane.mount(container)
 
             raw = self._widgets.setdefault(subagent_id, {"temp": []})
-            existing_temp = raw.get("temp")
-            temp_list = list(existing_temp) if isinstance(existing_temp, list) else []
+            existing_temp: Any = raw.get("temp")
+            temp_list: list[Any] = cast(list[Any], existing_temp) if isinstance(existing_temp, list) else []
             state = StreamWidgetState(
                 thinking=raw.get("thinking"),
                 content=raw.get("content"),
@@ -112,7 +112,10 @@ class SubagentUIManager:
             tab = tabs.get_tab(f"sub-{subagent_id}")
         except Exception:
             return
-        manager = self.app.sessions.active.subagent_manager if self.app.sessions.active else None
+        from orchid.app import Orchid
+
+        app = cast(Orchid, self.app)
+        manager = app.sessions.active.subagent_manager if app.sessions.active else None
         if not manager:
             return
         record = manager.get_record(subagent_id)
@@ -135,7 +138,7 @@ class SubagentUIManager:
         """
         self._mount_locks.pop(subagent_id, None)
 
-    async def sync_tabs(self, manager) -> None:
+    async def sync_tabs(self, manager: Any) -> None:
         tabs = self.app.query_one("#tabs", TabbedContent)
         pane_ids = [p.id for p in tabs.query("TabPane") if p.id and p.id.startswith("sub-")]
         for pane_id in pane_ids:
@@ -147,8 +150,20 @@ class SubagentUIManager:
         for record in manager.all_records():
             pane = TabPane(self._tab_label(record), id=f"sub-{record.id}")
             await tabs.add_pane(pane)
-            record.on_message = lambda msg, rid=record.id: self.on_message(rid, msg)
-            record.on_state_change = lambda state, rid=record.id: self.on_state_change(rid, state)
+            rid: str = record.id
+
+            def _make_msg_handler(sub_id: str) -> Any:
+                async def handler(msg: Message) -> None:  # noqa: B023
+                    await self.on_message(sub_id, msg)  # noqa: B023
+                return handler
+
+            def _make_state_handler(sub_id: str) -> Any:
+                async def handler(state: SubagentState) -> None:
+                    await self.on_state_change(sub_id, state)
+                return handler
+
+            record.on_message = _make_msg_handler(rid)
+            record.on_state_change = _make_state_handler(rid)
             for msg in record.messages:
                 await self.on_message(record.id, msg)
             footer = ChainFooterWidget(record.chain)
@@ -173,9 +188,12 @@ class SubagentUIManager:
         ``RUNNING``; once the subagent is terminal, the chain is finalized
         and ``freeze()`` renders the final ``model · elapsed · tokens``.
         """
-        if not self.app.sessions.active:
+        from orchid.app import Orchid
+
+        app = cast(Orchid, self.app)
+        if not app.sessions.active:
             return
-        manager = self.app.sessions.active.subagent_manager
+        manager = app.sessions.active.subagent_manager
         for sid, entry in self._widgets.items():
             footer = entry.get("footer")
             if footer is None:
@@ -200,8 +218,11 @@ class SubagentUIManager:
                     sidebar = self.app.query_one("#sidebar", Sidebar)
                 except Exception:
                     return
-                if self.app.sessions.active:
-                    records = self.app.sessions.active.subagent_manager.all_records()
+                from orchid.app import Orchid
+
+                app = cast(Orchid, self.app)
+                if app.sessions.active:
+                    records = app.sessions.active.subagent_manager.all_records()
                     await sidebar.update_subagents(records)
                 else:
                     await sidebar.update_subagents([])
@@ -210,7 +231,10 @@ class SubagentUIManager:
         self._manage_timer()
 
     def _manage_timer(self) -> None:
-        manager = self.app.sessions.active.subagent_manager if self.app.sessions.active else None
+        from orchid.app import Orchid
+
+        app = cast(Orchid, self.app)
+        manager = app.sessions.active.subagent_manager if app.sessions.active else None
         has_running = manager is not None and self.has_running(manager)
         if has_running and self._timer is None:
             self._timer = self.app.set_interval(1.0, self._tick_timer)


### PR DESCRIPTION
Add pyright in strict mode as a static type checker. Fixes 1228 type errors across 46 source files by adding type annotations, tightening generic type arguments (dict -> dict[str, Any]), and using targeted type-ignore comments for third-party library interop (litellm, textual, MCP SDK, numpy).

Changes:
- Add [tool.pyright] config to pyproject.toml with typeCheckingMode=strict
- Add pyright to dev dependencies
- Add pyright CI job to .github/workflows/lint.yml
- Fix all type errors across domain, llm, tools, widgets, screens, agents, mcp, commands, rag, ast, skills, themes, personality modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documented plan for upcoming stricter type checking.

* **Bug Fixes**
  * Improved validation and error handling in settings, sessions, agents, and tools.
  * Added safer checks to reduce crashes when expected app state is missing.
  * Refined command, message, and sidebar behavior for more reliable UI interactions.

* **Chores**
  * Added a new CI type-checking job alongside existing lint checks.
  * Updated project setup to include the new type-checking tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->