### PR TITLE
fix(mcp): improve cancellation handling in MCPManager and add related tests

### DIFF
--- a/src/orchid/llm/client.py
+++ b/src/orchid/llm/client.py
@@ -43,8 +43,8 @@ log = logging.getLogger(__name__)
 _YIELD_THROTTLE = 0.1
 _TOOL_TIMEOUT = 60
 _ERROR_DETAIL_MAX_LEN = 200
-_TOOL_OUTPUT_INLINE_THRESHOLD = 10_000
-_TOOLS_WITHOUT_OUTPUT_OFFLOAD = {"read", "grep", "glob", "directory_tree", "web_fetch", "skill", "write"}
+_TOOL_OUTPUT_INLINE_THRESHOLD = 20_000
+_TOOLS_WITHOUT_OUTPUT_OFFLOAD = {"read", "grep", "glob", "directory_tree", "web_fetch", "skill", "write", "wait_for_subagent"}
 _TOOLS_WITHOUT_TIMEOUT = {
     "wait_for_subagent",
     "get_file_skeleton",

--- a/src/orchid/mcp/__init__.py
+++ b/src/orchid/mcp/__init__.py
@@ -172,17 +172,17 @@ class MCPManager:
             # the async generators (stdio_client, sse_client) dangle and
             # their finalizers later raise "exit cancel scope in a different
             # task" when the event loop runs shutdown_asyncgens.
-            cancelled: bool = False
+            cancellation: asyncio.CancelledError | None = None
             try:
                 await self._stop.wait()
-            except asyncio.CancelledError:
-                cancelled = True
+            except asyncio.CancelledError as e:
+                cancellation = e
             try:
                 await self._exit_stack.aclose()
             except Exception:
                 logger.warning("Error during MCP shutdown", exc_info=True)
-            if cancelled:
-                raise
+            if cancellation is not None:
+                raise cancellation
 
     async def _await_runner(self, timeout: float = 3.0) -> None:
         self._stop.set()

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -200,6 +200,34 @@ class TestMCPLifecycle(unittest.IsolatedAsyncioTestCase):
             finally:
                 await manager.shutdown()
 
+    async def test_runner_cancellation_reraises_cancelled_error_after_cleanup(self):
+        """External runner cancellation must not turn into a bare-raise error.
+
+        ``asyncio.run()`` cancels pending tasks during event-loop shutdown. If
+        the MCP runner is still waiting on ``_stop`` at that point, it must
+        close its transports and then preserve cancellation semantics instead
+        of raising ``RuntimeError: No active exception to reraise``.
+        """
+        from orchid.mcp import MCPManager
+
+        manager = MCPManager()
+        servers = {"srv1": {"command": "fake", "args": []}}
+
+        with (
+            patch("orchid.mcp.stdio_client", fake_stdio_client),
+            patch("orchid.mcp.ClientSession", FakeClientSession),
+        ):
+            await manager.start_all(servers)
+            assert manager._runner is not None
+            runner = manager._runner
+            runner.cancel()
+
+            with self.assertRaises(asyncio.CancelledError):
+                await runner
+
+            self.assertTrue(runner.cancelled())
+            manager._runner = None
+
 
 _SSE_SENTINEL = object()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled background operations so shutdown now completes cleanly and returns the expected cancellation error instead of an unexpected runtime error.
  * Adjusted how larger tool results are handled, reducing unnecessary offloading for some tool outputs and keeping selected tool responses inline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->