### PR TITLE
perf(tui): fix scroll/click sluggishness, sidebar flicker, and streaming overhead

### DIFF
--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -1,0 +1,172 @@
+# TUI Performance Investigation
+
+## Overview
+
+Investigation into low interface performance in the Orchid TUI application (Textual-based terminal UI). The analysis covers widget rendering paths, timer-driven updates, session management, and DOM lifecycle patterns.
+
+---
+
+## Click and Scroll Sluggishness (Primary User-Facing Issue)
+
+The most noticeable performance problem is sluggish response when **clicking** or **scrolling** the interface. This has a specific causal chain:
+
+### Why scrolling is slow
+
+The `#output` `ScrollableContainer` (`src/orchid/app.py:247`) holds every widget ever mounted in the session -- none are ever removed or virtualized. Each widget uses `height: auto` (27 instances across CSS files), which forces Textual to **measure the intrinsic height** of every widget during layout. On scroll, Textual recomputes layout for the entire tree, not just visible widgets.
+
+Compounding this: `UserMessageWidget` and `AssistantMessageWidget` (`src/orchid/widgets/message_widget.py:193, 279`) inherit from `TextualMarkdown`, which internally creates a **sub-tree of child widgets** (paragraphs, code blocks, headings, lists, etc.). A single assistant response can expand into 10-20+ DOM nodes. After a long session, the DOM tree can have thousands of nodes, all participating in layout on every scroll frame.
+
+### Why clicking is slow
+
+Textual performs **hit-testing** by walking the widget tree from root to leaf on every click. With a large flat list of complex widgets in `#output`, each click must traverse the entire subtree to find which widget was clicked. The deeper the tree (Markdown sub-widgets, Collapsibles with their own children), the slower the hit-test.
+
+### Timer-driven reflows during interaction
+
+The 0.5s (`_tick_live_commands` at `app.py:683`) and 1.0s (`_tick_footer` at `app.py:569`, subagent footers at `subagent_ui.py:216`) timers call `.update()` on `Static` widgets, which triggers **layout reflows mid-scroll**. These mutations happen regardless of whether the user is currently interacting, causing frame drops and stutters during scroll/click.
+
+### Missing `PAUSE_GC_ON_SCROLL`
+
+Textual provides a built-in optimization flag that the app does not use:
+
+```python
+# src/orchid/app.py:188
+class Orchid(App):
+    PAUSE_GC_ON_SCROLL: bool = True  # Pauses Python GC during scroll
+```
+
+Without this, Python's garbage collector can run during scroll frames, causing unpredictable micro-stutters -- especially problematic given the GC pressure from `Session.messages` creating new lists every second (see finding #2 below).
+
+### Recommended fixes for click/scroll
+
+| Fix | Effort | Impact |
+|-----|--------|--------|
+| Set `PAUSE_GC_ON_SCROLL = True` on the App class | Trivial (one line) | Reduces GC-induced stutters |
+| Collapse old chains into lightweight `Static` stubs after N chains | Medium | Bounds DOM tree size |
+| Only expand stubs back to full widgets when scrolled into view | Medium-High | True virtualization |
+| Suspend timers while the user is actively scrolling | Medium | Eliminates timer-induced reflows during interaction |
+| Migrate to `ScrollView` with custom `render_line` | High (major refactor) | Full virtualization with O(1) scroll |
+
+---
+
+## Additional Root Causes (Streaming and Loading Performance)
+
+### 1. Sequential `await mount()` in `mount_all_messages` (HIGH impact)
+
+**File:** `src/orchid/app.py:780-805`
+
+When switching sessions or reloading, every single message widget is mounted sequentially with individual `await container.mount(widget)` calls inside nested loops. For sessions with many chains and messages, this is O(n) DOM mutations, each triggering a layout pass.
+
+```python
+for chain_index, chain in enumerate(self.sessions.active.chains):
+    # ...
+    await container.mount(chain_container)  # layout pass
+    for msg in chain.messages:
+        widget = create_message_widget(msg, loaded=True)
+        if widget is not None:
+            await chain_container.messages_area.mount(widget)  # layout pass per msg
+```
+
+**Recommendation:** Batch-mount widgets using `await container.mount(*widgets)` to reduce layout recalculations from N to 1.
+
+---
+
+### 2. `Session.messages` property creates a new list on every access (HIGH impact)
+
+**File:** `src/orchid/domain/session.py:37-38`
+
+```python
+@property
+def messages(self) -> list[Message]:
+    return [msg for chain in self.chains for msg in chain.messages]
+```
+
+This property is called in `_stream_response` on every LLM call and in `rerender_footer` which runs every second during streaming. Each invocation creates a brand-new list comprehension flattening all chains. As the session grows (hundreds of messages), this becomes increasingly expensive and generates GC pressure.
+
+**Recommendation:** Cache the flattened list and invalidate on chain/message mutation, or avoid materializing it when only iteration is needed.
+
+---
+
+### 3. `_session_usage_totals` iterates all chains + all subagents every tick (MEDIUM impact)
+
+**File:** `src/orchid/app.py:67-103`
+
+Called from `rerender_footer` which runs every 1 second during streaming (`_tick_footer`). It iterates every message in every chain AND every subagent record. Combined with issue #2, this means flattening + scanning the entire session history every second.
+
+**Recommendation:** Cache cumulative usage totals incrementally (add new usage delta instead of re-summing everything).
+
+---
+
+### 4. `_tick_live_commands` runs every 0.5s with sidebar rebuild (MEDIUM impact)
+
+**File:** `src/orchid/app.py:683, 688-756`
+
+This timer runs every 500ms and calls `sidebar.update_background_commands()`. On `_refresh_bg_cmd_display` (`sidebar.py:793`), even "structure_changed = False" iterations still loop through all children doing string formatting and widget updates. On structure changes, it does a full `remove_children()` + `mount()` cycle.
+
+**Recommendation:** Only wake on actual changes (event-driven instead of polling), or increase the interval to 1-2 seconds.
+
+---
+
+### 5. `update_subagents` and `update_todos` fully rebuild on structure changes (MEDIUM impact)
+
+**File:** `src/orchid/widgets/sidebar.py:474-575, 662-711`
+
+Both methods do a full `await container.remove_children()` followed by `await container.mount(*entries)` when the structure changes. This tears down and recreates the entire widget subtree, triggering full relayout.
+
+**Recommendation:** Use a diffing approach -- only add/remove changed entries rather than rebuilding the entire container.
+
+---
+
+### 6. `AssistantMessageWidget` uses Textual's `MarkdownStream` for every content delta (MEDIUM impact)
+
+**File:** `src/orchid/widgets/message_widget.py:279-298`
+
+Every content chunk from the LLM calls `await self._stream.write(delta)` which triggers markdown re-parsing and re-rendering. The underlying `TextualMarkdown` widget re-parses the entire markdown document on each write. For long responses, this becomes progressively more expensive as the content accumulates.
+
+**Recommendation:** This is inherent to the Textual Markdown streaming API. Consider throttling updates to the markdown widget more aggressively (e.g., buffer content and flush every 200-300ms like `ThinkingMessageWidget` does).
+
+---
+
+### 7. `list_saved_sessions` loads and JSON-parses every session file (LOW impact, noticeable on `/sessions`)
+
+**File:** `src/orchid/storage.py:54-71`
+
+When listing sessions, it opens and fully parses every `.json` session file to extract metadata. For users with many sessions, this blocks the event loop.
+
+**Recommendation:** Store an index file with metadata, or read only the first N bytes of each file to extract the header.
+
+---
+
+### 8. No virtualization on the `#output` ScrollableContainer (HIGH impact for click/scroll)
+
+The `#output` container keeps all message widgets mounted in the DOM. For long sessions, the widget tree grows unbounded -- Textual still lays out and composites all widgets even if they are off-screen. This is the **primary cause of sluggish scrolling and clicking** (see detailed analysis in the "Click and Scroll Sluggishness" section above).
+
+**Recommendation:** For very long sessions, consider unmounting off-screen widgets or collapsing old chains into stubs.
+
+---
+
+## Priority Summary
+
+| Priority | Issue | Expected Impact |
+|----------|-------|-----------------|
+| P0 | Set `PAUSE_GC_ON_SCROLL = True` | Quick win for scroll stutter |
+| P0 | Batch widget mounting in `mount_all_messages` | Major improvement on session load/switch |
+| P0 | Cache `Session.messages` or avoid materialization | Reduces per-tick CPU during streaming |
+| P1 | Widget virtualization / chain collapsing for `#output` | Fixes scroll/click sluggishness in long sessions |
+| P1 | Incremental usage totals in footer | Eliminates O(n) scan per second |
+| P1 | Event-driven live command updates | Removes constant 500ms polling overhead |
+| P2 | Throttle `AssistantMessageWidget` content updates | Reduces markdown re-parse frequency |
+| P2 | Sidebar diff-based updates | Avoids full teardown/rebuild cycles |
+| P2 | Suspend timers during active scroll | Eliminates reflow interruptions |
+| P3 | Session listing index file | Faster `/sessions` command |
+
+---
+
+## Timers Active During Streaming
+
+| Timer | Interval | Source | Work Done |
+|-------|----------|--------|-----------|
+| `_footer_timer` | 1.0s | `app.py:569` | `_tick_footer` -> `rerender_footer` (iterates all messages) |
+| `_bg_cmd_timer` | 0.5s | `app.py:683` | `_tick_live_commands` (polls store, updates sidebar) |
+| subagent timer | 1.0s | `subagent_ui.py:216` | `_tick_subagent_footers` (ticks all mounted footers) |
+
+All three timers run concurrently during active streaming, creating a cumulative load of DOM updates every 500ms at minimum.

--- a/src/orchid/app.py
+++ b/src/orchid/app.py
@@ -32,7 +32,13 @@ from orchid.widgets.message_widget import (
     live_command_widgets,
     mount_streamed_message,
 )
-from orchid.widgets.sidebar import NavEntry, Sidebar, SidebarBgCommandSelected, SidebarMainSelected, SidebarSubagentSelected
+from orchid.widgets.sidebar import (
+    NavEntry,
+    Sidebar,
+    SidebarBgCommandSelected,
+    SidebarMainSelected,
+    SidebarSubagentSelected,
+)
 from orchid.widgets.subagent_ui import SubagentUIManager
 
 log = logging.getLogger(__name__)
@@ -67,16 +73,22 @@ def _sum_usage(messages: list) -> tuple[int, int, int, int] | None:
 def _session_usage_totals(session: "Session") -> tuple[int, int, int, int] | None:
     """Sum token usage across chains and subagent records in ``session``.
 
-    Each chain contributes the sum of every usage-bearing message it holds
-    (cumulative across the chain's agentic-loop calls), not just the last
-    snapshot. Subagent records (R5/R6) are reached via
-    ``session.subagent_manager.all_records()``; each contributes the same sum
-    over its composed ``record.chain``.
-
-    Returns ``(prompt_tokens, cached_tokens, completion_tokens, total_tokens)``
-    when at least one message-list has usage, otherwise ``None``.
+    Uses a cached result stored on the session object to avoid re-iterating
+    all messages every tick. The cache is invalidated by comparing message
+    counts. Returns ``(prompt_tokens, cached_tokens, completion_tokens,
+    total_tokens)`` when at least one message-list has usage, otherwise ``None``.
     """
-    prompt = cached = completion = total = 0
+    # Build a lightweight fingerprint to detect changes
+    chain_msg_count = sum(len(c.messages) for c in session.chains)
+    sub_records = session.subagent_manager.all_records()
+    sub_msg_count = sum(len(r.chain.messages) for r in sub_records)
+    fingerprint = (chain_msg_count, sub_msg_count, len(session.chains), len(sub_records))
+
+    cached = getattr(session, "_usage_cache", None)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1]
+
+    prompt = cached_tok = completion = total = 0
     found = False
     for chain in session.chains:
         usage = _sum_usage(chain.messages)
@@ -84,23 +96,21 @@ def _session_usage_totals(session: "Session") -> tuple[int, int, int, int] | Non
             continue
         found = True
         prompt += usage[0]
-        cached += usage[1]
+        cached_tok += usage[1]
         completion += usage[2]
         total += usage[3]
-    # Fold subagent usage into the session total (R6). Each subagent's
-    # composed chain contributes its own usage sum.
-    for record in session.subagent_manager.all_records():
+    for record in sub_records:
         usage = _sum_usage(record.chain.messages)
         if usage is None:
             continue
         found = True
         prompt += usage[0]
-        cached += usage[1]
+        cached_tok += usage[1]
         completion += usage[2]
         total += usage[3]
-    if not found:
-        return None
-    return (prompt, cached, completion, total)
+    result = (prompt, cached_tok, completion, total) if found else None
+    session._usage_cache = (fingerprint, result)  # type: ignore[attr-defined]
+    return result
 
 
 def _format_session_model_label(
@@ -195,6 +205,14 @@ class Orchid(App):
         ("ctrl+b", "toggle_sidebar_focus", "Toggle Sidebar"),
     ]
     COMMANDS = {SessionCommands}
+
+    # Pause Python garbage collection during scroll to avoid GC-induced
+    # frame drops when the DOM tree is large (many message widgets).
+    PAUSE_GC_ON_SCROLL = True
+
+    # Maximum number of chains to keep fully mounted. Older chains are
+    # collapsed into lightweight stubs to bound DOM tree size.
+    _CHAIN_COLLAPSE_THRESHOLD = 20
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -682,7 +700,7 @@ class Orchid(App):
             has_live = False
 
         if has_live and self._bg_cmd_timer is None:
-            self._bg_cmd_timer = self.set_interval(0.5, self._tick_live_commands)
+            self._bg_cmd_timer = self.set_interval(1.5, self._tick_live_commands)
         elif not has_live and self._bg_cmd_timer is not None:
             self._bg_cmd_timer.stop()
             self._bg_cmd_timer = None
@@ -785,27 +803,58 @@ class Orchid(App):
         await container.remove_children()
         if not self.sessions.active:
             return
+
+        total_chains = len(self.sessions.active.chains)
+        # Determine which chains get full widgets vs collapsed stubs
+        collapse_count = max(0, total_chains - self._CHAIN_COLLAPSE_THRESHOLD)
+
+        # Build all chain containers first, then batch-mount them
+        chain_containers: list[ChainContainer | Static] = []
+        chain_widgets: list[list] = []
         for chain_index, chain in enumerate(self.sessions.active.chains):
-            subtotal_provider = _make_subagent_subtotal_provider(
-                self.sessions.active, chain_index
-            )
-            chain_container = ChainContainer(chain, subagent_subtotal=subtotal_provider)
-            await container.mount(chain_container)
-            chain_container.freeze()
-            prev_was_thinking = False
-            for msg in chain.messages:
-                classes = (
-                    "after-thinking"
-                    if msg.type == MessageType.TOOL_RESULT and prev_was_thinking
-                    else None
+            if chain_index < collapse_count:
+                # Collapse old chains into a lightweight stub
+                msg_count = len(chain.messages)
+                user_msgs = [m for m in chain.messages if m.role == MessageRole.USER]
+                preview = user_msgs[0].content[:60] + "..." if user_msgs else f"{msg_count} messages"
+                stub = Static(
+                    f"[dim]▸ Chain {chain_index + 1}: {preview}[/dim]",
+                    classes="collapsed-chain-stub",
                 )
-                widget = create_message_widget(msg, loaded=True, classes=classes)
-                if widget is not None:
-                    await chain_container.messages_area.mount(widget)
-                if msg.type == MessageType.THINKING:
-                    prev_was_thinking = True
-                elif msg.type != MessageType.TOOL_CALL:
-                    prev_was_thinking = False
+                chain_containers.append(stub)
+                chain_widgets.append([])  # no widgets for stubs
+            else:
+                subtotal_provider = _make_subagent_subtotal_provider(
+                    self.sessions.active, chain_index
+                )
+                chain_container = ChainContainer(chain, subagent_subtotal=subtotal_provider)
+                chain_containers.append(chain_container)
+                # Pre-build message widgets for this chain
+                widgets = []
+                prev_was_thinking = False
+                for msg in chain.messages:
+                    classes = (
+                        "after-thinking"
+                        if msg.type == MessageType.TOOL_RESULT and prev_was_thinking
+                        else None
+                    )
+                    widget = create_message_widget(msg, loaded=True, classes=classes)
+                    if widget is not None:
+                        widgets.append(widget)
+                    if msg.type == MessageType.THINKING:
+                        prev_was_thinking = True
+                    elif msg.type != MessageType.TOOL_CALL:
+                        prev_was_thinking = False
+                chain_widgets.append(widgets)
+        # Batch-mount all chain containers at once (single layout pass)
+        if chain_containers:
+            await container.mount(*chain_containers)
+        # Batch-mount message widgets within each chain container
+        for chain_container, widgets in zip(chain_containers, chain_widgets, strict=True):
+            if isinstance(chain_container, ChainContainer):
+                chain_container.freeze()
+                if widgets and chain_container.messages_area:
+                    await chain_container.messages_area.mount(*widgets)
 
     async def rerender_all(self) -> None:
         if not self.sessions.active:
@@ -821,10 +870,15 @@ class Orchid(App):
         if not self.sessions.active:
             return
 
+        # Find last usage by iterating chains in reverse without materializing
+        # the full flat message list (avoids O(n) list creation every tick).
         last_usage = None
-        for msg in reversed(self.sessions.active.messages):
-            if msg.usage:
-                last_usage = msg.usage
+        for chain in reversed(self.sessions.active.chains):
+            for msg in reversed(chain.messages):
+                if msg.usage:
+                    last_usage = msg.usage
+                    break
+            if last_usage:
                 break
         try:
             sidebar = self.query_one("#sidebar", Sidebar)

--- a/src/orchid/main.tcss
+++ b/src/orchid/main.tcss
@@ -220,6 +220,13 @@ OptionPicker {
     text-style: italic;
 }
 
+.collapsed-chain-stub {
+    padding: 0 1;
+    height: 1;
+    color: $text-muted;
+    text-style: dim;
+}
+
 Button.settings-add-btn {
     content-align: center middle;
     text-align: center;

--- a/src/orchid/storage.py
+++ b/src/orchid/storage.py
@@ -52,23 +52,60 @@ def load_session(session_id: str) -> dict | None:
 
 
 def list_saved_sessions() -> list[dict]:
-    """Return metadata for all saved sessions (id, name, model) sorted by most recent chains."""
+    """Return metadata for all saved sessions (id, name, model) sorted by most recent.
+
+    Uses a partial read strategy: reads only the first 2KB of each file to
+    extract metadata fields without parsing the entire JSON (which can be
+    large due to message histories). Falls back to full parse if the partial
+    read doesn't contain enough data.
+    """
     ensure_sessions_dir()
     sessions = []
+    partial_read_size = 2048
     for path in SESSIONS_DIR.glob("*.json"):
         try:
+            # Try partial read first — metadata fields are at the top of the file
             with open(path) as f:
-                data = json.load(f)
-            # Extract just the metadata we need for listing
-            sessions.append({
-                "id": data["id"],
-                "name": data.get("name", "Unnamed"),
-                "model": data.get("model"),
-                "chain_count": len(data.get("chains", [])),
-            })
+                head = f.read(partial_read_size)
+            # Quick extraction via string search (avoids full JSON parse)
+            session_id = _extract_json_string(head, '"id"')
+            name = _extract_json_string(head, '"name"')
+            model = _extract_json_string(head, '"model"')
+            if session_id:
+                sessions.append({
+                    "id": session_id,
+                    "name": name or "Unnamed",
+                    "model": model,
+                    "chain_count": head.count('"messages"'),  # rough estimate
+                })
+            else:
+                # Fallback: full parse
+                with open(path) as f:
+                    data = json.load(f)
+                sessions.append({
+                    "id": data["id"],
+                    "name": data.get("name", "Unnamed"),
+                    "model": data.get("model"),
+                    "chain_count": len(data.get("chains", [])),
+                })
         except (json.JSONDecodeError, OSError, KeyError, TypeError, AttributeError) as e:
             log.warning("Skipping corrupted session file %s: %s", path.name, e)
     return sessions
+
+
+def _extract_json_string(text: str, key: str) -> str | None:
+    """Extract a simple string value for a JSON key from partial text.
+
+    Works for flat top-level keys like "id", "name", "model" where the
+    value is a quoted string. Returns None if the key is not found or
+    value is null.
+    """
+    import re
+    pattern = key + r'\s*:\s*"([^"]*)"'
+    match = re.search(pattern, text)
+    if match:
+        return match.group(1)
+    return None
 
 
 def delete_session(session_id: str) -> bool:

--- a/src/orchid/widgets/message_widget.py
+++ b/src/orchid/widgets/message_widget.py
@@ -280,7 +280,9 @@ class AssistantMessageWidget(TextualMarkdown):
     """Assistant message using Textual's MarkdownStream for incremental streaming.
 
     Uses ``MarkdownStream.write()`` which handles buffering, coalescing,
-    and back-pressure internally.
+    and back-pressure internally. A throttle gate ensures that writes are
+    batched at most every ``_THROTTLE_INTERVAL`` seconds to avoid excessive
+    re-parsing of the full markdown document on every LLM chunk.
     """
 
     def __init__(self, msg: Message, *, loaded: bool = False, **kwargs):
@@ -288,13 +290,34 @@ class AssistantMessageWidget(TextualMarkdown):
         super().__init__(msg.content, **kwargs)
         self._stream = TextualMarkdown.get_stream(self)
         self._last_appended_len: int = len(msg.content)
+        self._last_write_time: float = 0
+        self._write_scheduled: bool = False
 
     async def update_content(self, content: str) -> None:
         self.msg.content = content
-        delta = content[self._last_appended_len :]
+        delta = content[self._last_appended_len:]
         if not delta:
             return
-        self._last_appended_len = len(content)
+        now = time.monotonic()
+        if now - self._last_write_time >= _THROTTLE_INTERVAL:
+            self._last_write_time = now
+            self._last_appended_len = len(content)
+            await self._stream.write(delta)
+        elif not self._write_scheduled:
+            self._write_scheduled = True
+            remaining = _THROTTLE_INTERVAL - (now - self._last_write_time)
+            self.set_timer(remaining, self._flush_write)
+
+    def _flush_write(self) -> None:
+        self._write_scheduled = False
+        self._last_write_time = time.monotonic()
+        delta = self.msg.content[self._last_appended_len:]
+        if delta:
+            self._last_appended_len = len(self.msg.content)
+            # Use call_later to write from within an async context
+            self.call_later(self._do_write, delta)
+
+    async def _do_write(self, delta: str) -> None:
         await self._stream.write(delta)
 
 

--- a/src/orchid/widgets/sidebar.py
+++ b/src/orchid/widgets/sidebar.py
@@ -621,10 +621,20 @@ class Sidebar(Vertical):
                 await container.remove_children()
             return
 
-        entries: list[Static] = []
-        for name, info in statuses.items():
-            entries.append(Static(self._format_mcp_server(name, info)))
+        # Diff-based update: update existing entries in-place, only rebuild
+        # if the number of servers changed.
+        new_texts = [self._format_mcp_server(name, info) for name, info in statuses.items()]
+        existing = list(container.children)
 
+        if len(existing) == len(new_texts):
+            # Same count — update labels in-place (no flicker)
+            for widget, text in zip(existing, new_texts, strict=True):
+                if isinstance(widget, Static):
+                    widget.update(text)
+            return
+
+        # Server count changed — must rebuild
+        entries: list[Static] = [Static(text) for text in new_texts]
         await container.remove_children()
         if entries:
             await container.mount(*entries)
@@ -673,13 +683,37 @@ class Sidebar(Vertical):
         active = [t for t in tasks if t.status not in TERMINAL_STATUSES]
         done = [t for t in tasks if t.status in TERMINAL_STATUSES]
 
+        # Detect current structure for diff comparison
         existing_collapse: Collapsible | None = None
+        current_active_count = 0
+        current_done_count = 0
         for child in container.children:
             if isinstance(child, Collapsible):
                 existing_collapse = child
+                current_done_count = len(list(child.query(".todo-entry")))
+            elif isinstance(child, Static) and "todo-entry" in child.classes:
+                current_active_count += 1
 
         was_finished_collapsed = existing_collapse.collapsed if existing_collapse else True
 
+        # If structure matches (same active/done counts), update in-place
+        if current_active_count == len(active) and current_done_count == len(done):
+            # Update active entries in-place
+            active_widgets = [
+                child for child in container.children
+                if isinstance(child, Static) and "todo-entry" in child.classes
+            ]
+            for widget, task in zip(active_widgets, active, strict=True):
+                widget.update(self._format_todo(task))
+            # Update done entries in-place
+            if existing_collapse:
+                done_widgets = list(existing_collapse.query(".todo-entry"))
+                for widget, task in zip(done_widgets, reversed(done), strict=True):
+                    if isinstance(widget, Static):
+                        widget.update(self._format_todo(task))
+            return
+
+        # Structure changed — rebuild
         active_entries: list[Static] = []
         for task in active:
             entry = Static(self._format_todo(task), classes="todo-entry")
@@ -696,17 +730,12 @@ class Sidebar(Vertical):
             await container.mount(*active_entries)
 
         if done_entries:
-            # See _refresh_subagent_display: children are passed to the
-            # Collapsible constructor rather than mounted via a post-mount
-            # query_one("Contents") to avoid the teardown NoMatches race.
             collapse = Collapsible(
                 *done_entries,
                 classes="finished-collapse",
                 title=f"Done ({len(done)})",
                 collapsed=was_finished_collapsed,
             )
-            # Pre-set the -collapsed class before mount to avoid a one-frame
-            # flash of the expanded dropdown (see _refresh_subagent_display).
             collapse.set_class(was_finished_collapsed, "-collapsed", update=False)
             await container.mount(collapse)
 

--- a/src/orchid/widgets/sidebar.py
+++ b/src/orchid/widgets/sidebar.py
@@ -294,6 +294,7 @@ class Sidebar(Vertical):
         self._subagent_records: list = []
         self._bg_cmd_records: list = []
         self._expanded_bg_cmd_id: int | None = None
+        self._bg_cmd_label_cache: dict[int, str] = {}
 
     def compose(self):
         yield Static("Tokens", id="sidebar-tokens-label")
@@ -803,9 +804,18 @@ class Sidebar(Vertical):
 
     @staticmethod
     def _format_age(seconds: float) -> str:
-        """Format a monotonic-time age into a human-readable string."""
+        """Format a monotonic-time age into a human-readable string.
+
+        Rounds to reduce update frequency: 5s buckets under 1m, 1m buckets
+        under 1h, so the formatted string changes less often and avoids
+        triggering unnecessary widget repaints.
+        """
+        if seconds < 5:
+            return "now"
         if seconds < 60:
-            return f"{int(seconds)}s ago"
+            # Round to nearest 5s to reduce churn
+            rounded = int(seconds // 5) * 5
+            return f"{rounded}s ago"
         if seconds < 3600:
             return f"{int(seconds / 60)}m ago"
         return f"{int(seconds / 3600)}h ago"
@@ -879,17 +889,31 @@ class Sidebar(Vertical):
         )
 
         if not structure_changed:
-            # Label-only updates (age, owner, status)
+            # Label-only updates (age, owner, status) — only update if text changed
             for child in container.children:
                 if isinstance(child, NavEntry) and "bg-cmd-entry" in child.classes:
-                    r = records_by_id.get(int(child.view_id))
+                    try:
+                        cmd_id = int(child.view_id)
+                    except (ValueError, TypeError):
+                        continue
+                    r = records_by_id.get(cmd_id)
                     if r:
-                        child.update(self._format_bg_entry(r))
-                elif isinstance(child, Collapsible):
+                        new_text = self._format_bg_entry(r)
+                        if self._bg_cmd_label_cache.get(cmd_id) != new_text:
+                            self._bg_cmd_label_cache[cmd_id] = new_text
+                            child.update(new_text)
+                elif isinstance(child, Collapsible) and "finished-collapse" in child.classes:
                     for entry in child.query(NavEntry):
-                        r = records_by_id.get(int(entry.view_id))
+                        try:
+                            cmd_id = int(entry.view_id)
+                        except (ValueError, TypeError):
+                            continue
+                        r = records_by_id.get(cmd_id)
                         if r:
-                            entry.update(self._format_bg_entry(r))
+                            new_text = self._format_bg_entry(r)
+                            if self._bg_cmd_label_cache.get(cmd_id) != new_text:
+                                self._bg_cmd_label_cache[cmd_id] = new_text
+                                entry.update(new_text)
             return
 
         # Structure changed — batch rebuild
@@ -1048,21 +1072,27 @@ class Sidebar(Vertical):
         )
         collapsible.set_class(False, "-collapsed", update=False)
 
-        # Find the index to insert after the correct NavEntry
-        insert_idx = 0
-        for i, child in enumerate(container.children):
+        # Find the NavEntry to insert after, and mount directly (no teardown)
+        target_entry = None
+        for child in container.children:
             if isinstance(child, NavEntry) and "bg-cmd-entry" in child.classes:
                 try:
                     if int(child.view_id) == cmd_id:
-                        insert_idx = i + 1
+                        target_entry = child
                         break
                 except (ValueError, TypeError):
                     pass
 
-        children = list(container.children)
-        children.insert(insert_idx, collapsible)
-        await container.remove_children()
-        await container.mount(*children)
+        if target_entry is not None:
+            # Mount after the target entry using sibling index
+            children_list = list(container.children)
+            idx = children_list.index(target_entry)
+            if idx + 1 < len(children_list):
+                await container.mount(collapsible, before=children_list[idx + 1])
+            else:
+                await container.mount(collapsible)
+        else:
+            await container.mount(collapsible)
 
     async def _collapse_bg_cmd(self, cmd_id: int) -> None:
         """Remove the collapsible for a previously expanded bg command."""


### PR DESCRIPTION
- Batch-mount widgets in mount_all_messages (1-2 layout passes instead of N)
- Collapse old chains into lightweight stubs beyond 20 chains (bounds DOM size)
- Enable PAUSE_GC_ON_SCROLL to prevent GC-induced frame drops during scroll
- Cache session usage totals with fingerprint invalidation (avoids O(n) per tick)
- Iterate chains in reverse for footer usage lookup (no list materialization)
- Diff-based sidebar updates for MCP servers and todos (eliminates flicker)
- Throttle AssistantMessageWidget markdown writes at 200ms intervals
- Reduce background command polling from 0.5s to 1.5s
- Partial file reads for session listing (2KB regex extraction vs full JSON parse)