### PR TITLE
Feat/apply patch tool

### DIFF
--- a/TODO-ELECTRON.md
+++ b/TODO-ELECTRON.md
@@ -27,7 +27,10 @@
   - MCP: `read_mcp_resource`, `list_mcp_resources`, and dynamically registered MCP tools
 
 ### TODOs geral
-- apply_patch tool
+- ~~apply_patch tool~~ (done — feat/apply-patch-tool)
+- **P0: Realpath-based path sandboxing for all filesystem tools** — `resolveToolPath` is lexical-only; symlinks inside the project can escape the working directory. apply_patch has a lexical containment check but it's bypassable via directory symlinks. `write`/`edit` have no containment at all. Reuse `assertPathInScopeRoot` from `defs/paths.ts:116` (realpaths root + parent + leaf). Apply uniformly to all mutating filesystem tools. (code review 2026-07-19, P0)
+- **P1: apply_patch sync matching can block event loop** — `seekSequence` is O(n×m×4) synchronous. Large file + non-matching pattern blocks the main process indefinitely; `Promise.race` timeout can't fire. Add a line-count guard in `applyChunksToContent` and `.max()` on the patch Zod schema. (code review 2026-07-19, P1)
+- **P1: apply_patch agent projector emits redundant full diffs** — full `<old_string>`/`<new_string>` per file can exceed 20KB offload threshold, stripping per-file error info the agent needs. Make projector compact: per-file status + errors only, omit diffs (UI renderer keeps them). (code review 2026-07-19, P1)
 - Change session storage to SQLite
 - Tools should start the execution as son as the generation is complete, even if the model is still generating output for other commands
 - RAG/AST Post Write Callback + automatic updating if changes are detected (Can be changed via commands / manually / etc that post write callback does not detect)

--- a/docs/brainstorms/apply-patch-tool-requirements.md
+++ b/docs/brainstorms/apply-patch-tool-requirements.md
@@ -1,0 +1,132 @@
+---
+date: 2026-07-19
+topic: apply-patch-tool
+---
+
+# apply_patch Tool
+
+## Summary
+
+A new `apply_patch` tool that accepts the OpenAI/Codex `*** Begin Patch` format, supporting multi-file create, update, delete, and rename operations in a single tool call with 4-tier progressive context matching and per-file error reporting. It complements the existing `edit` and `write` tools, giving agents a standard, token-efficient way to batch file changes.
+
+---
+
+## Problem Frame
+
+Orchid's current file-editing surface is split across two tools: `edit` (exact string replacement, single file, single or replace-all) and `write` (full file creation or replacement). Agents performing multi-file refactors, renames, or coordinated edits must issue one `edit` call per file per change, each requiring an exact string match. This creates three compounding costs:
+
+1. **Token overhead.** Each `edit` call sends the full `old_string` and `new_string` as tool arguments. A 10-file rename produces 10 round-trips, each carrying redundant context. Diff-style patches express the same changes in a fraction of the tokens.
+
+2. **Fragile matching.** `edit` requires byte-exact string matches. When an LLM's remembered file content drifts from reality (stale indentation, trailing whitespace, Unicode punctuation), the edit fails and the agent must re-read the file and retry. There is no tolerance for minor discrepancies.
+
+3. **No multi-file atomicity of intent.** While true all-or-nothing atomicity is undesirable (one bad hunk shouldn't block everything), there is no way for an agent to express "these 5 files change together" in a single tool call. Each file is a separate decision point where the agent can lose track of the overall refactor.
+
+Models are increasingly trained on the OpenAI apply_patch format. By accepting this format directly, Orchid lets models use a patch language they already know, reducing hallucinated tool syntax and improving first-attempt success rates.
+
+---
+
+## Requirements
+
+**Patch format and parsing**
+
+- R1. The tool accepts a single `patch` string argument containing the full `*** Begin Patch` ... `*** End Patch` envelope as defined by the OpenAI/Codex apply_patch format.
+- R2. The parser supports all three file operation headers: `*** Add File: <path>`, `*** Update File: <path>`, and `*** Delete File: <path>`.
+- R3. The parser supports the `*** Move to: <new path>` directive within update hunks for file rename/move operations.
+- R4. The parser supports `@@` context hint lines (e.g., `@@ class Foo`, `@@ def bar():`) that narrow the search position before matching change lines. Multiple stacked `@@` lines are supported for disambiguation.
+- R5. The parser supports the `*** End of File` marker to anchor a chunk to the end of the file.
+- R6. A single `*** Update File:` operation may contain multiple `@@` chunks, each targeting a different region of the file. Chunks are applied in order.
+- R7. The parser operates in lenient mode: it strips heredoc wrappers (`<<'EOF'...EOF`, `<<"EOF"...EOF`) that some models produce around the patch text.
+
+**Context matching**
+
+- R8. When applying an update chunk, the tool locates the old lines in the target file using a 4-tier progressive matching strategy, tried in order:
+  1. Exact line match
+  2. Match ignoring trailing whitespace (trim-end per line)
+  3. Match ignoring leading and trailing whitespace (trim both sides per line)
+  4. Match after Unicode punctuation normalization (typographic dashes to ASCII `-`, curly quotes to ASCII `"`/`'`, non-breaking and exotic spaces to ASCII space) combined with trim
+- R9. If no tier finds a match, the tool returns a per-file error that includes the unmatched lines and the file path, giving the agent actionable recovery information.
+- R10. When a `@@` context hint is present, the tool first locates the hint line in the file (using the same 4-tier matching), then searches for the old lines only after that position.
+
+**File operations**
+
+- R11. `*** Add File:` creates a new file with the content specified by `+` lines. Parent directories are created automatically if they do not exist.
+- R12. `*** Update File:` reads the existing file, applies all chunks to compute new content, and writes the result. The file must exist; updating a nonexistent file is a per-file error.
+- R13. `*** Delete File:` removes the specified file. Deleting a nonexistent file is a per-file error.
+- R14. `*** Move to:` within an update hunk writes the updated content to the new path, then removes the original file. If the destination already exists, it is overwritten.
+
+**Application semantics**
+
+- R15. Files are applied independently and sequentially in the order they appear in the patch. A failure in one file does not prevent subsequent files from being applied.
+- R16. The tool result reports per-file status (success or failure) with descriptive messages. On partial failure, the result includes which files were successfully committed and which failed.
+- R17. All file paths are resolved against the turn's frozen working directory. Relative paths in the patch are joined to this cwd. The tool rejects paths that traverse outside the project directory.
+- R18. File mutations use atomic writes to prevent partial content on failure.
+
+**Result format**
+
+- R19. The tool result reuses the existing `file-change` result family for per-file change data (hunks, added/removed line counts, resulting content), enabling existing UI widgets to render each file's diff.
+- R20. The aggregate result includes a summary of all files touched (added, modified, deleted) with per-file status, following the existing tool output envelope contract.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R8, R9.** Given a file where a line has trailing spaces (`"foo   "`) and the patch's old line is `"foo"` (no trailing spaces), when the patch is applied, the match succeeds at tier 2 (trim-end) and the file is updated.
+- AE2. **Covers R8.** Given a file containing a typographic en-dash (`\u{2013}`) in a comment and the patch uses an ASCII hyphen (`-`), when the patch is applied, the match succeeds at tier 4 (Unicode normalization) and the file is updated.
+- AE3. **Covers R9, R15, R16.** Given a 3-file patch where file 2's old lines don't match any content, when the patch is applied, files 1 and 3 are updated successfully and the result reports file 2 as failed with the unmatched lines included in the error message.
+- AE4. **Covers R4, R10.** Given a file with two identically-named local variables in different functions, and a patch with `@@ def target_func():` before the change lines, when the patch is applied, the change is made in the correct function because the context hint narrows the search.
+- AE5. **Covers R3, R14.** Given a patch with `*** Update File: src/old.ts` followed by `*** Move to: src/new.ts`, when the patch is applied, `src/new.ts` contains the updated content and `src/old.ts` is removed.
+- AE6. **Covers R5.** Given a patch chunk ending with `*** End of File` and pure `+` lines, when applied, the new lines are inserted at the end of the target file.
+- AE7. **Covers R7.** Given a patch wrapped in `<<'EOF'\n*** Begin Patch\n...\n*** End Patch\nEOF`, when the tool receives this string, the heredoc wrapper is stripped and the inner patch is parsed and applied normally.
+- AE8. **Covers R17.** Given a patch containing `*** Update File: ../../etc/passwd`, when the tool resolves the path against the project cwd, the operation is rejected with a path-traversal error.
+
+---
+
+## Success Criteria
+
+- Agents can perform multi-file refactors (renames, API migrations, coordinated edits) in a single tool call with fewer tokens than equivalent `edit` calls.
+- First-attempt patch application succeeds on files with minor whitespace or Unicode discrepancies that would cause `edit` to fail.
+- Per-file error messages are specific enough that an agent can re-read the failed file and produce a corrected patch without additional guidance.
+- The tool integrates with Orchid's existing result family and UI widget infrastructure so that per-file diffs render in the chat stream without new UI work.
+- The patch format matches what models are already trained on, minimizing hallucinated syntax and format errors.
+
+---
+
+## Scope Boundaries
+
+- Unified diff format is not supported; only the `*** Begin Patch` envelope format.
+- All-or-nothing multi-file atomicity is not implemented; files are applied independently.
+- The existing `edit` and `write` tools are not deprecated or removed; they remain available alongside `apply_patch`.
+- No custom renderer UI for multi-file patches; existing file-change widgets handle per-file rendering.
+- Streaming/incremental patch parsing (as in Codex's `StreamingPatchParser`) is not needed for tool-call semantics.
+- No approval/permission UI specific to apply_patch; existing tool execution guards apply.
+
+---
+
+## Key Decisions
+
+- **OpenAI apply_patch format over unified diff**: Models are increasingly trained on the `*** Begin Patch` format. It is multi-file by design, uses context-based matching (no line numbers to get wrong), and supports file creation and deletion natively. Unified diff is line-number-sensitive and single-file per block.
+- **Per-file independent application over all-or-nothing**: Matches Codex behavior. One bad hunk should not block an otherwise-valid multi-file patch. The agent gets specific per-file feedback and can retry just the failed file.
+- **4-tier progressive matching**: Exact match is preferred for predictability, but whitespace and Unicode tolerance dramatically improves first-attempt success on LLM-generated patches. The tiers are ordered from most to least strict, so the most precise match always wins.
+- **Single `patch` string input over structured operations array**: Models generate the patch as a single text block. A string input matches how the format is produced in practice and avoids requiring the model to construct a JSON array of operations.
+- **Complement, not replace**: `edit` remains better for quick single-string replacements. `apply_patch` targets multi-hunk and multi-file scenarios. Both stay in the toolset; usage data will inform whether `apply_patch` eventually subsumes `edit`/`write`.
+
+---
+
+## Dependencies / Assumptions
+
+- The `diff` npm package (already a dependency) is available for computing structured file changes from old/new content.
+- The existing `file-change` result family and `FileChangeData` schema can represent per-file changes from apply_patch without schema modifications.
+- The existing `atomicWrite` utility handles safe file mutation.
+- The Codex `apply-patch` crate (parser, seek_sequence, application logic) serves as the primary reference implementation for porting to TypeScript.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R19][Technical] Whether `FileChangeData` needs new optional fields (e.g., `movePath` for renames, per-file `status` for partial failures) or whether a new aggregate result family is cleaner for multi-file results.
+- [Affects R8][Needs research] Whether the Unicode normalization table from Codex's `seek_sequence` should be extended or trimmed for Orchid's use cases.
+- [Affects R17][Technical] How path-traversal rejection interacts with absolute paths in patches — Codex accepts both relative and absolute paths; Orchid's security model may require stricter constraints.
+- [Affects R6][Technical] How multiple chunks within a single file interact with the structured-diff computation — whether to compute one aggregate diff or per-chunk diffs for the result.
+- [Affects R20][Technical] How the tool output envelope should frame multi-file results — one envelope with an array of per-file changes, or a new aggregate family.

--- a/docs/plans/2026-07-19-001-feat-apply-patch-tool-plan.md
+++ b/docs/plans/2026-07-19-001-feat-apply-patch-tool-plan.md
@@ -1,0 +1,478 @@
+---
+title: "feat: Add apply_patch tool for multi-file patch application"
+type: feat
+status: active
+date: 2026-07-19
+origin: docs/brainstorms/apply-patch-tool-requirements.md
+---
+
+# feat: Add apply_patch tool for multi-file patch application
+
+## Summary
+
+Implement an `apply_patch` tool that accepts the OpenAI/Codex `*** Begin Patch` format and applies multi-file create, update, delete, and rename operations in a single tool call. The implementation is structured as four layers — parser, matcher, application engine, and tool handler — with a custom agent projector and UI renderer for multi-file results.
+
+---
+
+## Problem Frame
+
+Orchid's `edit` tool requires byte-exact string matches and operates on one file per call. Multi-file refactors produce N round-trips with redundant context, and minor whitespace or Unicode drift causes edit failures that force re-reads and retries. Models are increasingly trained on the OpenAI apply_patch format; accepting it directly reduces hallucinated syntax and improves first-attempt success. (see origin: `docs/brainstorms/apply-patch-tool-requirements.md`)
+
+---
+
+## Requirements
+
+- R1. Accept a single `patch` string in the `*** Begin Patch` ... `*** End Patch` envelope format
+- R2. Support `*** Add File:`, `*** Update File:`, `*** Delete File:` operation headers
+- R3. Support `*** Move to:` rename directive within update hunks
+- R4. Support `@@` context hint lines for search disambiguation, including stacked hints
+- R5. Support `*** End of File` marker for EOF-anchored chunks
+- R6. Support multiple `@@` chunks per file, applied in order
+- R7. Lenient parsing: strip heredoc wrappers (`<<'EOF'...EOF`)
+- R8. 4-tier progressive matching: exact → trim-end → trim-both → Unicode normalization + trim
+- R9. Per-file error with unmatched lines and file path on match failure
+- R10. `@@` context hints narrow search position before matching change lines
+- R11. `Add File` creates files with auto-created parent directories
+- R12. `Update File` requires existing file; nonexistent is a per-file error
+- R13. `Delete File` removes file; nonexistent is a per-file error
+- R14. `Move to` writes updated content to new path, removes original
+- R15. Per-file independent sequential application; one failure doesn't block others
+- R16. Per-file status reporting with committed-file tracking on partial failure
+- R17. Paths resolved against frozen turn cwd; reject traversal outside project directory
+- R18. Atomic writes prevent partial content on failure
+- R19. Per-file change data uses existing `file-change` result infrastructure (hunks, counts)
+- R20. Aggregate result includes summary of all files touched with per-file status
+
+**Origin acceptance examples:** AE1–AE8 (see origin document)
+
+---
+
+## Scope Boundaries
+
+- Unified diff format not supported; only `*** Begin Patch` envelope
+- All-or-nothing multi-file atomicity not implemented
+- Existing `edit` and `write` tools not deprecated
+- No custom renderer UI beyond per-file diff rendering via existing patterns
+- No streaming/incremental patch parsing
+- No approval/permission UI specific to apply_patch
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/main/tools/filesystem/edit.ts` — handler pattern: read → validate preconditions → `buildStructuredFileChange` → schema-parse at mutation boundary → `atomicWrite`
+- `src/main/tools/filesystem/write.ts` — file creation pattern: `mkdirSync(recursive)` + `atomicWrite` + `chmod 0o644` for new files
+- `src/main/tools/filesystem/structured-diff.ts` — `buildStructuredFileChange({ path, operation, oldContent, newContent })` computes and validates hunks via jsdiff before mutation
+- `src/main/tools/types.ts` — `ToolDefinition`, `ToolHandler`, `resolveToolPath`, `ToolExecutionContext`
+- `src/main/tools/result.ts` — `defaultFamilyAgentProjectors`, `fileChangeAgentProjector` (reconstructs old/new strings from hunks), `finalizeToolExecutionResult`
+- `src/shared/types/tool-result-filesystem.ts` — `fileChangeDataSchema`, `fileChangeHunkSchema` (strict, single-file)
+- `src/renderer/components/ToolResults/FileChangeToolResult.tsx` — diff rendering with DaisyUI semantic tokens
+- `src/renderer/components/ToolResults/registry.tsx` — `toolRenderers` / `familyRenderers` maps, `resolveToolResultRenderer`
+- `src/main/tools/index.ts` — `registerBuiltinToolsInto` registration pattern
+- `tests/unit/file-tools.test.ts` — handler test pattern (tmpDir, `toolCtx()`, direct handler invocation, on-disk verification)
+- `tests/unit/filesystem-tool-results.test.ts` — result pipeline test pattern (registry dispatch, canonical + projection assertions, `_setStructuredPatchForTests` seam)
+- `tests/parity/tools.test.ts` — inventory protection (`EXPECTED_TOOL_NAMES`, counts, definition validation)
+
+### External References
+
+- Codex `apply-patch` crate: `codex-rs/apply-patch/src/parser.rs` (grammar, lenient parsing), `seek_sequence.rs` (4-tier matching), `lib.rs` (application engine, delta tracking)
+- OpenAI apply_patch docs: https://developers.openai.com/api/docs/guides/tools-apply-patch
+- Codex model instructions: `codex-rs/prompts/templates/apply_patch_tool_instructions.md`
+
+---
+
+## Key Technical Decisions
+
+- **`generic` family with tool-level custom projector over new result family**: The `file-change` family is single-file by design. Rather than registering a new family (touching 6+ files for family registration, copy serialization, renderer registry, and count tests), use the `generic` family with a custom `agentProjector` on the tool definition and a tool-specific renderer via `toolRenderers.set('apply_patch', ...)`. This gives full control over multi-file projection and rendering with minimal plumbing. Per-file update facts still use `buildStructuredFileChange` so coordinates/counts can't drift.
+
+- **Reject absolute paths in patches**: The Codex format spec says "File references can only be relative, NEVER ABSOLUTE." Codex itself accepts absolute paths, but Orchid's security model (audit S4 P0 #1) requires stricter confinement. All paths must be relative, resolved against `ctx.cwd`, with a containment check rejecting `../` traversal.
+
+- **Apply all chunks then diff once per file**: Multiple `@@` chunks within a single file are applied sequentially to compute the final new content in memory. Then `buildStructuredFileChange(oldContent, newContent)` is called once, producing one aggregate diff. Individual chunk boundaries are not preserved in the canonical result.
+
+- **Port Codex matching algorithm as-is**: The 4-tier `seek_sequence` (exact → trim-end → trim-both → Unicode normalization + trim) is ported directly from `codex-rs/apply-patch/src/seek_sequence.rs`. The Unicode normalization table covers typographic dashes, curly quotes, and exotic spaces.
+
+- **Parser as a separate pure module**: The patch parser is a pure function (string → structured hunks) with no filesystem access, enabling thorough unit testing independent of the handler. Same for the matching algorithm and content transformation.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Result schema shape**: New `applyPatchResultDataSchema` wrapping an array of per-file results (each with status, optional `FileChangeData`, optional error). Tool uses `generic` family + custom projector. (see origin: Outstanding Questions Q1)
+- **Unicode normalization scope**: Port Codex table as-is. (see origin: Q2)
+- **Absolute path handling**: Reject; relative-only with containment check. (see origin: Q3)
+- **Multi-chunk diff computation**: Apply all chunks → final content → one `buildStructuredFileChange` per file. (see origin: Q4)
+- **Multi-file envelope framing**: One envelope, custom projector emits per-file XML. (see origin: Q5)
+
+### Deferred to Implementation
+
+- Exact XML projection format for per-file results — will be refined against the existing `fileChangeAgentProjector` output during implementation
+- Whether the `applyPatchResultDataSchema` should include the raw patch text for replay/debugging
+- Edge cases around CRLF handling in the parser (Codex strips `\r`; port and verify)
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+LLM tool call: { patch: "*** Begin Patch\n..." }
+│
+├─ 1. PARSE (pure, no I/O)
+│   parsePatch(patch) → Hunk[]
+│   (AddFile | DeleteFile | UpdateFile { chunks, movePath })
+│
+├─ 2. RESOLVE PATHS
+│   for each hunk:
+│     resolveToolPath(ctx.cwd, hunk.path) → absolute
+│     assertContained(resolved, ctx.cwd)  ← reject ../ traversal
+│
+├─ 3. APPLY PER-FILE (sequential, independent)
+│   for each hunk:
+│     ├─ AddFile:
+│     │   mkdirSync(parent, recursive) → atomicWrite(content) → chmod 0o644
+│     │
+│     ├─ DeleteFile:
+│     │   verify exists + not directory → unlink
+│     │
+│     └─ UpdateFile:
+│         readFileSync → split lines
+│         for each chunk:
+│           seekSequence(lines, chunk.oldLines, start, chunk.eof)
+│             tier 1: exact → tier 2: trimEnd → tier 3: trim → tier 4: unicode+trim
+│           apply replacements → new lines
+│         join → newContent
+│         buildStructuredFileChange(old, new) → FileChangeData
+│         atomicWrite(newContent)
+│         if movePath: write to dest, remove original
+│
+├─ 4. COLLECT RESULTS
+│   per-file: { path, status, fileChangeData?, error? }
+│   aggregate: { files: [...], added, modified, deleted, failed }
+│
+├─ 5. PROJECT (custom agentProjector)
+│   per successful file → file-change XML (old_string/new_string from hunks)
+│   per failed file → error XML with unmatched lines
+│
+└─ 6. RENDER (ApplyPatchToolResult.tsx)
+    per file → reuse FileChangeToolResult diff rendering pattern
+```
+
+---
+
+## Implementation Units
+
+- U1. **Patch parser**
+
+**Goal:** Parse the `*** Begin Patch` envelope format into structured hunk objects. Pure function, no filesystem access.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/main/tools/filesystem/apply-patch-parser.ts`
+- Test: `tests/unit/apply-patch-parser.test.ts`
+
+**Approach:**
+- Port the grammar from Codex's `parser.rs` and `apply_patch.lark` to TypeScript
+- Define types: `PatchHunk = AddFileHunk | DeleteFileHunk | UpdateFileHunk`
+- `UpdateFileHunk` contains `path`, optional `movePath`, and `chunks: UpdateFileChunk[]`
+- `UpdateFileChunk` contains `changeContext: string | null`, `oldLines: string[]`, `newLines: string[]`, `isEndOfFile: boolean`
+- Lenient mode: detect and strip `<<'EOF'...EOF` / `<<"EOF"...EOF` / `<<EOF...EOF` wrappers before parsing
+- Validate `*** Begin Patch` / `*** End Patch` boundaries
+- Reject empty update hunks (no chunks)
+- Support `@@ ` context hints and bare `@@` (no hint)
+- Support `*** End of File` marker setting `isEndOfFile: true`
+- Support `*** Move to:` directive
+- Multiple `@@` chunks per update file, applied in parse order
+
+**Patterns to follow:**
+- Codex `parser.rs` marker constants (`BEGIN_PATCH_MARKER`, `ADD_FILE_MARKER`, etc.)
+- Codex `streaming_parser.rs` for chunk accumulation logic
+- Existing Zod-first pattern: export a Zod schema for the parsed output if useful for validation
+
+**Test scenarios:**
+- Happy path: parse a multi-file patch with Add, Update (with chunks), and Delete operations → correct hunk array
+- Happy path: parse Update with `*** Move to:` → `movePath` populated
+- Happy path: parse Update with multiple `@@` chunks → chunks array in order
+- Happy path: parse `@@ class Foo` context hint → `changeContext` populated
+- Happy path: parse stacked `@@ class Foo` / `@@ def bar():` → last hint used as `changeContext`
+- Happy path: parse `*** End of File` marker → `isEndOfFile: true`
+- Happy path: parse Add File with `+` lines → contents joined with newlines
+- Edge case: patch with no hunks (empty `*** Begin Patch\n*** End Patch`) → empty array
+- Edge case: heredoc-wrapped patch (`<<'EOF'\n...\nEOF`) → stripped and parsed
+- Edge case: heredoc with double quotes (`<<"EOF"`) → stripped and parsed
+- Edge case: update hunk without explicit `@@` header (bare context/add lines) → parsed as single chunk
+- Error path: missing `*** Begin Patch` → parse error with descriptive message
+- Error path: missing `*** End Patch` → parse error
+- Error path: empty update hunk (no chunks after `*** Update File:`) → parse error
+- Error path: mismatched heredoc quotes (`<<"EOF'`) → parse error (not stripped)
+
+**Verification:**
+- All parser tests pass
+- Parser handles every example from the Codex `apply_patch_tool_instructions.md`
+
+---
+
+- U2. **Context matching engine (seek_sequence)**
+
+**Goal:** Implement the 4-tier progressive line-sequence matching algorithm. Pure function, no filesystem access.
+
+**Requirements:** R8, R10
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/main/tools/filesystem/apply-patch-match.ts`
+- Test: `tests/unit/apply-patch-match.test.ts`
+
+**Approach:**
+- Port `seek_sequence` from Codex's `seek_sequence.rs`
+- Function signature: `seekSequence(lines: string[], pattern: string[], start: number, eof: boolean): number | null`
+- Four matching tiers tried in order:
+  1. Exact: `lines[i..i+len] === pattern`
+  2. Trim-end: `line.trimEnd() === pat.trimEnd()` per line
+  3. Trim-both: `line.trim() === pat.trim()` per line
+  4. Unicode normalize + trim: normalize typographic dashes (`\u{2010}`–`\u{2015}`, `\u{2212}` → `-`), curly quotes (`\u{2018}`–`\u{201B}` → `'`, `\u{201C}`–`\u{201F}` → `"`), exotic spaces (`\u{00A0}`, `\u{2002}`–`\u{200A}`, `\u{202F}`, `\u{205F}`, `\u{3000}` → ` `), then trim and compare
+- When `eof` is true, start search from `lines.length - pattern.length` (anchor to end)
+- Empty pattern → return `start` (no-op match)
+- Pattern longer than lines → return `null`
+- Also export `findContextHint(lines: string[], hint: string, start: number): number | null` using the same 4-tier matching for `@@` context hints
+
+**Patterns to follow:**
+- Codex `seek_sequence.rs` — exact port of the algorithm and Unicode normalization table
+
+**Test scenarios:**
+- Happy path: exact match finds sequence at correct index
+- Happy path: trim-end match ignores trailing whitespace
+- Happy path: trim-both match ignores leading and trailing whitespace
+- Happy path: Unicode normalization matches ASCII dash against en-dash (`\u{2013}`)
+- Happy path: Unicode normalization matches ASCII quotes against curly quotes
+- Happy path: Unicode normalization matches ASCII space against non-breaking space
+- Happy path: `eof=true` anchors match to end of file
+- Edge case: empty pattern → returns `start`
+- Edge case: pattern longer than lines → returns `null`
+- Edge case: no match at any tier → returns `null`
+- Edge case: match at tier 1 preferred over tier 2 (exact wins when both would match)
+- Edge case: `start` offset skips earlier occurrences
+- Covers AE1: trailing whitespace tolerance
+- Covers AE2: Unicode dash tolerance
+- Covers AE4: context hint narrows search position
+
+**Verification:**
+- All matching tests pass
+- Matching behavior is identical to Codex's `seek_sequence` for the same inputs
+
+---
+
+- U3. **Patch application engine**
+
+**Goal:** Apply parsed hunks to file content in memory, computing new content for update operations. Pure content transformation — no filesystem I/O.
+
+**Requirements:** R6, R8, R9, R10
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `src/main/tools/filesystem/apply-patch-apply.ts`
+- Test: `tests/unit/apply-patch-apply.test.ts`
+
+**Approach:**
+- Port the content transformation logic from Codex's `lib.rs` (`derive_new_contents_from_chunks`, `compute_replacements`, `apply_replacements`)
+- `applyChunksToContent(originalContent: string, chunks: UpdateFileChunk[], filePath: string): string`
+  - Split content into lines, strip trailing empty element (matching Codex behavior)
+  - For each chunk:
+    - If `changeContext` present, use `findContextHint` to locate position, advance `lineIndex`
+    - If `oldLines` empty (pure addition), insert at end (or before final empty line)
+    - Otherwise, use `seekSequence` to find `oldLines` starting from `lineIndex`
+    - Handle trailing empty line in pattern (retry without it, per Codex)
+    - Record replacement: `(startIndex, oldLen, newLines)`
+  - Apply replacements in reverse order (descending index) to preserve positions
+  - Re-add trailing newline, join lines
+- On match failure, throw/return error with the unmatched lines and file path (R9)
+- Export a result type that distinguishes success (new content) from failure (error + unmatched lines)
+
+**Patterns to follow:**
+- Codex `lib.rs` `compute_replacements` and `apply_replacements` functions
+- Codex trailing-empty-line retry logic
+
+**Test scenarios:**
+- Happy path: single chunk replacement → correct new content
+- Happy path: multiple chunks in one file → all applied in order
+- Happy path: pure addition (no old lines) → inserted at end
+- Happy path: `*** End of File` chunk → inserted at file end
+- Happy path: context hint narrows search → change applied in correct location
+- Happy path: trailing empty line in pattern → retried without it, match succeeds
+- Edge case: empty file with pure addition → content created
+- Edge case: chunk replacing first line → correct
+- Edge case: chunk replacing last line → correct
+- Edge case: interleaved additions and deletions across non-adjacent regions
+- Error path: old lines not found at any tier → error with unmatched lines and file path
+- Error path: context hint not found → error with hint text and file path
+- Covers AE3: per-file error includes unmatched lines
+- Covers AE6: EOF marker anchors insertion
+
+**Verification:**
+- All application engine tests pass
+- Content transformation produces identical results to Codex for the same inputs
+
+---
+
+- U4. **Tool definition, handler, result schema, and registration**
+
+**Goal:** Wire the parser, matcher, and application engine into a registered tool with a Zod-validated input schema, result schema, and handler that performs filesystem operations.
+
+**Requirements:** R11, R12, R13, R14, R15, R16, R17, R18, R19, R20
+
+**Dependencies:** U3
+
+**Files:**
+- Create: `src/main/tools/filesystem/apply-patch.ts`
+- Create: `src/shared/types/tool-result-apply-patch.ts`
+- Modify: `src/main/tools/index.ts` (import + register)
+- Modify: `tests/parity/tools.test.ts` (add to `EXPECTED_TOOL_NAMES`, bump counts 29→30, 18→19, add definition validation block)
+- Modify: `tests/unit/filesystem-tool-results.test.ts` (add to family-metadata table)
+- Test: `tests/unit/apply-patch.test.ts`
+
+**Approach:**
+- **Input schema**: `applyPatchInputSchema = z.object({ patch: z.string().describe('...') })`
+- **Result schema** (`tool-result-apply-patch.ts`):
+  - `applyPatchFileResultSchema`: `{ path, operation: 'create'|'update'|'delete', status: 'complete'|'error', fileChange?: FileChangeData, error?: { code, message } }`
+  - `applyPatchResultDataSchema`: `{ files: ApplyPatchFileResult[], added: number, modified: number, deleted: number, failed: number }`
+- **Tool definition**: `name: 'apply_patch'`, `resultFamily: 'generic'`, `outputDataSchema: applyPatchResultDataSchema`, `category: 'filesystem'`, custom `agentProjector` (see U5)
+- **Handler flow**:
+  1. Parse patch via `parsePatch(input.patch)` — return error outcome on parse failure
+  2. For each hunk, resolve path via `resolveToolPath(ctx.cwd, hunk.path)`
+  3. Containment check: reject if resolved path escapes `ctx.cwd` (R17)
+  4. Reject absolute paths in the patch (format spec violation)
+  5. For each hunk sequentially (R15):
+     - **AddFile**: `mkdirSync(parent, { recursive: true })` → `atomicWrite(content)` → `chmod 0o644` for new files. Build `FileChangeData` with `operation: 'create'`
+     - **DeleteFile**: verify exists and not directory → read content for delta → `unlinkSync`. Build result with `operation: 'delete'`
+     - **UpdateFile**: read file → `applyChunksToContent` → `buildStructuredFileChange(old, new)` → `fileChangeDataSchema.parse(data)` at mutation boundary → `atomicWrite(newContent)`. If `movePath`: write to dest (auto-create parents), remove original
+  6. Collect per-file results, compute summary counts
+  7. Return `{ status: failed > 0 ? 'partial' : 'complete', data }`
+- **Registration**: `registry.register(applyPatchDefinition, applyPatchHandler)` in `registerBuiltinToolsInto`, alongside other filesystem tools
+- **Do NOT add to `RENDERER_ALLOWED_TOOLS`** — this is a mutating tool
+
+**Patterns to follow:**
+- `edit.ts` handler structure: read → validate → `buildStructuredFileChange` → schema-parse → `atomicWrite`
+- `write.ts` for file creation: `mkdirSync` + `atomicWrite` + `chmod`
+- `edit.ts` `errorOutcome` pattern for structured errors
+- `file-tools.test.ts` for handler test setup (tmpDir, `toolCtx()`, direct invocation)
+
+**Test scenarios:**
+- Happy path: single-file update patch → file modified, result has `modified: 1`
+- Happy path: multi-file patch (add + update + delete) → all applied, correct summary counts
+- Happy path: rename via `*** Move to:` → new file exists, original removed
+- Happy path: add file in nonexistent directory → parents created, file written with 0o644
+- Edge case: patch with no hunks → error outcome ("no files were modified")
+- Edge case: CRLF file content → handled correctly (CR stripped from line content)
+- Covers AE5: rename produces correct result
+- Covers AE7: heredoc-wrapped patch is parsed and applied
+- Covers AE8: `../../etc/passwd` path rejected with traversal error
+- Error path: update nonexistent file → per-file error, other files still applied
+- Error path: delete nonexistent file → per-file error
+- Error path: match failure in one file → that file errors, others succeed, status is `partial`
+- Error path: absolute path in patch → rejected
+- Error path: invalid patch syntax → error outcome with parse error message
+- Integration: handler invoked via `executeToolCall` through registry → canonical result + agent projection produced
+- Integration: `_setStructuredPatchForTests` seam → diff failure before mutation leaves file unchanged
+
+**Verification:**
+- All handler tests pass
+- Parity tests updated and passing (tool count, definition validation)
+- Tool appears in `toolRegistry.listAll()` and `toJsonSchema()`
+
+---
+
+- U5. **Agent projector and UI renderer**
+
+**Goal:** Custom agent projector for multi-file LLM-facing XML output, and a renderer component for the chat UI.
+
+**Requirements:** R19, R20
+
+**Dependencies:** U4
+
+**Files:**
+- Create: `src/renderer/components/ToolResults/ApplyPatchToolResult.tsx`
+- Modify: `src/renderer/components/ToolResults/registry.tsx` (`toolRenderers.set('apply_patch', ApplyPatchToolResult)`)
+- Modify: `src/renderer/utils/tool-title.ts` (add `apply_patch` branch)
+- Modify: `tests/unit/tool-result-rendering.test.ts` (add resolution + markup assertions)
+- Modify: `tests/unit/tool-title.test.ts` (add apply_patch title test)
+- Test: covered by modifications above
+
+**Approach:**
+- **Agent projector** (defined in `apply-patch.ts`, referenced by `definition.agentProjector`):
+  - Parse `applyPatchResultDataSchema` from `canonical.data`
+  - For each successful file with `fileChange`: reuse the `fileChangeAgentProjector` logic (reconstruct old/new strings from hunks, emit compact XML)
+  - For each failed file: emit error XML with path, error code, and unmatched lines
+  - Wrap in a single `<tool_result name="apply_patch" status="...">` envelope with per-file `<file>` sections
+  - Summary line: `N files added, M modified, K deleted, J failed`
+- **Renderer** (`ApplyPatchToolResult.tsx`):
+  - Parse `applyPatchResultDataSchema` from `canonical.data`
+  - Render a summary header (files added/modified/deleted/failed counts)
+  - For each file with `fileChange`: render using the same diff display pattern as `FileChangeToolResult` (hunk headers, `+`/`-`/` ` lines with semantic color tokens)
+  - For each failed file: render an error alert with the error message
+  - Use `ui/` primitives (`Alert`, `StatusBadge`) — no direct DaisyUI class names (styling contract)
+  - Use DaisyUI semantic color tokens (`bg-success/10`, `text-error-content`) — no raw colors
+- **Tool title**: `if (tool === 'apply_patch')` branch using `withLifecycle(...)` for "Applying patch to N files"
+- **Registry**: `toolRenderers.set('apply_patch', ApplyPatchToolResult)`
+
+**Patterns to follow:**
+- `FileChangeToolResult.tsx` for diff rendering (Hunk, DiffLine subcomponents, semantic tokens)
+- `result.ts` `fileChangeAgentProjector` for XML projection logic
+- `tool-title.ts` existing branches for title format
+
+**Test scenarios:**
+- Happy path: `resolveToolResultRenderer('apply_patch', 'generic')` returns `ApplyPatchToolResult`
+- Happy path: render multi-file result → markup contains per-file diff sections
+- Happy path: render result with failed file → markup contains error alert
+- Happy path: agent projector emits per-file XML with old/new strings for successful files
+- Happy path: agent projector emits error XML with unmatched lines for failed files
+- Happy path: tool title returns "Applying patch to N files" format
+- Edge case: render empty result (no files) → graceful handling
+
+**Verification:**
+- Renderer resolution test passes
+- Markup assertions pass for multi-file and error cases
+- Agent projector output is valid XML parseable by the LLM context
+- Tool title test passes
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `apply_patch` is invoked via the standard `executeToolCall` path in `tool-dispatch.ts`. No new IPC channels. Not added to `RENDERER_ALLOWED_TOOLS` (mutating tool).
+- **Error propagation:** Per-file errors are collected in the result data, not thrown. The handler returns `partial` status when any file fails. Parse errors return `error` status immediately.
+- **State lifecycle risks:** Each file write uses `atomicWrite` to prevent partial content. On multi-file partial failure, successfully written files remain on disk (by design — per-file independent semantics). The result data tracks which files were committed.
+- **API surface parity:** No new IPC channels. The tool is exposed to the LLM via `toJsonSchema()` automatically. MCP exposure follows the standard tool registry path.
+- **Integration coverage:** End-to-end test via `executeToolCall` with registry dispatch proves the canonical result + agent projection pipeline.
+- **Unchanged invariants:** `edit`, `write`, and all other existing tools are unchanged. The `file-change` family schema is not modified. The `RENDERER_ALLOWED_TOOLS` allowlist is not modified.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Parser divergence from Codex format as models evolve | Port Codex grammar faithfully; lenient parsing handles known model quirks (heredocs). Parser is a pure module — easy to update independently. |
+| Unicode normalization false positives (matching wrong location) | Normalization is the lowest-priority tier (tried last). Exact and whitespace matches always win. Normalization only fires when all stricter tiers fail. |
+| Multi-file partial failure confuses the agent | Per-file error messages include unmatched lines and file path, giving the agent enough to re-read and retry just the failed file. |
+| Large patches (many files, many chunks) hit tool timeout | Default 60s timeout is generous for filesystem operations. If needed, `noTimeout` can be set on the definition later. |
+| Result schema compatibility with existing UI | Custom renderer handles the new schema. Existing `FileChangeToolResult` is not modified. |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/apply-patch-tool-requirements.md](docs/brainstorms/apply-patch-tool-requirements.md)
+- **Codex apply-patch crate:** `codex-rs/apply-patch/src/` (parser.rs, seek_sequence.rs, lib.rs)
+- **OpenAI apply_patch docs:** https://developers.openai.com/api/docs/guides/tools-apply-patch
+- **Canonical tool results plan:** `docs/plans/2026-07-18-002-feat-canonical-tool-results-plan.md`
+- **Security audit:** `docs/code-review-reports/full-audit-2026-07-16/S4-tools-ast-rag-mcp.md` (P0 #1 path sandbox)
+- Related code: `src/main/tools/filesystem/edit.ts`, `src/main/tools/filesystem/structured-diff.ts`

--- a/electron/src/main/agents/defaults/general/AGENT.md
+++ b/electron/src/main/agents/defaults/general/AGENT.md
@@ -10,6 +10,7 @@ allowed_tools:
   - grep
   - edit
   - write
+  - apply_patch
   - execute_command
   - read_output
   - send_input

--- a/electron/src/main/agents/defaults/implementer/AGENT.md
+++ b/electron/src/main/agents/defaults/implementer/AGENT.md
@@ -10,6 +10,7 @@ allowed_tools:
   - grep
   - edit
   - write
+  - apply_patch
   - execute_command
   - read_output
   - send_input

--- a/electron/src/main/tools/filesystem/apply-patch-apply.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-apply.ts
@@ -52,6 +52,10 @@ function computeReplacements(
       lineIndex = found;
     }
 
+    if (chunk.oldLines.length === 0 && chunk.newLines.length === 0) {
+      continue;
+    }
+
     if (chunk.oldLines.length === 0) {
       const insertionIdx = lines.length > 0 && lines[lines.length - 1] === ''
         ? lines.length - 1

--- a/electron/src/main/tools/filesystem/apply-patch-apply.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-apply.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure content transformation engine that applies parsed patch chunks to file
+ * content in memory. No filesystem I/O.
+ *
+ * Ported from codex-rs/apply-patch/src/lib.rs (derive_new_contents_from_chunks,
+ * compute_replacements, apply_replacements).
+ */
+
+import type { UpdateFileChunk } from './apply-patch-parser';
+import { seekSequence, findContextHint } from './apply-patch-match';
+
+// ── Error ──────────────────────────────────────────────────────────────────
+
+export class ApplyPatchApplyError extends Error {
+  constructor(
+    message: string,
+    public filePath: string,
+    public unmatchedLines?: string[],
+  ) {
+    super(message);
+    this.name = 'ApplyPatchApplyError';
+  }
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface Replacement {
+  startIndex: number;
+  oldLen: number;
+  newLines: string[];
+}
+
+// ── Core algorithm ─────────────────────────────────────────────────────────
+
+function computeReplacements(
+  lines: string[],
+  chunks: UpdateFileChunk[],
+  filePath: string,
+): Replacement[] {
+  const replacements: Replacement[] = [];
+  let lineIndex = 0;
+
+  for (const chunk of chunks) {
+    if (chunk.changeContext !== null) {
+      const found = findContextHint(lines, chunk.changeContext, lineIndex);
+      if (found === null) {
+        throw new ApplyPatchApplyError(
+          `Failed to find context '${chunk.changeContext}' in ${filePath}`,
+          filePath,
+        );
+      }
+      lineIndex = found;
+    }
+
+    if (chunk.oldLines.length === 0) {
+      const insertionIdx = lines.length > 0 && lines[lines.length - 1] === ''
+        ? lines.length - 1
+        : lines.length;
+      replacements.push({ startIndex: insertionIdx, oldLen: 0, newLines: chunk.newLines });
+      continue;
+    }
+
+    let pattern = chunk.oldLines;
+    let newSlice = chunk.newLines;
+    let found = seekSequence(lines, pattern, lineIndex, chunk.isEndOfFile);
+
+    if (found === null && pattern.length > 0 && pattern[pattern.length - 1] === '') {
+      pattern = pattern.slice(0, pattern.length - 1);
+      if (newSlice.length > 0 && newSlice[newSlice.length - 1] === '') {
+        newSlice = newSlice.slice(0, newSlice.length - 1);
+      }
+      found = seekSequence(lines, pattern, lineIndex, chunk.isEndOfFile);
+    }
+
+    if (found !== null) {
+      replacements.push({ startIndex: found, oldLen: pattern.length, newLines: newSlice });
+      lineIndex = found + pattern.length;
+    } else {
+      throw new ApplyPatchApplyError(
+        `Failed to find expected lines in ${filePath}:\n${chunk.oldLines.join('\n')}`,
+        filePath,
+        chunk.oldLines,
+      );
+    }
+  }
+
+  replacements.sort((a, b) => a.startIndex - b.startIndex);
+  return replacements;
+}
+
+function applyReplacements(lines: string[], replacements: Replacement[]): string[] {
+  const result = [...lines];
+
+  for (let i = replacements.length - 1; i >= 0; i--) {
+    const { startIndex, oldLen, newLines } = replacements[i];
+
+    result.splice(startIndex, oldLen, ...newLines);
+  }
+
+  return result;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Apply update chunks to file content, computing the new content.
+ * Pure content transformation — no filesystem I/O.
+ *
+ * Throws ApplyPatchApplyError on match failure.
+ */
+export function applyChunksToContent(
+  originalContent: string,
+  chunks: UpdateFileChunk[],
+  filePath: string,
+): string {
+  const lines = originalContent.split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  const replacements = computeReplacements(lines, chunks, filePath);
+  const newLines = applyReplacements(lines, replacements);
+
+  if (newLines.length === 0 || newLines[newLines.length - 1] !== '') {
+    newLines.push('');
+  }
+
+  return newLines.join('\n');
+}

--- a/electron/src/main/tools/filesystem/apply-patch-apply.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-apply.ts
@@ -6,8 +6,8 @@
  * compute_replacements, apply_replacements).
  */
 
-import type { UpdateFileChunk } from './apply-patch-parser';
-import { seekSequence, findContextHint } from './apply-patch-match';
+import type { UpdateFileChunk, HunkLineOp } from './apply-patch-parser';
+import { seekSequenceWithMeta, findContextHint } from './apply-patch-match';
 
 // ── Error ──────────────────────────────────────────────────────────────────
 
@@ -28,6 +28,24 @@ interface Replacement {
   startIndex: number;
   oldLen: number;
   newLines: string[];
+}
+
+// ── Line ending detection ──────────────────────────────────────────────────
+
+/**
+ * Detect the dominant line ending of a file. Files with mixed endings pick
+ * the majority variant; ties default to LF (the patch envelope's native form).
+ */
+function detectLineEnding(content: string): '\r\n' | '\n' {
+  let crlf = 0;
+  let lf = 0;
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '\n') {
+      if (i > 0 && content[i - 1] === '\r') crlf++;
+      else lf++;
+    }
+  }
+  return crlf > lf ? '\r\n' : '\n';
 }
 
 // ── Core algorithm ─────────────────────────────────────────────────────────
@@ -52,40 +70,112 @@ function computeReplacements(
       lineIndex = found;
     }
 
-    if (chunk.oldLines.length === 0 && chunk.newLines.length === 0) {
+    if (chunk.lineOps.length === 0) {
       continue;
     }
 
-    if (chunk.oldLines.length === 0) {
+    const oldLines = chunk.oldLines;
+
+    if (oldLines.length === 0) {
+      // Pure addition (no context, no removes) — append at EOF.
+      // If the file ends with an empty line, insert before it so the new
+      // content lands at the true end of file.
       const insertionIdx = lines.length > 0 && lines[lines.length - 1] === ''
         ? lines.length - 1
         : lines.length;
-      replacements.push({ startIndex: insertionIdx, oldLen: 0, newLines: chunk.newLines });
+      const newSlice = chunk.lineOps
+        .filter((op): op is Extract<HunkLineOp, { kind: 'add' }> => op.kind === 'add')
+        .map((op) => op.content);
+      replacements.push({ startIndex: insertionIdx, oldLen: 0, newLines: newSlice });
       continue;
     }
 
-    let pattern = chunk.oldLines;
-    let newSlice = chunk.newLines;
-    let found = seekSequence(lines, pattern, lineIndex, chunk.isEndOfFile);
+    // Search for the old lines in the file.
+    let pattern = oldLines;
+    let lineOpsForBuild = chunk.lineOps;
+    let result = seekSequenceWithMeta(lines, pattern, lineIndex, chunk.isEndOfFile);
 
-    if (found === null && pattern.length > 0 && pattern[pattern.length - 1] === '') {
+    // Retry without a trailing empty line in the pattern if the first seek
+    // failed — the patch may have included a trailing-newline placeholder
+    // that the file (which we already stripped) does not have.
+    if (result === null && pattern.length > 0 && pattern[pattern.length - 1] === '') {
       pattern = pattern.slice(0, pattern.length - 1);
-      if (newSlice.length > 0 && newSlice[newSlice.length - 1] === '') {
-        newSlice = newSlice.slice(0, newSlice.length - 1);
+      // Also drop the trailing context '' from lineOps so the newSlice
+      // builder doesn't try to read a non-existent file line. Remove ops
+      // don't contribute to newSlice so trimming them is harmless either way.
+      if (lineOpsForBuild.length > 0) {
+        const lastOp = lineOpsForBuild[lineOpsForBuild.length - 1];
+        if (lastOp.kind === 'context' && lastOp.content === '') {
+          lineOpsForBuild = lineOpsForBuild.slice(0, lineOpsForBuild.length - 1);
+        }
       }
-      found = seekSequence(lines, pattern, lineIndex, chunk.isEndOfFile);
+      result = seekSequenceWithMeta(lines, pattern, lineIndex, chunk.isEndOfFile);
     }
 
-    if (found !== null) {
-      replacements.push({ startIndex: found, oldLen: pattern.length, newLines: newSlice });
-      lineIndex = found + pattern.length;
-    } else {
+    if (result === null) {
+      // F2: when the EOF anchor is set and the pattern isn't found at the
+      // end-of-file position, surface a specific EOF error rather than a
+      // generic match failure.
+      if (chunk.isEndOfFile) {
+        throw new ApplyPatchApplyError(
+          `*** End of File anchor failed in ${filePath}: pattern not found at end of file.\nUnmatched lines:\n${oldLines.join('\n')}`,
+          filePath,
+          oldLines,
+        );
+      }
       throw new ApplyPatchApplyError(
-        `Failed to find expected lines in ${filePath}:\n${chunk.oldLines.join('\n')}`,
+        `Failed to find expected lines in ${filePath}:\n${oldLines.join('\n')}`,
         filePath,
-        chunk.oldLines,
+        oldLines,
       );
     }
+
+    // F2: enforce *** End of File anchor — the matched region must end at
+    // the file's last line. If not, fail rather than silently applying to
+    // a non-EOF location.
+    if (chunk.isEndOfFile && result.index + pattern.length < lines.length) {
+      throw new ApplyPatchApplyError(
+        `*** End of File anchor failed in ${filePath}: match ends at line ${result.index + pattern.length} but file has ${lines.length} lines.`,
+        filePath,
+        oldLines,
+      );
+    }
+
+    // F6: if the match is ambiguous AND the chunk has no @@ context header,
+    // error with disambiguation guidance. When a @@ header is present the
+    // user has already attempted to disambiguate, so we honor the first
+    // match.
+    if (result.ambiguous && chunk.changeContext === null) {
+      throw new ApplyPatchApplyError(
+        `Hunk matches multiple locations in ${filePath}. Add a @@ header with the enclosing class or function name to disambiguate.\nUnmatched lines:\n${oldLines.join('\n')}`,
+        filePath,
+        oldLines,
+      );
+    }
+
+    const found = result.index;
+
+    // F1: build the replacement slice from lineOps. For context lines, use
+    // the file's original content (preserving whitespace) instead of the
+    // patch's version. Add lines use the patch's content. Remove lines are
+    // dropped from the output.
+    const newSlice: string[] = [];
+    let fileIdx = found;
+    for (const op of lineOpsForBuild) {
+      if (op.kind === 'context') {
+        // Use the file's version of this line — preserves trailing/leading
+        // whitespace that fuzzy matching would otherwise overwrite.
+        newSlice.push(lines[fileIdx]);
+        fileIdx++;
+      } else if (op.kind === 'remove') {
+        fileIdx++;
+      } else {
+        newSlice.push(op.content);
+      }
+    }
+
+    replacements.push({ startIndex: found, oldLen: pattern.length, newLines: newSlice });
+    lineIndex = found + pattern.length;
   }
 
   replacements.sort((a, b) => a.startIndex - b.startIndex);
@@ -110,14 +200,29 @@ function applyReplacements(lines: string[], replacements: Replacement[]): string
  * Apply update chunks to file content, computing the new content.
  * Pure content transformation — no filesystem I/O.
  *
- * Throws ApplyPatchApplyError on match failure.
+ * Throws ApplyPatchApplyError on match failure, EOF anchor failure, or
+ * ambiguous match without a @@ disambiguation header.
  */
 export function applyChunksToContent(
   originalContent: string,
   chunks: UpdateFileChunk[],
   filePath: string,
 ): string {
-  const lines = originalContent.split('\n');
+  // F4: detect dominant line ending and preserve it on output. The patch
+  // envelope uses LF internally; we normalize to LF for processing, then
+  // restore the original ending on join.
+  const lineEnding = detectLineEnding(originalContent);
+  const normalizedContent = lineEnding === '\r\n'
+    ? originalContent.replace(/\r\n/g, '\n')
+    : originalContent;
+
+  const lines = normalizedContent.split('\n');
+  // F7: track whether the original had a trailing newline before stripping it.
+  // An empty file is treated as having a trailing newline so that pure
+  // additions produce conventional text-file output.
+  const hadTrailingNewline =
+    normalizedContent.length === 0 ||
+    normalizedContent[normalizedContent.length - 1] === '\n';
   if (lines.length > 0 && lines[lines.length - 1] === '') {
     lines.pop();
   }
@@ -125,9 +230,11 @@ export function applyChunksToContent(
   const replacements = computeReplacements(lines, chunks, filePath);
   const newLines = applyReplacements(lines, replacements);
 
-  if (newLines.length === 0 || newLines[newLines.length - 1] !== '') {
+  // F7: only re-add a trailing newline if the original had one. Do NOT
+  // synthesize a trailing newline for files that lacked one.
+  if (hadTrailingNewline && (newLines.length === 0 || newLines[newLines.length - 1] !== '')) {
     newLines.push('');
   }
 
-  return newLines.join('\n');
+  return newLines.join(lineEnding);
 }

--- a/electron/src/main/tools/filesystem/apply-patch-match.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-match.ts
@@ -1,0 +1,125 @@
+// ── Unicode normalization ──────────────────────────────────────────────────
+
+const DASH_CHARS = new Set([
+  '\u{2010}', '\u{2011}', '\u{2012}', '\u{2013}', '\u{2014}', '\u{2015}', '\u{2212}',
+]);
+
+const SINGLE_QUOTE_CHARS = new Set([
+  '\u{2018}', '\u{2019}', '\u{201A}', '\u{201B}',
+]);
+
+const DOUBLE_QUOTE_CHARS = new Set([
+  '\u{201C}', '\u{201D}', '\u{201E}', '\u{201F}',
+]);
+
+const SPACE_CHARS = new Set([
+  '\u{00A0}', '\u{2002}', '\u{2003}', '\u{2004}', '\u{2005}', '\u{2006}',
+  '\u{2007}', '\u{2008}', '\u{2009}', '\u{200A}', '\u{202F}', '\u{205F}',
+  '\u{3000}',
+]);
+
+/**
+ * Normalize a string by trimming and mapping common Unicode punctuation to ASCII equivalents.
+ */
+export function normalizeUnicode(s: string): string {
+  let out = '';
+  for (const ch of s.trim()) {
+    if (DASH_CHARS.has(ch)) out += '-';
+    else if (SINGLE_QUOTE_CHARS.has(ch)) out += "'";
+    else if (DOUBLE_QUOTE_CHARS.has(ch)) out += '"';
+    else if (SPACE_CHARS.has(ch)) out += ' ';
+    else out += ch;
+  }
+  return out;
+}
+
+// ── Matching tiers ─────────────────────────────────────────────────────────
+
+function matchExact(lines: string[], pattern: string[], i: number): boolean {
+  for (let j = 0; j < pattern.length; j++) {
+    if (lines[i + j] !== pattern[j]) return false;
+  }
+  return true;
+}
+
+function matchTrimEnd(lines: string[], pattern: string[], i: number): boolean {
+  for (let j = 0; j < pattern.length; j++) {
+    if (lines[i + j].trimEnd() !== pattern[j].trimEnd()) return false;
+  }
+  return true;
+}
+
+function matchTrim(lines: string[], pattern: string[], i: number): boolean {
+  for (let j = 0; j < pattern.length; j++) {
+    if (lines[i + j].trim() !== pattern[j].trim()) return false;
+  }
+  return true;
+}
+
+function matchNormalized(lines: string[], pattern: string[], i: number): boolean {
+  for (let j = 0; j < pattern.length; j++) {
+    if (normalizeUnicode(lines[i + j]) !== normalizeUnicode(pattern[j])) return false;
+  }
+  return true;
+}
+
+// ── Core algorithm ─────────────────────────────────────────────────────────
+
+/**
+ * Attempt to find a sequence of pattern lines within source lines, starting at or after `start`.
+ * Returns the starting index of the match, or null if not found.
+ *
+ * Matching is attempted with decreasing strictness across 4 tiers:
+ * 1. Exact match
+ * 2. Trailing whitespace ignored (trimEnd per line)
+ * 3. Both leading and trailing whitespace ignored (trim per line)
+ * 4. Unicode punctuation normalization + trim
+ */
+export function seekSequence(
+  lines: string[],
+  pattern: string[],
+  start: number,
+  eof: boolean,
+): number | null {
+  if (pattern.length === 0) return start;
+  if (pattern.length > lines.length) return null;
+
+  const searchStart = eof && lines.length >= pattern.length
+    ? lines.length - pattern.length
+    : start;
+
+  const lastStart = lines.length - pattern.length;
+
+  const tiers = [matchExact, matchTrimEnd, matchTrim, matchNormalized];
+
+  for (const tier of tiers) {
+    for (let i = searchStart; i <= lastStart; i++) {
+      if (tier(lines, pattern, i)) return i;
+    }
+  }
+
+  if (eof && searchStart !== start) {
+    for (const tier of tiers) {
+      for (let i = start; i <= lastStart; i++) {
+        if (tier(lines, pattern, i)) return i;
+      }
+    }
+  }
+
+  return null;
+}
+
+// ── Context hint finder ────────────────────────────────────────────────────
+
+/**
+ * Find a @@ context hint line in the source, using the same 4-tier matching.
+ * Returns the index after the found hint (so subsequent chunk matching starts after it).
+ */
+export function findContextHint(
+  lines: string[],
+  hint: string,
+  start: number,
+): number | null {
+  const found = seekSequence(lines, [hint], start, false);
+  return found !== null ? found + 1 : null;
+}

--- a/electron/src/main/tools/filesystem/apply-patch-match.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-match.ts
@@ -65,6 +65,12 @@ function matchNormalized(lines: string[], pattern: string[], i: number): boolean
 
 // ── Core algorithm ─────────────────────────────────────────────────────────
 
+export interface SeekResult {
+  index: number;
+  /** True if the winning tier matched more than one position. */
+  ambiguous: boolean;
+}
+
 /**
  * Attempt to find a sequence of pattern lines within source lines, starting at or after `start`.
  * Returns the starting index of the match, or null if not found.
@@ -74,6 +80,10 @@ function matchNormalized(lines: string[], pattern: string[], i: number): boolean
  * 2. Trailing whitespace ignored (trimEnd per line)
  * 3. Both leading and trailing whitespace ignored (trim per line)
  * 4. Unicode punctuation normalization + trim
+ *
+ * When `eof` is true, the search is anchored to the end of the file: only the
+ * final position where the pattern could fit is considered. There is NO
+ * fallback to earlier positions — a non-EOF match returns null.
  */
 export function seekSequence(
   lines: string[],
@@ -81,28 +91,47 @@ export function seekSequence(
   start: number,
   eof: boolean,
 ): number | null {
-  if (pattern.length === 0) return start;
+  const result = seekSequenceWithMeta(lines, pattern, start, eof);
+  return result ? result.index : null;
+}
+
+/**
+ * Same as seekSequence, but also reports whether the winning tier matched
+ * multiple positions (ambiguous). The first match is returned.
+ */
+export function seekSequenceWithMeta(
+  lines: string[],
+  pattern: string[],
+  start: number,
+  eof: boolean,
+): SeekResult | null {
+  if (pattern.length === 0) return { index: start, ambiguous: false };
   if (pattern.length > lines.length) return null;
 
+  // When eof is true, only consider the single position where the pattern
+  // would end at the file's last line. No fallback to earlier positions.
   const searchStart = eof && lines.length >= pattern.length
     ? lines.length - pattern.length
     : start;
 
   const lastStart = lines.length - pattern.length;
+  if (searchStart > lastStart) return null;
 
   const tiers = [matchExact, matchTrimEnd, matchTrim, matchNormalized];
 
   for (const tier of tiers) {
+    let firstMatch: number | null = null;
     for (let i = searchStart; i <= lastStart; i++) {
-      if (tier(lines, pattern, i)) return i;
-    }
-  }
-
-  if (eof && searchStart !== start) {
-    for (const tier of tiers) {
-      for (let i = start; i <= lastStart; i++) {
-        if (tier(lines, pattern, i)) return i;
+      if (tier(lines, pattern, i)) {
+        if (firstMatch === null) {
+          firstMatch = i;
+        } else {
+          return { index: firstMatch, ambiguous: true };
+        }
       }
+    }
+    if (firstMatch !== null) {
+      return { index: firstMatch, ambiguous: false };
     }
   }
 

--- a/electron/src/main/tools/filesystem/apply-patch-parser.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-parser.ts
@@ -1,0 +1,302 @@
+/**
+ * Pure parser for the OpenAI/Codex `*** Begin Patch` envelope format.
+ *
+ * Ported from codex-rs/apply-patch/src/parser.rs and streaming_parser.rs.
+ * No filesystem I/O — string in, structured hunks out.
+ */
+
+// ── Markers ────────────────────────────────────────────────────────────────
+
+export const BEGIN_PATCH_MARKER = '*** Begin Patch';
+export const END_PATCH_MARKER = '*** End Patch';
+export const ADD_FILE_MARKER = '*** Add File: ';
+export const DELETE_FILE_MARKER = '*** Delete File: ';
+export const UPDATE_FILE_MARKER = '*** Update File: ';
+export const MOVE_TO_MARKER = '*** Move to: ';
+export const EOF_MARKER = '*** End of File';
+export const CHANGE_CONTEXT_MARKER = '@@ ';
+export const EMPTY_CHANGE_CONTEXT_MARKER = '@@';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface UpdateFileChunk {
+  changeContext: string | null;
+  oldLines: string[];
+  newLines: string[];
+  isEndOfFile: boolean;
+}
+
+export type PatchHunk =
+  | { type: 'add'; path: string; contents: string }
+  | { type: 'delete'; path: string }
+  | { type: 'update'; path: string; movePath: string | null; chunks: UpdateFileChunk[] };
+
+export interface ParseResult {
+  hunks: PatchHunk[];
+  patch: string;
+}
+
+export class ParseError extends Error {
+  constructor(message: string, public lineNumber?: number) {
+    super(message);
+    this.name = 'ParseError';
+  }
+}
+
+// ── Heredoc stripping ──────────────────────────────────────────────────────
+
+function stripHeredoc(lines: string[]): string[] {
+  if (lines.length < 4) return lines;
+
+  const first = lines[0];
+  const last = lines[lines.length - 1];
+
+  const isHeredocStart =
+    first === '<<EOF' || first === "<<'EOF'" || first === '<<"EOF"';
+
+  if (isHeredocStart && last.endsWith('EOF')) {
+    return lines.slice(1, lines.length - 1);
+  }
+
+  return lines;
+}
+
+// ── Boundary validation ────────────────────────────────────────────────────
+
+function validateBoundaries(lines: string[]): void {
+  const first = lines.length > 0 ? lines[0].trim() : '';
+  const last = lines.length > 0 ? lines[lines.length - 1].trim() : '';
+
+  if (first !== BEGIN_PATCH_MARKER) {
+    throw new ParseError("The first line of the patch must be '*** Begin Patch'");
+  }
+  if (last !== END_PATCH_MARKER) {
+    throw new ParseError("The last line of the patch must be '*** End Patch'");
+  }
+}
+
+// ── Chunk helpers ──────────────────────────────────────────────────────────
+
+function newChunk(changeContext: string | null): UpdateFileChunk {
+  return { changeContext, oldLines: [], newLines: [], isEndOfFile: false };
+}
+
+function ensureChunk(chunks: UpdateFileChunk[]): UpdateFileChunk {
+  if (chunks.length === 0) {
+    chunks.push(newChunk(null));
+  }
+  return chunks[chunks.length - 1];
+}
+
+// ── Parser ─────────────────────────────────────────────────────────────────
+
+type ParserMode = 'started' | 'add' | 'delete' | 'update';
+
+interface UpdateState {
+  hunk: Extract<PatchHunk, { type: 'update' }>;
+  hunkLineNumber: number;
+}
+
+export function parsePatch(input: string): ParseResult {
+  let lines = input.trim().split('\n').map((l) => l.replace(/\r$/, ''));
+  lines = stripHeredoc(lines);
+  validateBoundaries(lines);
+
+  const patch = lines.join('\n');
+  const hunks: PatchHunk[] = [];
+  let mode: ParserMode = 'started';
+  let updateState: UpdateState | null = null;
+
+  function finalizeUpdateHunk(lineNum: number): void {
+    if (!updateState) return;
+    const { hunk, hunkLineNumber } = updateState;
+    if (hunk.chunks.length === 0) {
+      throw new ParseError(
+        `Update file hunk for path '${hunk.path}' is empty`,
+        hunkLineNumber,
+      );
+    }
+    const lastChunk = hunk.chunks[hunk.chunks.length - 1];
+    if (lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
+      throw new ParseError('Update hunk does not contain any lines', lineNum);
+    }
+    updateState = null;
+  }
+
+  for (let i = 1; i < lines.length - 1; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    const lineNum = i + 1;
+    const headerLine = mode === 'update' ? line.replace(/\s+$/, '') : trimmed;
+
+    if (headerLine === END_PATCH_MARKER) {
+      finalizeUpdateHunk(lineNum);
+      break;
+    }
+
+    if (headerLine.startsWith(ADD_FILE_MARKER)) {
+      finalizeUpdateHunk(lineNum);
+      const path = headerLine.slice(ADD_FILE_MARKER.length);
+      hunks.push({ type: 'add', path, contents: '' });
+      mode = 'add';
+      continue;
+    }
+
+    if (headerLine.startsWith(DELETE_FILE_MARKER)) {
+      finalizeUpdateHunk(lineNum);
+      const path = headerLine.slice(DELETE_FILE_MARKER.length);
+      hunks.push({ type: 'delete', path });
+      mode = 'delete';
+      continue;
+    }
+
+    if (headerLine.startsWith(UPDATE_FILE_MARKER)) {
+      finalizeUpdateHunk(lineNum);
+      const path = headerLine.slice(UPDATE_FILE_MARKER.length);
+      const hunk: Extract<PatchHunk, { type: 'update' }> = {
+        type: 'update',
+        path,
+        movePath: null,
+        chunks: [],
+      };
+      hunks.push(hunk);
+      updateState = { hunk, hunkLineNumber: lineNum };
+      mode = 'update';
+      continue;
+    }
+
+    if (mode === 'add') {
+      const lastHunk = hunks[hunks.length - 1];
+      if (lastHunk && lastHunk.type === 'add' && line.startsWith('+')) {
+        lastHunk.contents += line.slice(1) + '\n';
+        continue;
+      }
+      throw new ParseError(
+        `'${trimmed}' is not a valid hunk header. Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'`,
+        lineNum,
+      );
+    }
+
+    if (mode === 'delete') {
+      throw new ParseError(
+        `'${trimmed}' is not a valid hunk header. Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'`,
+        lineNum,
+      );
+    }
+
+    if (mode === 'update' && updateState) {
+      const { hunk } = updateState;
+      const updateLine = line.replace(/\s+$/, '');
+
+      if (
+        hunk.chunks.length === 0 &&
+        hunk.movePath === null &&
+        updateLine.startsWith(MOVE_TO_MARKER)
+      ) {
+        hunk.movePath = updateLine.slice(MOVE_TO_MARKER.length);
+        continue;
+      }
+
+      const lastChunk = hunk.chunks.length > 0 ? hunk.chunks[hunk.chunks.length - 1] : null;
+
+      if (lastChunk && lastChunk.isEndOfFile) {
+        if (updateLine === '') continue;
+        if (
+          updateLine !== EMPTY_CHANGE_CONTEXT_MARKER &&
+          !updateLine.startsWith(CHANGE_CONTEXT_MARKER)
+        ) {
+          throw new ParseError(
+            `Expected update hunk to start with a @@ context marker, got: '${line}'`,
+            lineNum,
+          );
+        }
+      }
+
+      if (updateLine === EMPTY_CHANGE_CONTEXT_MARKER) {
+        if (lastChunk && lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
+          lastChunk.changeContext = null;
+        } else {
+          hunk.chunks.push(newChunk(null));
+        }
+        continue;
+      }
+
+      if (updateLine.startsWith(CHANGE_CONTEXT_MARKER)) {
+        const ctx = updateLine.slice(CHANGE_CONTEXT_MARKER.length);
+        if (lastChunk && lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
+          lastChunk.changeContext = ctx;
+        } else {
+          hunk.chunks.push(newChunk(ctx));
+        }
+        continue;
+      }
+
+      if (updateLine === EOF_MARKER) {
+        if (
+          lastChunk &&
+          lastChunk.oldLines.length === 0 &&
+          lastChunk.newLines.length === 0
+        ) {
+          throw new ParseError('Update hunk does not contain any lines', lineNum);
+        }
+        if (lastChunk) {
+          lastChunk.isEndOfFile = true;
+        }
+        continue;
+      }
+
+      if (line === '') {
+        const chunk = ensureChunk(hunk.chunks);
+        chunk.oldLines.push('');
+        chunk.newLines.push('');
+        continue;
+      }
+
+      if (line.startsWith(' ')) {
+        const chunk = ensureChunk(hunk.chunks);
+        const content = line.slice(1);
+        chunk.oldLines.push(content);
+        chunk.newLines.push(content);
+        continue;
+      }
+
+      if (line.startsWith('+')) {
+        const chunk = ensureChunk(hunk.chunks);
+        chunk.newLines.push(line.slice(1));
+        continue;
+      }
+
+      if (line.startsWith('-')) {
+        const chunk = ensureChunk(hunk.chunks);
+        chunk.oldLines.push(line.slice(1));
+        continue;
+      }
+
+      if (
+        lastChunk &&
+        (lastChunk.oldLines.length > 0 || lastChunk.newLines.length > 0)
+      ) {
+        throw new ParseError(
+          `Expected update hunk to start with a @@ context marker, got: '${line}'`,
+          lineNum,
+        );
+      }
+
+      throw new ParseError(
+        `Unexpected line found in update hunk: '${line}'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)`,
+        lineNum,
+      );
+    }
+
+    if (mode === 'started') {
+      throw new ParseError(
+        `'${trimmed}' is not a valid hunk header. Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'`,
+        lineNum,
+      );
+    }
+  }
+
+  finalizeUpdateHunk(lines.length);
+
+  return { hunks, patch };
+}

--- a/electron/src/main/tools/filesystem/apply-patch-parser.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-parser.ts
@@ -117,7 +117,7 @@ export function parsePatch(input: string): ParseResult {
       );
     }
     const lastChunk = hunk.chunks[hunk.chunks.length - 1];
-    if (lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
+    if (lastChunk.changeContext === null && lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
       throw new ParseError('Update hunk does not contain any lines', lineNum);
     }
     updateState = null;
@@ -224,7 +224,11 @@ export function parsePatch(input: string): ParseResult {
       if (updateLine.startsWith(CHANGE_CONTEXT_MARKER)) {
         const ctx = updateLine.slice(CHANGE_CONTEXT_MARKER.length);
         if (lastChunk && lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
-          lastChunk.changeContext = ctx;
+          if (lastChunk.changeContext !== null) {
+            hunk.chunks.push(newChunk(ctx));
+          } else {
+            lastChunk.changeContext = ctx;
+          }
         } else {
           hunk.chunks.push(newChunk(ctx));
         }

--- a/electron/src/main/tools/filesystem/apply-patch-parser.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-parser.ts
@@ -131,7 +131,7 @@ export function parsePatch(input: string): ParseResult {
       );
     }
     const lastChunk = hunk.chunks[hunk.chunks.length - 1];
-    if (lastChunk.changeContext === null && lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
+    if (lastChunk.oldLines.length === 0 && lastChunk.newLines.length === 0) {
       throw new ParseError('Update hunk does not contain any lines', lineNum);
     }
     updateState = null;
@@ -144,8 +144,10 @@ export function parsePatch(input: string): ParseResult {
     const headerLine = mode === 'update' ? line.replace(/\s+$/, '') : trimmed;
 
     if (headerLine === END_PATCH_MARKER) {
-      finalizeUpdateHunk(lineNum);
-      break;
+      throw new ParseError(
+        `'${END_PATCH_MARKER}' must only appear as the last line of the patch`,
+        lineNum,
+      );
     }
 
     if (headerLine.startsWith(ADD_FILE_MARKER)) {

--- a/electron/src/main/tools/filesystem/apply-patch-parser.ts
+++ b/electron/src/main/tools/filesystem/apply-patch-parser.ts
@@ -19,9 +19,23 @@ export const EMPTY_CHANGE_CONTEXT_MARKER = '@@';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
+/**
+ * Ordered hunk line operation. Context lines are matched fuzzily against the
+ * file but the file's version is preserved in the output; add/remove lines
+ * alter content.
+ */
+export type HunkLineOp =
+  | { kind: 'context'; content: string }
+  | { kind: 'add'; content: string }
+  | { kind: 'remove'; content: string };
+
 export interface UpdateFileChunk {
   changeContext: string | null;
+  /** Ordered list of context/add/remove operations. Source of truth for output. */
+  lineOps: HunkLineOp[];
+  /** Derived: context + remove contents, in order. Used for matching. */
   oldLines: string[];
+  /** Derived: context + add contents, in order. Used for tests/projection. */
   newLines: string[];
   isEndOfFile: boolean;
 }
@@ -78,7 +92,7 @@ function validateBoundaries(lines: string[]): void {
 // ── Chunk helpers ──────────────────────────────────────────────────────────
 
 function newChunk(changeContext: string | null): UpdateFileChunk {
-  return { changeContext, oldLines: [], newLines: [], isEndOfFile: false };
+  return { changeContext, lineOps: [], oldLines: [], newLines: [], isEndOfFile: false };
 }
 
 function ensureChunk(chunks: UpdateFileChunk[]): UpdateFileChunk {
@@ -251,6 +265,7 @@ export function parsePatch(input: string): ParseResult {
 
       if (line === '') {
         const chunk = ensureChunk(hunk.chunks);
+        chunk.lineOps.push({ kind: 'context', content: '' });
         chunk.oldLines.push('');
         chunk.newLines.push('');
         continue;
@@ -259,6 +274,7 @@ export function parsePatch(input: string): ParseResult {
       if (line.startsWith(' ')) {
         const chunk = ensureChunk(hunk.chunks);
         const content = line.slice(1);
+        chunk.lineOps.push({ kind: 'context', content });
         chunk.oldLines.push(content);
         chunk.newLines.push(content);
         continue;
@@ -266,13 +282,17 @@ export function parsePatch(input: string): ParseResult {
 
       if (line.startsWith('+')) {
         const chunk = ensureChunk(hunk.chunks);
-        chunk.newLines.push(line.slice(1));
+        const content = line.slice(1);
+        chunk.lineOps.push({ kind: 'add', content });
+        chunk.newLines.push(content);
         continue;
       }
 
       if (line.startsWith('-')) {
         const chunk = ensureChunk(hunk.chunks);
-        chunk.oldLines.push(line.slice(1));
+        const content = line.slice(1);
+        chunk.lineOps.push({ kind: 'remove', content });
+        chunk.oldLines.push(content);
         continue;
       }
 
@@ -280,14 +300,15 @@ export function parsePatch(input: string): ParseResult {
         lastChunk &&
         (lastChunk.oldLines.length > 0 || lastChunk.newLines.length > 0)
       ) {
+        const prefix = line.length > 0 ? line[0] : '';
         throw new ParseError(
-          `Expected update hunk to start with a @@ context marker, got: '${line}'`,
+          `Invalid hunk line prefix '${prefix}' in '${line}'. Lines must start with ' ' (context), '+' (add), or '-' (remove). Use @@ to start a new hunk.`,
           lineNum,
         );
       }
 
       throw new ParseError(
-        `Unexpected line found in update hunk: '${line}'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)`,
+        `Invalid hunk line prefix '${line.length > 0 ? line[0] : ''}' in '${line}'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)`,
         lineNum,
       );
     }

--- a/electron/src/main/tools/filesystem/apply-patch.ts
+++ b/electron/src/main/tools/filesystem/apply-patch.ts
@@ -40,7 +40,10 @@ export const applyPatchInputSchema = z.object({
     'or *** Delete File: <path> (remove). ' +
     'Within an update, each hunk starts with @@ (optionally followed by a class/function name for disambiguation). ' +
     'Hunk lines use " " (context), "-" (remove), "+" (add) prefixes. ' +
-    'File paths must be relative, NEVER absolute.',
+    'File paths must be relative, NEVER absolute. ' +
+    'A hunk with only "+" lines and no context appends to the end of the file. ' +
+    '*** End of File after a hunk anchors the match to the file\'s last line — the patch fails if the pattern is not at EOF. ' +
+    'Control characters (null, bell, escape) cannot be embedded in patch content.',
   ),
 });
 
@@ -57,7 +60,10 @@ const applyPatchAgentProjector: AgentProjector = (canonical, toolName = 'apply_p
   if (modified > 0) summaryParts.push(`${modified} modified`);
   if (deleted > 0) summaryParts.push(`${deleted} deleted`);
   if (failed > 0) summaryParts.push(`${failed} failed`);
-  const summary = `${files.length} file${files.length === 1 ? '' : 's'}: ${summaryParts.join(', ')}`;
+  // F11: count unique file paths so multi-operation patches on the same file
+  // don't inflate the file count in the summary.
+  const uniquePaths = new Set(files.map((f) => f.path));
+  const summary = `${uniquePaths.size} file${uniquePaths.size === 1 ? '' : 's'}: ${summaryParts.join(', ')}`;
 
   const fileSections = files.map((file) => {
     const attrs: Record<string, string | number | undefined> = {
@@ -155,7 +161,14 @@ export const applyPatchDefinition: ToolDefinition = {
     '  [3 lines pre-context]\n' +
     '  - [old_code]\n' +
     '  + [new_code]\n\n' +
-    'Use *** End of File after the last hunk line to anchor changes to the end of the file.\n\n' +
+    'Use *** End of File after the last hunk line to anchor changes to the end of the file. ' +
+    'The patch fails if the anchored pattern is not at EOF — use this to disambiguate hunks that could match near the end.\n\n' +
+    'A hunk with only "+" lines and no context appends to the end of the file.\n\n' +
+    'If a hunk could match multiple locations, you MUST use @@ with the enclosing class/function name. ' +
+    'Without it, the patch fails with an ambiguity error.\n\n' +
+    'Limitations:\n' +
+    '- Control characters (null, bell, escape) cannot be embedded in patch content.\n' +
+    '- Do NOT patch symlinks directly — the tool follows symlinks and patches the target.\n\n' +
     'Grammar:\n' +
     'Patch := Begin { FileOp } End\n' +
     'Begin := "*** Begin Patch" NEWLINE\n' +
@@ -214,6 +227,28 @@ function isPathContainedIn(resolved: string, cwd: string): boolean {
   return resolved === cwd || resolved.startsWith(cwd + path.sep);
 }
 
+/**
+ * F3: If `filePath` is a symlink, write `content` to the symlink's resolved
+ * target instead of replacing the symlink with a regular file. Returns true
+ * if the write was performed through the symlink, false if the caller should
+ * perform a normal atomic write (file doesn't exist or isn't a symlink).
+ *
+ * For move destinations that don't yet exist, this is a no-op (returns false).
+ */
+function symlinkSafeWrite(filePath: string, content: string): boolean {
+  try {
+    const stat = fs.lstatSync(filePath);
+    if (stat.isSymbolicLink()) {
+      const target = fs.realpathSync(filePath);
+      atomicWrite(target, content);
+      return true;
+    }
+  } catch {
+    // File doesn't exist (move destination) or lstat failed — not a symlink.
+  }
+  return false;
+}
+
 // ── Handler ────────────────────────────────────────────────────────────────
 
 export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
@@ -245,6 +280,15 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
 
     if (hunk.path.startsWith('/') || !isPathContainedIn(resolved, ctx.cwd)) {
       files.push(fileError(hunk.path, hunk.type === 'add' ? 'create' : hunk.type === 'delete' ? 'delete' : 'update', 'path_traversal', `Path '${hunk.path}' escapes the working directory.`));
+      failed++;
+      continue;
+    }
+
+    // F10: reject trailing slash on Add File paths — a trailing slash implies
+    // a directory, not a file.
+    if (hunk.type === 'add' && hunk.path.endsWith('/')) {
+      files.push(fileError(hunk.path, 'create', 'invalid_path',
+        `Add File path '${hunk.path}' must not end with '/'. To create a directory, add a file inside it.`));
       failed++;
       continue;
     }
@@ -319,16 +363,42 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
             failed++;
             continue;
           }
+          // F5: refuse to overwrite an existing file at the move destination.
+          if (fs.existsSync(moveResolved)) {
+            files.push(fileError(hunk.path, 'update', 'move_target_exists',
+              `Move target '${hunk.movePath}' already exists. Delete it first or choose a different target.`));
+            failed++;
+            continue;
+          }
           fs.mkdirSync(path.dirname(moveResolved), { recursive: true });
-          atomicWrite(moveResolved, newContent);
-          fs.chmodSync(moveResolved, 0o644);
+          // F3: if the source is a symlink, write the patched content to the
+          // symlink's target (preserving the symlink itself) rather than
+          // replacing the symlink with a regular file at the new path.
+          const moveSourceIsSymlink = symlinkSafeWrite(moveResolved, newContent);
+          if (!moveSourceIsSymlink) {
+            atomicWrite(moveResolved, newContent);
+            fs.chmodSync(moveResolved, 0o644);
+          }
           fs.unlinkSync(resolved);
           files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated, movePath: hunk.movePath });
+          modified++;
         } else {
-          atomicWrite(resolved, newContent);
-          files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated });
+          // F3: if the target is a symlink, write to the resolved target
+          // path (preserving the symlink) rather than replacing the symlink
+          // with a regular file.
+          const wroteThroughSymlink = symlinkSafeWrite(resolved, newContent);
+          if (!wroteThroughSymlink) {
+            atomicWrite(resolved, newContent);
+          }
+          // F9: if the new content is identical to the original (no-op hunk),
+          // report success but do not increment the modified counter.
+          if (newContent === content) {
+            files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated });
+          } else {
+            files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated });
+            modified++;
+          }
         }
-        modified++;
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/electron/src/main/tools/filesystem/apply-patch.ts
+++ b/electron/src/main/tools/filesystem/apply-patch.ts
@@ -227,6 +227,10 @@ function isPathContainedIn(resolved: string, cwd: string): boolean {
   return resolved === cwd || resolved.startsWith(cwd + path.sep);
 }
 
+function isAbsolutePatchPath(filePath: string): boolean {
+  return path.isAbsolute(filePath) || path.win32.isAbsolute(filePath);
+}
+
 /**
  * F3: If `filePath` is a symlink, write `content` to the symlink's resolved
  * target instead of replacing the symlink with a regular file. Returns true
@@ -278,7 +282,7 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
   for (const hunk of parsed.hunks) {
     const resolved = resolveToolPath(ctx.cwd, hunk.path);
 
-    if (hunk.path.startsWith('/') || !isPathContainedIn(resolved, ctx.cwd)) {
+    if (isAbsolutePatchPath(hunk.path) || !isPathContainedIn(resolved, ctx.cwd)) {
       files.push(fileError(hunk.path, hunk.type === 'add' ? 'create' : hunk.type === 'delete' ? 'delete' : 'update', 'path_traversal', `Path '${hunk.path}' escapes the working directory.`));
       failed++;
       continue;
@@ -358,7 +362,7 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
 
         if (hunk.movePath) {
           const moveResolved = resolveToolPath(ctx.cwd, hunk.movePath);
-          if (hunk.movePath.startsWith('/') || !isPathContainedIn(moveResolved, ctx.cwd)) {
+          if (isAbsolutePatchPath(hunk.movePath) || !isPathContainedIn(moveResolved, ctx.cwd)) {
             files.push(fileError(hunk.path, 'update', 'path_traversal', `Move path '${hunk.movePath}' escapes the working directory.`));
             failed++;
             continue;

--- a/electron/src/main/tools/filesystem/apply-patch.ts
+++ b/electron/src/main/tools/filesystem/apply-patch.ts
@@ -13,6 +13,7 @@ import {
   renderXmlToolResult,
   xmlTextElement,
   escapeXmlText,
+  escapeXmlAttribute,
   projectionWithCanonicalCompleteness,
 } from '../result';
 import type { AgentProjector } from '../../../shared/types/tool-result';
@@ -68,11 +69,11 @@ const applyPatchAgentProjector: AgentProjector = (canonical, toolName = 'apply_p
 
     const attrString = Object.entries(attrs)
       .filter(([, v]) => v !== undefined)
-      .map(([k, v]) => ` ${k}="${escapeXmlText(v)}"`)
+      .map(([k, v]) => ` ${k}="${escapeXmlAttribute(v)}"`)
       .join('');
 
     if (file.status === 'error' && file.error) {
-      return `<file${attrString}>\n<error code="${escapeXmlText(file.error.code)}">${escapeXmlText(file.error.message)}</error>\n</file>`;
+      return `<file${attrString}>\n<error code="${escapeXmlAttribute(file.error.code)}">${escapeXmlText(file.error.message)}</error>\n</file>`;
     }
 
     if (!file.fileChange) {
@@ -250,6 +251,12 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
 
     try {
       if (hunk.type === 'add') {
+        if (fs.existsSync(resolved)) {
+          files.push(fileError(hunk.path, 'create', 'already_exists',
+            `File '${hunk.path}' already exists. Use *** Update File to modify existing files.`));
+          failed++;
+          continue;
+        }
         fs.mkdirSync(path.dirname(resolved), { recursive: true });
         atomicWrite(resolved, hunk.contents);
         fs.chmodSync(resolved, 0o644);
@@ -304,7 +311,6 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
           newContent,
         });
         const validated = fileChangeDataSchema.parse(data);
-        atomicWrite(resolved, newContent);
 
         if (hunk.movePath) {
           const moveResolved = resolveToolPath(ctx.cwd, hunk.movePath);
@@ -319,6 +325,7 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
           fs.unlinkSync(resolved);
           files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated, movePath: hunk.movePath });
         } else {
+          atomicWrite(resolved, newContent);
           files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated });
         }
         modified++;

--- a/electron/src/main/tools/filesystem/apply-patch.ts
+++ b/electron/src/main/tools/filesystem/apply-patch.ts
@@ -1,0 +1,337 @@
+/**
+ * apply_patch tool — multi-file patch application in the *** Begin Patch format.
+ *
+ * Each file operation is applied independently; a failure in one file does not
+ * prevent others from being applied.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { ToolDefinition, ToolHandler, ToolHandlerOutcome } from '../types';
+import { resolveToolPath } from '../types';
+import {
+  renderXmlToolResult,
+  xmlTextElement,
+  escapeXmlText,
+  projectionWithCanonicalCompleteness,
+} from '../result';
+import type { AgentProjector } from '../../../shared/types/tool-result';
+import { atomicWrite } from '../ast/utils';
+import { buildStructuredFileChange } from './structured-diff';
+import { parsePatch, ParseError } from './apply-patch-parser';
+import { applyChunksToContent, ApplyPatchApplyError } from './apply-patch-apply';
+import {
+  fileChangeDataSchema,
+} from '../../../shared/types/tool-result-filesystem';
+import {
+  applyPatchResultDataSchema,
+  type ApplyPatchFileResult,
+  type ApplyPatchResultData,
+} from '../../../shared/types/tool-result-apply-patch';
+
+// ── Schema ─────────────────────────────────────────────────────────────────
+
+export const applyPatchInputSchema = z.object({
+  patch: z.string().describe(
+    'The full patch text in the *** Begin Patch / *** End Patch envelope format. ' +
+    'Each file operation starts with a header: ' +
+    '*** Add File: <path> (create), *** Update File: <path> (modify, optionally with *** Move to: <new path> to rename), ' +
+    'or *** Delete File: <path> (remove). ' +
+    'Within an update, each hunk starts with @@ (optionally followed by a class/function name for disambiguation). ' +
+    'Hunk lines use " " (context), "-" (remove), "+" (add) prefixes. ' +
+    'File paths must be relative, NEVER absolute.',
+  ),
+});
+
+export type ApplyPatchInput = z.infer<typeof applyPatchInputSchema>;
+
+// ── Agent projector ─────────────────────────────────────────────────────────
+
+const applyPatchAgentProjector: AgentProjector = (canonical, toolName = 'apply_patch') => {
+  const parsed = applyPatchResultDataSchema.parse(canonical.data);
+  const { files, added, modified, deleted, failed } = parsed;
+
+  const summaryParts: string[] = [];
+  if (added > 0) summaryParts.push(`${added} added`);
+  if (modified > 0) summaryParts.push(`${modified} modified`);
+  if (deleted > 0) summaryParts.push(`${deleted} deleted`);
+  if (failed > 0) summaryParts.push(`${failed} failed`);
+  const summary = `${files.length} file${files.length === 1 ? '' : 's'}: ${summaryParts.join(', ')}`;
+
+  const fileSections = files.map((file) => {
+    const attrs: Record<string, string | number | undefined> = {
+      path: file.path,
+      operation: file.operation,
+      status: file.status,
+    };
+    if (file.movePath) attrs.move_path = file.movePath;
+
+    const attrString = Object.entries(attrs)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => ` ${k}="${escapeXmlText(v)}"`)
+      .join('');
+
+    if (file.status === 'error' && file.error) {
+      return `<file${attrString}>\n<error code="${escapeXmlText(file.error.code)}">${escapeXmlText(file.error.message)}</error>\n</file>`;
+    }
+
+    if (!file.fileChange) {
+      return `<file${attrString}>\n</file>`;
+    }
+
+    const oldParts: string[] = [];
+    const newParts: string[] = [];
+    for (const hunk of file.fileChange.hunks) {
+      for (const line of hunk.lines) {
+        if (line.kind === 'context') {
+          oldParts.push(line.content);
+          newParts.push(line.content);
+        } else if (line.kind === 'remove') {
+          oldParts.push(line.content);
+        } else {
+          newParts.push(line.content);
+        }
+      }
+    }
+
+    const bodyParts: string[] = [];
+    if (oldParts.length > 0) bodyParts.push(xmlTextElement('old_string', oldParts.join('\n')));
+    if (newParts.length > 0) bodyParts.push(xmlTextElement('new_string', newParts.join('\n')));
+
+    if (bodyParts.length === 0) {
+      return `<file${attrString}>\n</file>`;
+    }
+    return `<file${attrString}>\n${bodyParts.join('\n')}\n</file>`;
+  });
+
+  const body = [summary, ...fileSections].join('\n');
+
+  return projectionWithCanonicalCompleteness(
+    canonical,
+    renderXmlToolResult(toolName, canonical, body, {
+      files: files.length,
+      added,
+      modified,
+      deleted,
+      ...(failed > 0 ? { failed } : {}),
+    }, undefined, true),
+  );
+};
+
+// ── Tool definition ────────────────────────────────────────────────────────
+
+export const applyPatchDefinition: ToolDefinition = {
+  name: 'apply_patch',
+  description:
+    'Apply a multi-file patch using the *** Begin Patch envelope format. ' +
+    'Each file is applied independently — a failure in one file does not prevent others from being applied.\n\n' +
+    'Format:\n' +
+    '*** Begin Patch\n' +
+    '[ one or more file operations ]\n' +
+    '*** End Patch\n\n' +
+    'Each operation starts with one of three headers:\n' +
+    '*** Add File: <path> — create a new file. Every following line is a + line (the initial contents).\n' +
+    '*** Delete File: <path> — remove an existing file. Nothing follows.\n' +
+    '*** Update File: <path> — patch an existing file in place. May be immediately followed by ' +
+    '*** Move to: <new path> to rename the file. Then one or more hunks, each introduced by @@ ' +
+    '(optionally followed by a class or function name to disambiguate repeated code).\n\n' +
+    'Within a hunk each line starts with:\n' +
+    '  " " (space) — context line (unchanged)\n' +
+    '  "-" — line to remove\n' +
+    '  "+" — line to add\n\n' +
+    'Context guidelines:\n' +
+    '- Show 3 lines of code immediately above and below each change. ' +
+    'If a change is within 3 lines of a previous change, do NOT duplicate context lines.\n' +
+    '- If 3 lines of context cannot uniquely identify the code, use @@ with the enclosing class or function name:\n' +
+    '  @@ class BaseClass\n' +
+    '  [3 lines pre-context]\n' +
+    '  - [old_code]\n' +
+    '  + [new_code]\n' +
+    '  [3 lines post-context]\n' +
+    '- For deeply repeated code, stack multiple @@ lines:\n' +
+    '  @@ class BaseClass\n' +
+    '  @@ def method():\n' +
+    '  [3 lines pre-context]\n' +
+    '  - [old_code]\n' +
+    '  + [new_code]\n\n' +
+    'Use *** End of File after the last hunk line to anchor changes to the end of the file.\n\n' +
+    'Grammar:\n' +
+    'Patch := Begin { FileOp } End\n' +
+    'Begin := "*** Begin Patch" NEWLINE\n' +
+    'End := "*** End Patch" NEWLINE\n' +
+    'FileOp := AddFile | DeleteFile | UpdateFile\n' +
+    'AddFile := "*** Add File: " path NEWLINE { "+" line NEWLINE }\n' +
+    'DeleteFile := "*** Delete File: " path NEWLINE\n' +
+    'UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] { Hunk }\n' +
+    'MoveTo := "*** Move to: " newPath NEWLINE\n' +
+    'Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]\n' +
+    'HunkLine := (" " | "-" | "+") text NEWLINE\n\n' +
+    'Example:\n' +
+    '*** Begin Patch\n' +
+    '*** Add File: hello.txt\n' +
+    '+Hello world\n' +
+    '*** Update File: src/app.py\n' +
+    '*** Move to: src/main.py\n' +
+    '@@ def greet():\n' +
+    '-print("Hi")\n' +
+    '+print("Hello, world!")\n' +
+    '*** Delete File: obsolete.txt\n' +
+    '*** End Patch\n\n' +
+    'Important:\n' +
+    '- You MUST include a header (Add/Delete/Update) for each file operation.\n' +
+    '- You MUST prefix new lines with + even when creating a new file.\n' +
+    '- File paths must be relative to the working directory, NEVER absolute.\n' +
+    '- Do not re-read files after applying a patch — the tool reports success or failure per file.',
+  inputSchema: applyPatchInputSchema,
+  resultFamily: 'generic',
+  outputDataSchema: applyPatchResultDataSchema,
+  actionLabel: 'Applying patch...',
+  category: 'filesystem',
+  agentProjector: applyPatchAgentProjector,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function errorOutcome(message: string, code: string): ToolHandlerOutcome<ApplyPatchResultData> {
+  return {
+    status: 'error',
+    data: { files: [], added: 0, modified: 0, deleted: 0, failed: 0 },
+    error: { code, message },
+  };
+}
+
+function fileError(
+  filePath: string,
+  operation: 'create' | 'update' | 'delete',
+  code: string,
+  message: string,
+): ApplyPatchFileResult {
+  return { path: filePath, operation, status: 'error', error: { code, message } };
+}
+
+function isPathContainedIn(resolved: string, cwd: string): boolean {
+  return resolved === cwd || resolved.startsWith(cwd + path.sep);
+}
+
+// ── Handler ────────────────────────────────────────────────────────────────
+
+export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
+  const { patch } = input as ApplyPatchInput;
+
+  let parsed;
+  try {
+    parsed = parsePatch(patch);
+  } catch (err) {
+    if (err instanceof ParseError) {
+      return errorOutcome(err.message, 'parse_error');
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return errorOutcome(`Failed to parse patch: ${message}`, 'parse_error');
+  }
+
+  if (parsed.hunks.length === 0) {
+    return errorOutcome('No files were modified.', 'empty_patch');
+  }
+
+  const files: ApplyPatchFileResult[] = [];
+  let added = 0;
+  let modified = 0;
+  let deleted = 0;
+  let failed = 0;
+
+  for (const hunk of parsed.hunks) {
+    const resolved = resolveToolPath(ctx.cwd, hunk.path);
+
+    if (hunk.path.startsWith('/') || !isPathContainedIn(resolved, ctx.cwd)) {
+      files.push(fileError(hunk.path, hunk.type === 'add' ? 'create' : hunk.type === 'delete' ? 'delete' : 'update', 'path_traversal', `Path '${hunk.path}' escapes the working directory.`));
+      failed++;
+      continue;
+    }
+
+    try {
+      if (hunk.type === 'add') {
+        fs.mkdirSync(path.dirname(resolved), { recursive: true });
+        atomicWrite(resolved, hunk.contents);
+        fs.chmodSync(resolved, 0o644);
+
+        const data = buildStructuredFileChange({
+          path: resolved,
+          operation: 'create',
+          oldContent: '',
+          newContent: hunk.contents,
+        });
+        const validated = fileChangeDataSchema.parse(data);
+        files.push({ path: hunk.path, operation: 'create', status: 'complete', fileChange: validated });
+        added++;
+      } else if (hunk.type === 'delete') {
+        if (!fs.existsSync(resolved) || fs.statSync(resolved).isDirectory()) {
+          files.push(fileError(hunk.path, 'delete', 'not_found', `Cannot delete '${hunk.path}': file does not exist or is a directory.`));
+          failed++;
+          continue;
+        }
+        fs.unlinkSync(resolved);
+        files.push({ path: hunk.path, operation: 'delete', status: 'complete' });
+        deleted++;
+      } else {
+        let content: string;
+        try {
+          content = fs.readFileSync(resolved, 'utf-8');
+        } catch {
+          files.push(fileError(hunk.path, 'update', 'read_failed', `Cannot read file '${hunk.path}' for update.`));
+          failed++;
+          continue;
+        }
+
+        let newContent: string;
+        try {
+          newContent = applyChunksToContent(content, hunk.chunks, resolved);
+        } catch (err) {
+          if (err instanceof ApplyPatchApplyError) {
+            const unmatched = err.unmatchedLines ? `\nUnmatched lines:\n${err.unmatchedLines.join('\n')}` : '';
+            files.push(fileError(hunk.path, 'update', 'match_failed', `${err.message}${unmatched}`));
+          } else {
+            const message = err instanceof Error ? err.message : String(err);
+            files.push(fileError(hunk.path, 'update', 'apply_failed', message));
+          }
+          failed++;
+          continue;
+        }
+
+        const data = buildStructuredFileChange({
+          path: resolved,
+          operation: 'update',
+          oldContent: content,
+          newContent,
+        });
+        const validated = fileChangeDataSchema.parse(data);
+        atomicWrite(resolved, newContent);
+
+        if (hunk.movePath) {
+          const moveResolved = resolveToolPath(ctx.cwd, hunk.movePath);
+          if (hunk.movePath.startsWith('/') || !isPathContainedIn(moveResolved, ctx.cwd)) {
+            files.push(fileError(hunk.path, 'update', 'path_traversal', `Move path '${hunk.movePath}' escapes the working directory.`));
+            failed++;
+            continue;
+          }
+          fs.mkdirSync(path.dirname(moveResolved), { recursive: true });
+          atomicWrite(moveResolved, newContent);
+          fs.chmodSync(moveResolved, 0o644);
+          fs.unlinkSync(resolved);
+          files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated, movePath: hunk.movePath });
+        } else {
+          files.push({ path: hunk.path, operation: 'update', status: 'complete', fileChange: validated });
+        }
+        modified++;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const op = hunk.type === 'add' ? 'create' : hunk.type === 'delete' ? 'delete' : 'update';
+      files.push(fileError(hunk.path, op, 'operation_failed', message));
+      failed++;
+    }
+  }
+
+  const resultData: ApplyPatchResultData = { files, added, modified, deleted, failed };
+
+  return { status: 'complete', data: applyPatchResultDataSchema.parse(resultData) };
+};

--- a/electron/src/main/tools/index.ts
+++ b/electron/src/main/tools/index.ts
@@ -17,6 +17,7 @@ import { editDefinition, editHandler } from './filesystem/edit';
 import { writeDefinition, writeHandler } from './filesystem/write';
 import { readDirectoryDefinition, readDirectoryHandler } from './filesystem/read-directory';
 import { globDefinition, globHandler } from './filesystem/glob';
+import { applyPatchDefinition, applyPatchHandler } from './filesystem/apply-patch';
 import { grepToolDefinition, grepHandler } from './search/grep';
 import { ragSearchDefinition, ragSearchHandler } from './rag/search';
 import { ragIndexDefinition, ragIndexHandler } from './rag';
@@ -213,6 +214,7 @@ function registerBuiltinToolsInto(
   registry.register(writeDefinition, writeHandler);
   registry.register(readDirectoryDefinition, readDirectoryHandler);
   registry.register(globDefinition, globHandler);
+  registry.register(applyPatchDefinition, applyPatchHandler);
   registry.register(grepToolDefinition, grepHandler);
   registry.register(ragSearchDefinition, ragSearchHandler);
   registry.register(ragIndexDefinition, ragIndexHandler);

--- a/electron/src/main/tools/result.ts
+++ b/electron/src/main/tools/result.ts
@@ -65,7 +65,7 @@ function renderXmlAttributes(attributes: Record<string, XmlAttributeValue>): str
     .join('');
 }
 
-function renderXmlToolResult(
+export function renderXmlToolResult(
   toolName: string,
   canonical: CanonicalToolResult,
   body: string,
@@ -90,7 +90,7 @@ function renderXmlToolResult(
     line.length > 0 || index === 0 || index === lines.length - 1).join('\n');
 }
 
-function xmlTextElement(name: string, value: string): string {
+export function xmlTextElement(name: string, value: string): string {
   return '<' + name + '>' + escapeXmlText(value) + '</' + name + '>';
 }
 
@@ -120,7 +120,7 @@ export function parseToolExecutionResult(raw: unknown): ToolExecutionResult {
   return toolExecutionResultSchema.parse(raw) as ToolExecutionResult;
 }
 
-function projectionWithCanonicalCompleteness(
+export function projectionWithCanonicalCompleteness(
   canonical: CanonicalToolResult,
   content: string,
 ): AgentProjection {

--- a/electron/src/renderer/components/ToolResults/ApplyPatchToolResult.tsx
+++ b/electron/src/renderer/components/ToolResults/ApplyPatchToolResult.tsx
@@ -1,0 +1,113 @@
+import {
+  applyPatchResultDataSchema,
+  type ApplyPatchFileResult,
+} from '../../../shared/types/tool-result-apply-patch';
+import type {
+  FileChangeHunk,
+  FileChangeLine,
+} from '../../../shared/types/tool-result-filesystem';
+import type { CanonicalToolResult } from '../../../shared/types/tool-result';
+import { Alert } from '../ui/Alert';
+import { StatusBadge } from '../ui/StatusBadge';
+
+export interface ApplyPatchToolResultProps {
+  canonical: CanonicalToolResult;
+  toolName: string;
+  isLive?: boolean;
+}
+
+function rowLabel(line: FileChangeLine): string {
+  if (line.kind === 'add') return `Added line ${line.newLineNumber}`;
+  if (line.kind === 'remove') return `Removed line ${line.oldLineNumber}`;
+  return `Unchanged line ${line.newLineNumber}`;
+}
+
+function lineClass(kind: FileChangeLine['kind']): string {
+  if (kind === 'add') return 'bg-success/10 text-success-content';
+  if (kind === 'remove') return 'bg-error/10 text-error-content';
+  return 'text-base-content/80';
+}
+
+function DiffLine({ line }: { line: FileChangeLine }) {
+  const oldNumber = line.kind === 'add' ? '' : String(line.oldLineNumber);
+  const newNumber = line.kind === 'remove' ? '' : String(line.newLineNumber);
+  const marker = line.kind === 'add' ? '+' : line.kind === 'remove' ? '-' : ' ';
+  return (
+    <div role="row" aria-label={`${rowLabel(line)}: ${line.content}`} className={`flex min-w-max font-mono text-xs leading-5 ${lineClass(line.kind)}`}>
+      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{oldNumber}</span>
+      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{newNumber}</span>
+      <span aria-hidden className="w-5 shrink-0 px-1 text-center font-semibold">{marker}</span>
+      <span role="cell" className="whitespace-pre px-2">{line.content || ' '}</span>
+    </div>
+  );
+}
+
+function Hunk({ hunk }: { hunk: FileChangeHunk }) {
+  return (
+    <section role="rowgroup" className="border-b border-base-300/60 last:border-b-0">
+      <div role="row" className="min-w-max bg-base-200/60 px-2 py-1 font-mono text-xs text-base-content/70">
+        <span role="cell">@@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},{hunk.newLines} @@</span>
+      </div>
+      {hunk.lines.map((line, index) => <DiffLine key={`${hunk.oldStart}:${hunk.newStart}:${index}`} line={line} />)}
+    </section>
+  );
+}
+
+function operationTone(operation: ApplyPatchFileResult['operation']): 'success' | 'info' | 'warning' {
+  if (operation === 'create') return 'success';
+  if (operation === 'delete') return 'warning';
+  return 'info';
+}
+
+function FileSection({ file }: { file: ApplyPatchFileResult }) {
+  return (
+    <div className="min-w-0 space-y-1">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+        <code className="min-w-0 max-w-full break-all text-sm">{file.path}</code>
+        <StatusBadge tone={operationTone(file.operation)} outline size="xs">{file.operation}</StatusBadge>
+        {file.movePath && (
+          <span className="text-base-content/60">→ <code className="text-xs">{file.movePath}</code></span>
+        )}
+        {file.status === 'error' && <StatusBadge tone="error" size="xs">failed</StatusBadge>}
+      </div>
+      {file.status === 'error' && file.error && (
+        <Alert tone="error" variant="soft" className="text-sm">{file.error.message}</Alert>
+      )}
+      {file.fileChange && file.fileChange.hunks.length > 0 && (
+        <div role="table" aria-label={`File ${file.operation} diff for ${file.path}`} className="max-h-96 max-w-full overflow-auto rounded-box border border-base-300/70">
+          <div className="min-w-max">
+            {file.fileChange.hunks.map((hunk) => <Hunk key={`${hunk.oldStart}:${hunk.newStart}`} hunk={hunk} />)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Multi-file patch result presentation with per-file diffs and error reporting. */
+export function ApplyPatchToolResult({ canonical }: ApplyPatchToolResultProps) {
+  const parsed = applyPatchResultDataSchema.safeParse(canonical.data);
+  if (!parsed.success) return null;
+  const data = parsed.data;
+
+  const summaryParts: string[] = [];
+  if (data.added > 0) summaryParts.push(`${data.added} added`);
+  if (data.modified > 0) summaryParts.push(`${data.modified} modified`);
+  if (data.deleted > 0) summaryParts.push(`${data.deleted} deleted`);
+  if (data.failed > 0) summaryParts.push(`${data.failed} failed`);
+
+  return (
+    <div className="min-w-0 space-y-3" data-result-family="apply-patch">
+      {canonical.status === 'error' && (
+        <Alert tone="error" variant="soft" className="text-sm">{canonical.error.message}</Alert>
+      )}
+      <div className="flex flex-wrap items-center gap-x-2 text-xs text-base-content/70">
+        <span className="font-medium text-base-content">{data.files.length} file{data.files.length === 1 ? '' : 's'}</span>
+        {summaryParts.length > 0 && <span>· {summaryParts.join(', ')}</span>}
+      </div>
+      <div className="space-y-3">
+        {data.files.map((file) => <FileSection key={file.path} file={file} />)}
+      </div>
+    </div>
+  );
+}

--- a/electron/src/renderer/components/ToolResults/ApplyPatchToolResult.tsx
+++ b/electron/src/renderer/components/ToolResults/ApplyPatchToolResult.tsx
@@ -2,55 +2,15 @@ import {
   applyPatchResultDataSchema,
   type ApplyPatchFileResult,
 } from '../../../shared/types/tool-result-apply-patch';
-import type {
-  FileChangeHunk,
-  FileChangeLine,
-} from '../../../shared/types/tool-result-filesystem';
 import type { CanonicalToolResult } from '../../../shared/types/tool-result';
 import { Alert } from '../ui/Alert';
 import { StatusBadge } from '../ui/StatusBadge';
+import { Hunk } from './diff-view';
 
 export interface ApplyPatchToolResultProps {
   canonical: CanonicalToolResult;
   toolName: string;
   isLive?: boolean;
-}
-
-function rowLabel(line: FileChangeLine): string {
-  if (line.kind === 'add') return `Added line ${line.newLineNumber}`;
-  if (line.kind === 'remove') return `Removed line ${line.oldLineNumber}`;
-  return `Unchanged line ${line.newLineNumber}`;
-}
-
-function lineClass(kind: FileChangeLine['kind']): string {
-  if (kind === 'add') return 'bg-success/10 text-success-content';
-  if (kind === 'remove') return 'bg-error/10 text-error-content';
-  return 'text-base-content/80';
-}
-
-function DiffLine({ line }: { line: FileChangeLine }) {
-  const oldNumber = line.kind === 'add' ? '' : String(line.oldLineNumber);
-  const newNumber = line.kind === 'remove' ? '' : String(line.newLineNumber);
-  const marker = line.kind === 'add' ? '+' : line.kind === 'remove' ? '-' : ' ';
-  return (
-    <div role="row" aria-label={`${rowLabel(line)}: ${line.content}`} className={`flex min-w-max font-mono text-xs leading-5 ${lineClass(line.kind)}`}>
-      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{oldNumber}</span>
-      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{newNumber}</span>
-      <span aria-hidden className="w-5 shrink-0 px-1 text-center font-semibold">{marker}</span>
-      <span role="cell" className="whitespace-pre px-2">{line.content || ' '}</span>
-    </div>
-  );
-}
-
-function Hunk({ hunk }: { hunk: FileChangeHunk }) {
-  return (
-    <section role="rowgroup" className="border-b border-base-300/60 last:border-b-0">
-      <div role="row" className="min-w-max bg-base-200/60 px-2 py-1 font-mono text-xs text-base-content/70">
-        <span role="cell">@@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},{hunk.newLines} @@</span>
-      </div>
-      {hunk.lines.map((line, index) => <DiffLine key={`${hunk.oldStart}:${hunk.newStart}:${index}`} line={line} />)}
-    </section>
-  );
 }
 
 function operationTone(operation: ApplyPatchFileResult['operation']): 'success' | 'info' | 'warning' {

--- a/electron/src/renderer/components/ToolResults/FileChangeToolResult.tsx
+++ b/electron/src/renderer/components/ToolResults/FileChangeToolResult.tsx
@@ -1,11 +1,8 @@
-import {
-  fileChangeDataSchema,
-  type FileChangeHunk,
-  type FileChangeLine,
-} from '../../../shared/types/tool-result-filesystem';
+import { fileChangeDataSchema } from '../../../shared/types/tool-result-filesystem';
 import type { CanonicalToolResult } from '../../../shared/types/tool-result';
 import { Alert } from '../ui/Alert';
 import { StatusBadge } from '../ui/StatusBadge';
+import { Hunk } from './diff-view';
 
 export interface FileChangeToolResultProps {
   canonical: CanonicalToolResult;
@@ -22,43 +19,6 @@ function statusNotice(canonical: CanonicalToolResult) {
     return <Alert tone="info" variant="soft" role="status" className="mb-2 text-sm">No file changes were produced.</Alert>;
   }
   return null;
-}
-
-function rowLabel(line: FileChangeLine): string {
-  if (line.kind === 'add') return `Added line ${line.newLineNumber}`;
-  if (line.kind === 'remove') return `Removed line ${line.oldLineNumber}`;
-  return `Unchanged line ${line.newLineNumber}`;
-}
-
-function lineClass(kind: FileChangeLine['kind']): string {
-  if (kind === 'add') return 'bg-success/10 text-success-content';
-  if (kind === 'remove') return 'bg-error/10 text-error-content';
-  return 'text-base-content/80';
-}
-
-function DiffLine({ line }: { line: FileChangeLine }) {
-  const oldNumber = line.kind === 'add' ? '' : String(line.oldLineNumber);
-  const newNumber = line.kind === 'remove' ? '' : String(line.newLineNumber);
-  const marker = line.kind === 'add' ? '+' : line.kind === 'remove' ? '-' : ' ';
-  return (
-    <div role="row" aria-label={`${rowLabel(line)}: ${line.content}`} className={`flex min-w-max font-mono text-xs leading-5 ${lineClass(line.kind)}`}>
-      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{oldNumber}</span>
-      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{newNumber}</span>
-      <span aria-hidden className="w-5 shrink-0 px-1 text-center font-semibold">{marker}</span>
-      <span role="cell" className="whitespace-pre px-2">{line.content || ' '}</span>
-    </div>
-  );
-}
-
-function Hunk({ hunk }: { hunk: FileChangeHunk }) {
-  return (
-    <section role="rowgroup" className="border-b border-base-300/60 last:border-b-0">
-      <div role="row" className="min-w-max bg-base-200/60 px-2 py-1 font-mono text-xs text-base-content/70">
-        <span role="cell">@@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},{hunk.newLines} @@</span>
-      </div>
-      {hunk.lines.map((line, index) => <DiffLine key={`${hunk.oldStart}:${hunk.newStart}:${index}`} line={line} />)}
-    </section>
-  );
 }
 
 /** Native structured diff presentation. The shell owns lifecycle and complete-copy. */

--- a/electron/src/renderer/components/ToolResults/diff-view.tsx
+++ b/electron/src/renderer/components/ToolResults/diff-view.tsx
@@ -1,0 +1,45 @@
+import type {
+  FileChangeHunk,
+  FileChangeLine,
+} from '../../../shared/types/tool-result-filesystem';
+
+/** Accessible label describing a diff line's kind and position. */
+export function rowLabel(line: FileChangeLine): string {
+  if (line.kind === 'add') return `Added line ${line.newLineNumber}`;
+  if (line.kind === 'remove') return `Removed line ${line.oldLineNumber}`;
+  return `Unchanged line ${line.newLineNumber}`;
+}
+
+/** Semantic color classes for a diff line kind. */
+export function lineClass(kind: FileChangeLine['kind']): string {
+  if (kind === 'add') return 'bg-success/10 text-success-content';
+  if (kind === 'remove') return 'bg-error/10 text-error-content';
+  return 'text-base-content/80';
+}
+
+/** Single diff line row with old/new line numbers, marker, and content. */
+export function DiffLine({ line }: { line: FileChangeLine }) {
+  const oldNumber = line.kind === 'add' ? '' : String(line.oldLineNumber);
+  const newNumber = line.kind === 'remove' ? '' : String(line.newLineNumber);
+  const marker = line.kind === 'add' ? '+' : line.kind === 'remove' ? '-' : ' ';
+  return (
+    <div role="row" aria-label={`${rowLabel(line)}: ${line.content}`} className={`flex min-w-max font-mono text-xs leading-5 ${lineClass(line.kind)}`}>
+      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{oldNumber}</span>
+      <span role="cell" aria-hidden className="w-12 shrink-0 border-r border-base-300/60 px-2 text-right text-base-content/50">{newNumber}</span>
+      <span aria-hidden className="w-5 shrink-0 px-1 text-center font-semibold">{marker}</span>
+      <span role="cell" className="whitespace-pre px-2">{line.content || ' '}</span>
+    </div>
+  );
+}
+
+/** Hunk header and its diff lines grouped as a rowgroup. */
+export function Hunk({ hunk }: { hunk: FileChangeHunk }) {
+  return (
+    <section role="rowgroup" className="border-b border-base-300/60 last:border-b-0">
+      <div role="row" className="min-w-max bg-base-200/60 px-2 py-1 font-mono text-xs text-base-content/70">
+        <span role="cell">@@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},{hunk.newLines} @@</span>
+      </div>
+      {hunk.lines.map((line, index) => <DiffLine key={`${hunk.oldStart}:${hunk.newStart}:${index}`} line={line} />)}
+    </section>
+  );
+}

--- a/electron/src/renderer/components/ToolResults/registry.tsx
+++ b/electron/src/renderer/components/ToolResults/registry.tsx
@@ -8,6 +8,7 @@ import { FileWriteToolResult } from './FileWriteToolResult';
 import { FileContentToolResult } from './FileContentToolResult';
 import { DirectoryToolResult } from './DirectoryToolResult';
 import { SearchToolResult } from './SearchToolResult';
+import { ApplyPatchToolResult } from './ApplyPatchToolResult';
 import { LiveCommandInline } from '../ToolWidgets/LiveCommandInline';
 import { StatusBadge } from '../ui/StatusBadge';
 
@@ -107,6 +108,7 @@ toolRenderers.set('read', FileContentToolResult);
 toolRenderers.set('read_directory', DirectoryToolResult);
 toolRenderers.set('glob', SearchToolResult);
 toolRenderers.set('grep', SearchToolResult);
+toolRenderers.set('apply_patch', ApplyPatchToolResult);
 const builtInToolRenderers = new Map(toolRenderers);
 
 export function registerToolResultRenderer(

--- a/electron/src/renderer/utils/tool-title.ts
+++ b/electron/src/renderer/utils/tool-title.ts
@@ -345,6 +345,10 @@ export function buildToolTitle(input: ToolTitleInput): ToolTitle {
     preparing: 'Preparing to list', running: 'Listing', completed: 'Listed', failed: 'list',
   }, pathValue ?? undefined);
 
+  if (tool === 'apply_patch') return withLifecycle(input.status, {
+    preparing: 'Preparing to apply patch', running: 'Applying patch', completed: 'Applied patch', failed: 'apply patch',
+  });
+
   if (tool === 'read_output' || tool === 'send_input' || tool === 'terminate_command') {
     const id = numberForKey(rawArgs, args, ['id']);
     const subject = id !== null ? `command #${id}` : 'background command';

--- a/electron/src/shared/types/tool-result-apply-patch.ts
+++ b/electron/src/shared/types/tool-result-apply-patch.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical result schema for the apply_patch tool.
+ */
+import { z } from 'zod';
+import { fileChangeDataSchema } from './tool-result-filesystem';
+
+export const applyPatchFileResultSchema = z.object({
+  path: z.string().min(1),
+  operation: z.enum(['create', 'update', 'delete']),
+  status: z.enum(['complete', 'error']),
+  fileChange: fileChangeDataSchema.optional(),
+  movePath: z.string().optional(),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }).optional(),
+}).strict();
+
+export type ApplyPatchFileResult = z.infer<typeof applyPatchFileResultSchema>;
+
+export const applyPatchResultDataSchema = z.object({
+  files: z.array(applyPatchFileResultSchema),
+  added: z.number().int().nonnegative(),
+  modified: z.number().int().nonnegative(),
+  deleted: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+}).strict();
+
+export type ApplyPatchResultData = z.infer<typeof applyPatchResultDataSchema>;

--- a/electron/tests/parity/agents.test.ts
+++ b/electron/tests/parity/agents.test.ts
@@ -137,6 +137,7 @@ describe('Agent Parity', () => {
     expect(general.allowed_tools).toContain('grep');
     expect(general.allowed_tools).toContain('edit');
     expect(general.allowed_tools).toContain('write');
+    expect(general.allowed_tools).toContain('apply_patch');
     expect(general.allowed_tools).toContain('delegate_to_subagent');
     expect(general.allowed_skills).toContain('*');
 
@@ -145,6 +146,9 @@ describe('Agent Parity', () => {
 
     const sessionNamer = getAgent('session-namer')!;
     expect(sessionNamer.allowed_tools).toEqual([]);
+
+    const implementer = getAgent('implementer')!;
+    expect(implementer.allowed_tools).toContain('apply_patch');
   });
 
   it('explorer has read-only tools (no edit/write)', () => {

--- a/electron/tests/parity/tools.test.ts
+++ b/electron/tests/parity/tools.test.ts
@@ -19,6 +19,7 @@ import { editDefinition, editHandler } from '../../src/main/tools/filesystem/edi
 import { writeDefinition, writeHandler } from '../../src/main/tools/filesystem/write';
 import { readDirectoryDefinition, readDirectoryHandler } from '../../src/main/tools/filesystem/read-directory';
 import { globDefinition, globHandler } from '../../src/main/tools/filesystem/glob';
+import { applyPatchDefinition, applyPatchHandler } from '../../src/main/tools/filesystem/apply-patch';
 import { grepToolDefinition, grepHandler } from '../../src/main/tools/search/grep';
 import { ragSearchDefinition, ragSearchHandler } from '../../src/main/tools/rag/search';
 import { ragIndexDefinition, ragIndexHandler } from '../../src/main/tools/rag/index';
@@ -66,10 +67,11 @@ import { buildWaitTool } from '../../src/main/tools/subagent/wait';
 import { buildInterruptTool } from '../../src/main/tools/subagent/interrupt';
 import { registerBuiltinTools, toolRegistry } from '../../src/main/tools';
 
-// ── Expected tool names (29 total) ─────────────────────────────────────────
+// ── Expected tool names (30 total) ─────────────────────────────────────────
 
 const EXPECTED_TOOL_NAMES = [
-  // Filesystem (5)
+  // Filesystem (6)
+  'apply_patch',
   'read',
   'edit',
   'write',
@@ -139,7 +141,14 @@ function expectValidHandler(handler: unknown): void {
 // ── Static Tool Tests ───────────────────────────────────────────────────────
 
 describe('Static Tool Definitions', () => {
-  describe('filesystem tools (5)', () => {
+  describe('filesystem tools (6)', () => {
+    it('apply_patch has valid definition, schema, and handler', () => {
+      expectValidDefinition(applyPatchDefinition, 'apply_patch');
+      expectValidJsonSchema(applyPatchDefinition.inputSchema, 'apply_patch');
+      expectValidHandler(applyPatchHandler);
+      expect(applyPatchDefinition.category).toBe('filesystem');
+    });
+
     it('read has valid definition, schema, and handler', () => {
       expectValidDefinition(readDefinition, 'read');
       expectValidJsonSchema(readDefinition.inputSchema, 'read');
@@ -382,15 +391,16 @@ describe('Dynamic Tool Builders', () => {
 // ── Completeness Check ─────────────────────────────────────────────────────
 
 describe('Tool Completeness', () => {
-  it('all 29 expected tool names are defined in this test file', () => {
+  it('all 30 expected tool names are defined in this test file', () => {
     // This test ensures we haven't accidentally removed a tool from our list.
     // If a new tool is added to the codebase, this list must be updated.
-    expect(EXPECTED_TOOL_NAMES).toHaveLength(29);
+    expect(EXPECTED_TOOL_NAMES).toHaveLength(30);
   });
 
   it('static tool count matches expected', () => {
-    // 5 filesystem + 1 search + 2 rag + 4 process + 6 ast = 18 static tools
+    // 6 filesystem + 1 search + 2 rag + 4 process + 6 ast = 19 static tools
     const staticDefinitions = [
+      applyPatchDefinition,
       readDefinition,
       editDefinition,
       writeDefinition,
@@ -410,14 +420,15 @@ describe('Tool Completeness', () => {
       renameSymbolDefinition,
       astIndexDefinition,
     ];
-    expect(staticDefinitions).toHaveLength(18);
+    expect(staticDefinitions).toHaveLength(19);
     // All names should be unique
     const names = staticDefinitions.map((d) => d.name);
-    expect(new Set(names).size).toBe(18);
+    expect(new Set(names).size).toBe(19);
   });
 
   it('all tool names are unique across static and dynamic tools', () => {
     const allNames = [
+      applyPatchDefinition.name,
       readDefinition.name,
       editDefinition.name,
       writeDefinition.name,
@@ -449,8 +460,8 @@ describe('Tool Completeness', () => {
       buildWaitTool({} as any).definition.name,
       buildInterruptTool({} as any).definition.name,
     ];
-    expect(allNames).toHaveLength(29);
-    expect(new Set(allNames).size).toBe(29);
+    expect(allNames).toHaveLength(30);
+    expect(new Set(allNames).size).toBe(30);
   });
 
   it('registerBuiltinTools populates the singleton registry with all tools', () => {

--- a/electron/tests/unit/agent-skill-loading.test.ts
+++ b/electron/tests/unit/agent-skill-loading.test.ts
@@ -267,6 +267,7 @@ describe('Agent Loading — Defaults', () => {
     expect(general!.allowed_tools).toContain('grep');
     expect(general!.allowed_tools).toContain('edit');
     expect(general!.allowed_tools).toContain('write');
+    expect(general!.allowed_tools).toContain('apply_patch');
     expect(general!.allowed_tools).toContain('delegate_to_subagent');
     expect(general!.allowed_skills).toEqual(['*']);
   });
@@ -341,6 +342,7 @@ describe('Agent Loading — Defaults', () => {
     expect(impl!.allowed_tools).toContain('read');
     expect(impl!.allowed_tools).toContain('edit');
     expect(impl!.allowed_tools).toContain('write');
+    expect(impl!.allowed_tools).toContain('apply_patch');
     expect(impl!.allowed_tools).toContain('execute_command');
     expect(impl!.allowed_skills).toContain('work');
     expect(impl!.allowed_skills).toContain('commit');

--- a/electron/tests/unit/apply-patch-apply.test.ts
+++ b/electron/tests/unit/apply-patch-apply.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyChunksToContent,
+  ApplyPatchApplyError,
+} from '../../src/main/tools/filesystem/apply-patch-apply';
+import type { UpdateFileChunk } from '../../src/main/tools/filesystem/apply-patch-parser';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function chunk(overrides: Partial<UpdateFileChunk> = {}): UpdateFileChunk {
+  return {
+    changeContext: null,
+    oldLines: [],
+    newLines: [],
+    isEndOfFile: false,
+    ...overrides,
+  };
+}
+
+// ── Happy path ─────────────────────────────────────────────────────────────
+
+describe('applyChunksToContent', () => {
+  it('applies a single chunk replacement', () => {
+    const content = 'line1\nline2\nline3\n';
+    const chunks = [
+      chunk({ oldLines: ['line2'], newLines: ['replaced'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'line1\nreplaced\nline3\n',
+    );
+  });
+
+  it('applies multiple chunks in one file', () => {
+    const content = 'aaa\nbbb\nccc\nddd\neee\n';
+    const chunks = [
+      chunk({ oldLines: ['bbb'], newLines: ['BBB'] }),
+      chunk({ oldLines: ['ddd'], newLines: ['DDD'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'aaa\nBBB\nccc\nDDD\neee\n',
+    );
+  });
+
+  it('inserts pure addition at end of file', () => {
+    const content = 'existing\n';
+    const chunks = [
+      chunk({ oldLines: [], newLines: ['added1', 'added2'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'existing\nadded1\nadded2\n',
+    );
+  });
+
+  it('handles isEndOfFile chunk anchored to file end', () => {
+    const content = 'foo\nbar\nfoo\nbar\n';
+    const chunks = [
+      chunk({ oldLines: ['foo', 'bar'], newLines: ['baz'], isEndOfFile: true }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'foo\nbar\nbaz\n',
+    );
+  });
+
+  it('uses context hint to narrow search location', () => {
+    const content = 'header\ntarget\nfooter\ntarget\nend\n';
+    const chunks = [
+      chunk({
+        changeContext: 'header',
+        oldLines: ['target'],
+        newLines: ['CHANGED'],
+      }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'header\nCHANGED\nfooter\ntarget\nend\n',
+    );
+  });
+
+  it('retries without trailing empty line in oldLines', () => {
+    const content = 'alpha\nbeta\n';
+    const chunks = [
+      chunk({ oldLines: ['beta', ''], newLines: ['gamma', ''] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'alpha\ngamma\n',
+    );
+  });
+
+  it('preserves context lines in both old and new', () => {
+    const content = 'ctx_before\nold_line\nctx_after\n';
+    const chunks = [
+      chunk({
+        oldLines: ['ctx_before', 'old_line', 'ctx_after'],
+        newLines: ['ctx_before', 'new_line', 'ctx_after'],
+      }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'ctx_before\nnew_line\nctx_after\n',
+    );
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────────
+
+  it('creates content from empty file with pure addition', () => {
+    const chunks = [
+      chunk({ oldLines: [], newLines: ['hello', 'world'] }),
+    ];
+    expect(applyChunksToContent('', chunks, 'test.txt')).toBe(
+      'hello\nworld\n',
+    );
+  });
+
+  it('replaces the first line', () => {
+    const content = 'first\nsecond\nthird\n';
+    const chunks = [
+      chunk({ oldLines: ['first'], newLines: ['FIRST'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'FIRST\nsecond\nthird\n',
+    );
+  });
+
+  it('replaces the last line', () => {
+    const content = 'first\nsecond\nlast\n';
+    const chunks = [
+      chunk({ oldLines: ['last'], newLines: ['LAST'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'first\nsecond\nLAST\n',
+    );
+  });
+
+  it('handles interleaved additions and deletions across non-adjacent regions', () => {
+    const content = 'a\nb\nc\nd\ne\nf\n';
+    const chunks = [
+      chunk({ oldLines: ['b'], newLines: ['B1', 'B2'] }),
+      chunk({ oldLines: ['e'], newLines: [] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'a\nB1\nB2\nc\nd\nf\n',
+    );
+  });
+
+  it('adds trailing newline to content without one', () => {
+    const content = 'no\ntrailing\nnewline';
+    const chunks = [
+      chunk({ oldLines: ['trailing'], newLines: ['TRAILING'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'no\nTRAILING\nnewline\n',
+    );
+  });
+
+  // ── Error paths ────────────────────────────────────────────────────────
+
+  it('throws ApplyPatchApplyError when old lines not found', () => {
+    const content = 'aaa\nbbb\nccc\n';
+    const chunks = [
+      chunk({ oldLines: ['zzz'], newLines: ['replacement'] }),
+    ];
+    expect(() => applyChunksToContent(content, chunks, 'test.txt')).toThrow(
+      ApplyPatchApplyError,
+    );
+    try {
+      applyChunksToContent(content, chunks, 'test.txt');
+    } catch (e) {
+      const err = e as ApplyPatchApplyError;
+      expect(err.filePath).toBe('test.txt');
+      expect(err.unmatchedLines).toEqual(['zzz']);
+      expect(err.message).toContain('Failed to find expected lines in test.txt');
+    }
+  });
+
+  it('throws ApplyPatchApplyError when context hint not found', () => {
+    const content = 'aaa\nbbb\n';
+    const chunks = [
+      chunk({
+        changeContext: 'nonexistent_context',
+        oldLines: ['bbb'],
+        newLines: ['ccc'],
+      }),
+    ];
+    expect(() => applyChunksToContent(content, chunks, 'test.txt')).toThrow(
+      ApplyPatchApplyError,
+    );
+    try {
+      applyChunksToContent(content, chunks, 'test.txt');
+    } catch (e) {
+      const err = e as ApplyPatchApplyError;
+      expect(err.filePath).toBe('test.txt');
+      expect(err.message).toContain("Failed to find context 'nonexistent_context' in test.txt");
+    }
+  });
+});

--- a/electron/tests/unit/apply-patch-apply.test.ts
+++ b/electron/tests/unit/apply-patch-apply.test.ts
@@ -75,6 +75,23 @@ describe('applyChunksToContent', () => {
     );
   });
 
+  it('uses stacked context-advancing chunks to narrow search', () => {
+    const lines = Array.from({ length: 21 }, (_, i) => `line${i + 1}`);
+    lines[0] = 'class Foo';
+    lines[4] = 'def bar';
+    lines[5] = 'target';
+    lines[19] = 'target';
+    const content = lines.join('\n') + '\n';
+    const chunks = [
+      chunk({ changeContext: 'class Foo', oldLines: [], newLines: [] }),
+      chunk({ changeContext: 'def bar', oldLines: ['target'], newLines: ['CHANGED'] }),
+    ];
+    const result = applyChunksToContent(content, chunks, 'test.txt');
+    const resultLines = result.split('\n');
+    expect(resultLines[5]).toBe('CHANGED');
+    expect(resultLines[19]).toBe('target');
+  });
+
   it('retries without trailing empty line in oldLines', () => {
     const content = 'alpha\nbeta\n';
     const chunks = [

--- a/electron/tests/unit/apply-patch-apply.test.ts
+++ b/electron/tests/unit/apply-patch-apply.test.ts
@@ -3,18 +3,88 @@ import {
   applyChunksToContent,
   ApplyPatchApplyError,
 } from '../../src/main/tools/filesystem/apply-patch-apply';
-import type { UpdateFileChunk } from '../../src/main/tools/filesystem/apply-patch-parser';
+import type { UpdateFileChunk, HunkLineOp } from '../../src/main/tools/filesystem/apply-patch-parser';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+/**
+ * Reconstruct ordered lineOps from parallel oldLines/newLines arrays.
+ * Used by the chunk() helper so tests can stay ergonomic. O(n²) is fine
+ * for the small arrays in unit tests.
+ */
+function deriveLineOps(oldLines: string[], newLines: string[]): HunkLineOp[] {
+  const ops: HunkLineOp[] = [];
+  let o = 0;
+  let n = 0;
+  while (o < oldLines.length && n < newLines.length) {
+    if (oldLines[o] === newLines[n]) {
+      ops.push({ kind: 'context', content: oldLines[o] });
+      o++;
+      n++;
+    } else {
+      // Find the next alignment point — a line that appears in both arrays
+      // at or after the current positions. Lines before it are removes (old)
+      // or adds (new).
+      let nextO = -1;
+      let nextN = -1;
+      for (let i = o + 1; i < oldLines.length; i++) {
+        for (let j = n; j < newLines.length; j++) {
+          if (oldLines[i] === newLines[j]) {
+            nextO = i;
+            nextN = j;
+            break;
+          }
+        }
+        if (nextO !== -1) break;
+      }
+      if (nextO === -1) {
+        while (o < oldLines.length) {
+          ops.push({ kind: 'remove', content: oldLines[o] });
+          o++;
+        }
+        while (n < newLines.length) {
+          ops.push({ kind: 'add', content: newLines[n] });
+          n++;
+        }
+      } else {
+        while (o < nextO) {
+          ops.push({ kind: 'remove', content: oldLines[o] });
+          o++;
+        }
+        while (n < nextN) {
+          ops.push({ kind: 'add', content: newLines[n] });
+          n++;
+        }
+      }
+    }
+  }
+  while (o < oldLines.length) {
+    ops.push({ kind: 'remove', content: oldLines[o] });
+    o++;
+  }
+  while (n < newLines.length) {
+    ops.push({ kind: 'add', content: newLines[n] });
+    n++;
+  }
+  return ops;
+}
+
 function chunk(overrides: Partial<UpdateFileChunk> = {}): UpdateFileChunk {
-  return {
+  const base: UpdateFileChunk = {
     changeContext: null,
+    lineOps: [],
     oldLines: [],
     newLines: [],
     isEndOfFile: false,
     ...overrides,
   };
+  // Test convenience: if the test sets oldLines/newLines directly (bypassing
+  // the parser), derive lineOps so the apply engine has the ordered ops it
+  // needs to preserve context-line whitespace.
+  if (base.lineOps.length === 0 && (base.oldLines.length > 0 || base.newLines.length > 0)) {
+    base.lineOps = deriveLineOps(base.oldLines, base.newLines);
+  }
+  return base;
 }
 
 // ── Happy path ─────────────────────────────────────────────────────────────
@@ -157,13 +227,107 @@ describe('applyChunksToContent', () => {
     );
   });
 
-  it('adds trailing newline to content without one', () => {
+  it('preserves absence of trailing newline (F7)', () => {
     const content = 'no\ntrailing\nnewline';
     const chunks = [
       chunk({ oldLines: ['trailing'], newLines: ['TRAILING'] }),
     ];
     expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'no\nTRAILING\nnewline',
+    );
+  });
+
+  it('preserves presence of trailing newline (F7)', () => {
+    const content = 'no\ntrailing\nnewline\n';
+    const chunks = [
+      chunk({ oldLines: ['trailing'], newLines: ['TRAILING'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
       'no\nTRAILING\nnewline\n',
+    );
+  });
+
+  it('preserves CRLF line endings across the whole file (F4)', () => {
+    const content = 'line1\r\nline2\r\nline3\r\n';
+    const chunks = [
+      chunk({ oldLines: ['line2'], newLines: ['LINE2'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'line1\r\nLINE2\r\nline3\r\n',
+    );
+  });
+
+  it('preserves file whitespace on context lines (F1)', () => {
+    // File has trailing spaces on a context line; the patch's context line
+    // lacks them. The file's version must be preserved in the output.
+    // lineOps must be set explicitly — deriveLineOps can't infer a context
+    // line when the patch's version differs from the file's in whitespace.
+    const content = 'hello   \nold\nworld\n';
+    const chunks = [
+      {
+        changeContext: null,
+        isEndOfFile: false,
+        lineOps: [
+          { kind: 'context', content: 'hello' },
+          { kind: 'remove', content: 'old' },
+          { kind: 'add', content: 'new' },
+          { kind: 'context', content: 'world' },
+        ],
+        oldLines: ['hello', 'old', 'world'],
+        newLines: ['hello', 'new', 'world'],
+      } as UpdateFileChunk,
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'hello   \nnew\nworld\n',
+    );
+  });
+
+  it('fails when *** End of File anchor does not match EOF (F2)', () => {
+    const content = 'aaa\nbbb\nccc\nddd\neee\n';
+    const chunks = [
+      chunk({ oldLines: ['bbb', 'ccc'], newLines: ['BBB', 'CCC'], isEndOfFile: true }),
+    ];
+    expect(() => applyChunksToContent(content, chunks, 'test.txt')).toThrow(
+      ApplyPatchApplyError,
+    );
+    expect(() => applyChunksToContent(content, chunks, 'test.txt')).toThrow(
+      'End of File anchor failed',
+    );
+  });
+
+  it('succeeds when *** End of File anchor matches EOF (F2)', () => {
+    const content = 'aaa\nbbb\nccc\nddd\neee\n';
+    const chunks = [
+      chunk({ oldLines: ['ddd', 'eee'], newLines: ['DDD', 'EEE'], isEndOfFile: true }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'aaa\nbbb\nccc\nDDD\nEEE\n',
+    );
+  });
+
+  it('errors on ambiguous match without @@ context header (F6)', () => {
+    const content = 'foo\nbar\nfoo\nbar\n';
+    const chunks = [
+      chunk({ oldLines: ['foo', 'bar'], newLines: ['FOO', 'BAR'] }),
+    ];
+    expect(() => applyChunksToContent(content, chunks, 'test.txt')).toThrow(
+      ApplyPatchApplyError,
+    );
+    expect(() => applyChunksToContent(content, chunks, 'test.txt')).toThrow(
+      'matches multiple locations',
+    );
+  });
+
+  it('does not error on ambiguous match when @@ context header is present (F6)', () => {
+    // With a @@ header, the context hint narrows the search position past
+    // the first 'foo', so the pattern matches only the second 'foo\nbar'
+    // unambiguously. The user attempted disambiguation; we honor the match.
+    const content = 'foo\nbar\nfoo\nbar\n';
+    const chunks = [
+      chunk({ changeContext: 'foo', oldLines: ['foo', 'bar'], newLines: ['FOO', 'BAR'] }),
+    ];
+    expect(applyChunksToContent(content, chunks, 'test.txt')).toBe(
+      'foo\nbar\nFOO\nBAR\n',
     );
   });
 

--- a/electron/tests/unit/apply-patch-match.test.ts
+++ b/electron/tests/unit/apply-patch-match.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   seekSequence,
+  seekSequenceWithMeta,
   findContextHint,
   normalizeUnicode,
 } from '../../src/main/tools/filesystem/apply-patch-match';
@@ -48,6 +49,27 @@ describe('seekSequence', () => {
     expect(seekSequence(lines, ['foo', 'bar'], 0, true)).toBe(2);
   });
 
+  it('returns null when eof anchor misses (no fallback)', () => {
+    const lines = ['target', 'a', 'b', 'c'];
+    expect(seekSequence(lines, ['target'], 0, true)).toBeNull();
+  });
+
+  it('reports ambiguity when multiple matches exist at winning tier', () => {
+    const lines = ['foo', 'bar', 'foo', 'bar'];
+    const result = seekSequenceWithMeta(lines, ['foo', 'bar'], 0, false);
+    expect(result).not.toBeNull();
+    expect(result!.index).toBe(0);
+    expect(result!.ambiguous).toBe(true);
+  });
+
+  it('reports no ambiguity when exactly one match at winning tier', () => {
+    const lines = ['a', 'b', 'c', 'd'];
+    const result = seekSequenceWithMeta(lines, ['b', 'c'], 0, false);
+    expect(result).not.toBeNull();
+    expect(result!.index).toBe(1);
+    expect(result!.ambiguous).toBe(false);
+  });
+
   it('matches a multi-line pattern correctly', () => {
     const lines = ['a', 'b', 'c', 'd', 'e'];
     expect(seekSequence(lines, ['b', 'c', 'd'], 0, false)).toBe(1);
@@ -74,11 +96,6 @@ describe('seekSequence', () => {
   it('skips earlier occurrences when start offset is set', () => {
     const lines = ['x', 'x', 'x'];
     expect(seekSequence(lines, ['x'], 1, false)).toBe(1);
-  });
-
-  it('falls back to searching from start when eof anchor misses', () => {
-    const lines = ['target', 'a', 'b', 'c'];
-    expect(seekSequence(lines, ['target'], 0, true)).toBe(0);
   });
 });
 

--- a/electron/tests/unit/apply-patch-match.test.ts
+++ b/electron/tests/unit/apply-patch-match.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  seekSequence,
+  findContextHint,
+  normalizeUnicode,
+} from '../../src/main/tools/filesystem/apply-patch-match';
+
+// ── seekSequence ───────────────────────────────────────────────────────────
+
+describe('seekSequence', () => {
+  it('finds an exact match at the correct index', () => {
+    const lines = ['foo', 'bar', 'baz'];
+    expect(seekSequence(lines, ['bar', 'baz'], 0, false)).toBe(1);
+  });
+
+  it('matches with trim-end ignoring trailing whitespace', () => {
+    const lines = ['foo   ', 'bar\t\t'];
+    expect(seekSequence(lines, ['foo', 'bar'], 0, false)).toBe(0);
+  });
+
+  it('matches with trim ignoring leading and trailing whitespace', () => {
+    const lines = ['    foo   ', '   bar\t'];
+    expect(seekSequence(lines, ['foo', 'bar'], 0, false)).toBe(0);
+  });
+
+  it('matches ASCII dash against en-dash via Unicode normalization', () => {
+    const lines = ['a\u{2013}b'];
+    expect(seekSequence(lines, ['a-b'], 0, false)).toBe(0);
+  });
+
+  it('matches ASCII single quote against curly quote via Unicode normalization', () => {
+    const lines = ['\u{2018}hello\u{2019}'];
+    expect(seekSequence(lines, ["'hello'"], 0, false)).toBe(0);
+  });
+
+  it('matches ASCII double quote against curly quote via Unicode normalization', () => {
+    const lines = ['\u{201C}hello\u{201D}'];
+    expect(seekSequence(lines, ['"hello"'], 0, false)).toBe(0);
+  });
+
+  it('matches ASCII space against non-breaking space via Unicode normalization', () => {
+    const lines = ['a\u{00A0}b'];
+    expect(seekSequence(lines, ['a b'], 0, false)).toBe(0);
+  });
+
+  it('anchors match to end of file when eof is true', () => {
+    const lines = ['foo', 'bar', 'foo', 'bar'];
+    expect(seekSequence(lines, ['foo', 'bar'], 0, true)).toBe(2);
+  });
+
+  it('matches a multi-line pattern correctly', () => {
+    const lines = ['a', 'b', 'c', 'd', 'e'];
+    expect(seekSequence(lines, ['b', 'c', 'd'], 0, false)).toBe(1);
+  });
+
+  it('returns start for an empty pattern', () => {
+    expect(seekSequence(['a', 'b'], [], 1, false)).toBe(1);
+  });
+
+  it('returns null when pattern is longer than lines', () => {
+    expect(seekSequence(['one'], ['a', 'b', 'c'], 0, false)).toBeNull();
+  });
+
+  it('returns null when no tier matches', () => {
+    const lines = ['alpha', 'beta'];
+    expect(seekSequence(lines, ['gamma'], 0, false)).toBeNull();
+  });
+
+  it('prefers exact match over trim match', () => {
+    const lines = ['  foo  ', 'foo'];
+    expect(seekSequence(lines, ['foo'], 0, false)).toBe(1);
+  });
+
+  it('skips earlier occurrences when start offset is set', () => {
+    const lines = ['x', 'x', 'x'];
+    expect(seekSequence(lines, ['x'], 1, false)).toBe(1);
+  });
+
+  it('falls back to searching from start when eof anchor misses', () => {
+    const lines = ['target', 'a', 'b', 'c'];
+    expect(seekSequence(lines, ['target'], 0, true)).toBe(0);
+  });
+});
+
+// ── findContextHint ────────────────────────────────────────────────────────
+
+describe('findContextHint', () => {
+  it('finds hint and returns index after it', () => {
+    const lines = ['header', '@@ context', 'body'];
+    expect(findContextHint(lines, '@@ context', 0)).toBe(2);
+  });
+
+  it('returns null when hint is not found', () => {
+    expect(findContextHint(['a', 'b'], 'missing', 0)).toBeNull();
+  });
+
+  it('tolerates whitespace differences in hint', () => {
+    const lines = ['  @@ context  '];
+    expect(findContextHint(lines, '@@ context', 0)).toBe(1);
+  });
+});
+
+// ── normalizeUnicode ───────────────────────────────────────────────────────
+
+describe('normalizeUnicode', () => {
+  it('trims and maps dashes', () => {
+    expect(normalizeUnicode('  \u{2014}  ')).toBe('-');
+  });
+
+  it('maps all dash variants', () => {
+    const dashes = '\u{2010}\u{2011}\u{2012}\u{2013}\u{2014}\u{2015}\u{2212}';
+    expect(normalizeUnicode(dashes)).toBe('-------');
+  });
+
+  it('maps single quotes', () => {
+    expect(normalizeUnicode('\u{2018}\u{2019}\u{201A}\u{201B}')).toBe("''''");
+  });
+
+  it('maps double quotes', () => {
+    expect(normalizeUnicode('\u{201C}\u{201D}\u{201E}\u{201F}')).toBe('""""');
+  });
+
+  it('maps space variants', () => {
+    expect(normalizeUnicode('a\u{00A0}\u{3000}b')).toBe('a  b');
+  });
+
+  it('leaves ASCII unchanged', () => {
+    expect(normalizeUnicode('  hello world  ')).toBe('hello world');
+  });
+});

--- a/electron/tests/unit/apply-patch-parser.test.ts
+++ b/electron/tests/unit/apply-patch-parser.test.ts
@@ -191,7 +191,7 @@ describe('@@ context hint', () => {
 // ── Happy path: stacked @@ hints ───────────────────────────────────────────
 
 describe('stacked @@ hints', () => {
-  it('should use the last hint as changeContext', () => {
+  it('should produce multiple chunks for stacked hints', () => {
     const patch = [
       '*** Begin Patch',
       '*** Update File: app.py',
@@ -205,10 +205,45 @@ describe('stacked @@ hints', () => {
     const result = parsePatch(patch);
     const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
 
-    expect(hunk.chunks).toHaveLength(1);
-    expect(hunk.chunks[0].changeContext).toBe('def bar():');
-    expect(hunk.chunks[0].oldLines).toEqual(['    pass']);
-    expect(hunk.chunks[0].newLines).toEqual(['    return 1']);
+    expect(hunk.chunks).toHaveLength(2);
+
+    expect(hunk.chunks[0].changeContext).toBe('class Foo');
+    expect(hunk.chunks[0].oldLines).toEqual([]);
+    expect(hunk.chunks[0].newLines).toEqual([]);
+
+    expect(hunk.chunks[1].changeContext).toBe('def bar():');
+    expect(hunk.chunks[1].oldLines).toEqual(['    pass']);
+    expect(hunk.chunks[1].newLines).toEqual(['    return 1']);
+  });
+
+  it('should produce three chunks for three stacked hints', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: app.py',
+      '@@ a',
+      '@@ b',
+      '@@ c',
+      '-x',
+      '+y',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+
+    expect(hunk.chunks).toHaveLength(3);
+
+    expect(hunk.chunks[0].changeContext).toBe('a');
+    expect(hunk.chunks[0].oldLines).toEqual([]);
+    expect(hunk.chunks[0].newLines).toEqual([]);
+
+    expect(hunk.chunks[1].changeContext).toBe('b');
+    expect(hunk.chunks[1].oldLines).toEqual([]);
+    expect(hunk.chunks[1].newLines).toEqual([]);
+
+    expect(hunk.chunks[2].changeContext).toBe('c');
+    expect(hunk.chunks[2].oldLines).toEqual(['x']);
+    expect(hunk.chunks[2].newLines).toEqual(['y']);
   });
 });
 

--- a/electron/tests/unit/apply-patch-parser.test.ts
+++ b/electron/tests/unit/apply-patch-parser.test.ts
@@ -479,6 +479,23 @@ describe('missing *** End Patch', () => {
       "The last line of the patch must be '*** End Patch'",
     );
   });
+
+  it('should reject an End Patch marker before the final line', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: first.txt',
+      '+first',
+      '*** End Patch',
+      '*** Add File: second.txt',
+      '+second',
+      '*** End Patch',
+    ].join('\n');
+
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+    expect(() => parsePatch(patch)).toThrow(
+      "'*** End Patch' must only appear as the last line of the patch",
+    );
+  });
 });
 
 // ── Error: empty update hunk ───────────────────────────────────────────────
@@ -505,6 +522,18 @@ describe('empty update hunk', () => {
 
   it('should throw ParseError for @@ with no lines before End Patch', () => {
     const patch = '*** Begin Patch\n*** Update File: file.txt\n@@\n*** End Patch';
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+    expect(() => parsePatch(patch)).toThrow('Update hunk does not contain any lines');
+  });
+
+  it('should throw ParseError for a dangling context hint', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.txt',
+      '@@ functionName',
+      '*** End Patch',
+    ].join('\n');
+
     expect(() => parsePatch(patch)).toThrow(ParseError);
     expect(() => parsePatch(patch)).toThrow('Update hunk does not contain any lines');
   });

--- a/electron/tests/unit/apply-patch-parser.test.ts
+++ b/electron/tests/unit/apply-patch-parser.test.ts
@@ -558,7 +558,7 @@ describe('invalid line in update hunk', () => {
     ].join('\n');
     expect(() => parsePatch(patch)).toThrow(ParseError);
     expect(() => parsePatch(patch)).toThrow(
-      "Expected update hunk to start with a @@ context marker, got: 'bad'",
+      "Invalid hunk line prefix 'b' in 'bad'",
     );
   });
 

--- a/electron/tests/unit/apply-patch-parser.test.ts
+++ b/electron/tests/unit/apply-patch-parser.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePatch,
+  ParseError,
+  BEGIN_PATCH_MARKER,
+  END_PATCH_MARKER,
+  ADD_FILE_MARKER,
+  DELETE_FILE_MARKER,
+  UPDATE_FILE_MARKER,
+  MOVE_TO_MARKER,
+  EOF_MARKER,
+  CHANGE_CONTEXT_MARKER,
+  EMPTY_CHANGE_CONTEXT_MARKER,
+} from '../../src/main/tools/filesystem/apply-patch-parser';
+import type { PatchHunk } from '../../src/main/tools/filesystem/apply-patch-parser';
+
+// ── Marker constants ───────────────────────────────────────────────────────
+
+describe('marker constants', () => {
+  it('should export all marker constants', () => {
+    expect(BEGIN_PATCH_MARKER).toBe('*** Begin Patch');
+    expect(END_PATCH_MARKER).toBe('*** End Patch');
+    expect(ADD_FILE_MARKER).toBe('*** Add File: ');
+    expect(DELETE_FILE_MARKER).toBe('*** Delete File: ');
+    expect(UPDATE_FILE_MARKER).toBe('*** Update File: ');
+    expect(MOVE_TO_MARKER).toBe('*** Move to: ');
+    expect(EOF_MARKER).toBe('*** End of File');
+    expect(CHANGE_CONTEXT_MARKER).toBe('@@ ');
+    expect(EMPTY_CHANGE_CONTEXT_MARKER).toBe('@@');
+  });
+});
+
+// ── Happy path: multi-file patch ───────────────────────────────────────────
+
+describe('multi-file patch', () => {
+  it('should parse Add, Update (with chunks), and Delete hunks', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: path/add.py',
+      '+abc',
+      '+def',
+      '*** Delete File: path/delete.py',
+      '*** Update File: path/update.py',
+      '*** Move to: path/update2.py',
+      '@@ def f():',
+      '-    pass',
+      '+    return 123',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+
+    expect(result.hunks).toHaveLength(3);
+
+    const addHunk = result.hunks[0] as Extract<PatchHunk, { type: 'add' }>;
+    expect(addHunk.type).toBe('add');
+    expect(addHunk.path).toBe('path/add.py');
+    expect(addHunk.contents).toBe('abc\ndef\n');
+
+    const deleteHunk = result.hunks[1] as Extract<PatchHunk, { type: 'delete' }>;
+    expect(deleteHunk.type).toBe('delete');
+    expect(deleteHunk.path).toBe('path/delete.py');
+
+    const updateHunk = result.hunks[2] as Extract<PatchHunk, { type: 'update' }>;
+    expect(updateHunk.type).toBe('update');
+    expect(updateHunk.path).toBe('path/update.py');
+    expect(updateHunk.movePath).toBe('path/update2.py');
+    expect(updateHunk.chunks).toHaveLength(1);
+    expect(updateHunk.chunks[0].changeContext).toBe('def f():');
+    expect(updateHunk.chunks[0].oldLines).toEqual(['    pass']);
+    expect(updateHunk.chunks[0].newLines).toEqual(['    return 123']);
+    expect(updateHunk.chunks[0].isEndOfFile).toBe(false);
+  });
+
+  it('should return the normalized patch string', () => {
+    const patch = '*** Begin Patch\n*** Add File: foo\n+hi\n*** End Patch';
+    const result = parsePatch(patch);
+    expect(result.patch).toBe(patch);
+  });
+});
+
+// ── Happy path: Move to ────────────────────────────────────────────────────
+
+describe('update with Move to', () => {
+  it('should populate movePath', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/old.rs',
+      '*** Move to: src/new.rs',
+      '@@',
+      '-old',
+      '+new',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+
+    expect(hunk.path).toBe('src/old.rs');
+    expect(hunk.movePath).toBe('src/new.rs');
+  });
+
+  it('should set movePath to null when no Move to marker', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.py',
+      '@@',
+      '-old',
+      '+new',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(hunk.movePath).toBeNull();
+  });
+});
+
+// ── Happy path: multiple @@ chunks ─────────────────────────────────────────
+
+describe('multiple @@ chunks', () => {
+  it('should parse chunks in order', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/config.rs',
+      '@@ impl Config',
+      '-    pub apply_patch_progress: bool,',
+      '+    pub stream_apply_patch_progress: bool,',
+      '     pub include_diagnostics: bool,',
+      '@@ fn default_progress_interval()',
+      '-    Duration::from_millis(500)',
+      '+    Duration::from_millis(250)',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+
+    expect(hunk.chunks).toHaveLength(2);
+
+    expect(hunk.chunks[0].changeContext).toBe('impl Config');
+    expect(hunk.chunks[0].oldLines).toEqual([
+      '    pub apply_patch_progress: bool,',
+      '    pub include_diagnostics: bool,',
+    ]);
+    expect(hunk.chunks[0].newLines).toEqual([
+      '    pub stream_apply_patch_progress: bool,',
+      '    pub include_diagnostics: bool,',
+    ]);
+
+    expect(hunk.chunks[1].changeContext).toBe('fn default_progress_interval()');
+    expect(hunk.chunks[1].oldLines).toEqual(['    Duration::from_millis(500)']);
+    expect(hunk.chunks[1].newLines).toEqual(['    Duration::from_millis(250)']);
+  });
+});
+
+// ── Happy path: @@ context hint ────────────────────────────────────────────
+
+describe('@@ context hint', () => {
+  it('should populate changeContext from @@ hint', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: app.py',
+      '@@ class Foo',
+      '-    x = 1',
+      '+    x = 2',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(hunk.chunks[0].changeContext).toBe('class Foo');
+  });
+
+  it('should set changeContext to null for bare @@', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: app.py',
+      '@@',
+      '-old',
+      '+new',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(hunk.chunks[0].changeContext).toBeNull();
+  });
+});
+
+// ── Happy path: stacked @@ hints ───────────────────────────────────────────
+
+describe('stacked @@ hints', () => {
+  it('should use the last hint as changeContext', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: app.py',
+      '@@ class Foo',
+      '@@ def bar():',
+      '-    pass',
+      '+    return 1',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+
+    expect(hunk.chunks).toHaveLength(1);
+    expect(hunk.chunks[0].changeContext).toBe('def bar():');
+    expect(hunk.chunks[0].oldLines).toEqual(['    pass']);
+    expect(hunk.chunks[0].newLines).toEqual(['    return 1']);
+  });
+});
+
+// ── Happy path: End of File ────────────────────────────────────────────────
+
+describe('*** End of File', () => {
+  it('should set isEndOfFile true on the current chunk', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.txt',
+      '@@',
+      '+quux',
+      '*** End of File',
+      '',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(hunk.chunks[0].isEndOfFile).toBe(true);
+    expect(hunk.chunks[0].newLines).toEqual(['quux']);
+  });
+});
+
+// ── Happy path: Add File contents ──────────────────────────────────────────
+
+describe('Add File with + lines', () => {
+  it('should join contents with trailing newline', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: hello.txt',
+      '+Hello',
+      '+world',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'add' }>;
+    expect(hunk.contents).toBe('Hello\nworld\n');
+  });
+
+  it('should handle single + line', () => {
+    const patch = '*** Begin Patch\n*** Add File: foo\n+hi\n*** End Patch';
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'add' }>;
+    expect(hunk.contents).toBe('hi\n');
+  });
+});
+
+// ── Edge case: empty patch ─────────────────────────────────────────────────
+
+describe('empty patch', () => {
+  it('should return empty hunks array', () => {
+    const patch = '*** Begin Patch\n*** End Patch';
+    const result = parsePatch(patch);
+    expect(result.hunks).toEqual([]);
+  });
+});
+
+// ── Edge case: heredoc stripping ───────────────────────────────────────────
+
+describe('heredoc stripping', () => {
+  const innerPatch = [
+    '*** Begin Patch',
+    '*** Update File: file2.py',
+    ' import foo',
+    '+bar',
+    '*** End Patch',
+  ].join('\n');
+
+  it('should strip <<EOF wrapper', () => {
+    const wrapped = `<<EOF\n${innerPatch}\nEOF`;
+    const result = parsePatch(wrapped);
+    expect(result.hunks).toHaveLength(1);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(hunk.path).toBe('file2.py');
+  });
+
+  it("should strip <<'EOF' wrapper", () => {
+    const wrapped = `<<'EOF'\n${innerPatch}\nEOF`;
+    const result = parsePatch(wrapped);
+    expect(result.hunks).toHaveLength(1);
+  });
+
+  it('should strip <<"EOF" wrapper', () => {
+    const wrapped = `<<"EOF"\n${innerPatch}\nEOF`;
+    const result = parsePatch(wrapped);
+    expect(result.hunks).toHaveLength(1);
+  });
+
+  it('should not strip heredoc with fewer than 4 lines', () => {
+    const short = '<<EOF\n*** Begin Patch\nEOF';
+    expect(() => parsePatch(short)).toThrow(ParseError);
+  });
+});
+
+// ── Edge case: implicit chunk (no @@ header) ───────────────────────────────
+
+describe('implicit chunk without @@ header', () => {
+  it('should create implicit chunk with null changeContext', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file2.py',
+      ' import foo',
+      '+bar',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+
+    expect(hunk.chunks).toHaveLength(1);
+    expect(hunk.chunks[0].changeContext).toBeNull();
+    expect(hunk.chunks[0].oldLines).toEqual(['import foo']);
+    expect(hunk.chunks[0].newLines).toEqual(['import foo', 'bar']);
+  });
+});
+
+// ── Edge case: context lines ───────────────────────────────────────────────
+
+describe('context lines', () => {
+  it('should add space-prefixed lines to both oldLines and newLines', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.py',
+      '@@',
+      ' context before',
+      '-removed',
+      '+added',
+      ' context after',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    const chunk = hunk.chunks[0];
+
+    expect(chunk.oldLines).toEqual(['context before', 'removed', 'context after']);
+    expect(chunk.newLines).toEqual(['context before', 'added', 'context after']);
+  });
+
+  it('should handle bare empty lines as empty context lines', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.txt',
+      '@@',
+      ' context before',
+      '',
+      ' context after',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    const chunk = hunk.chunks[0];
+
+    expect(chunk.oldLines).toEqual(['context before', '', 'context after']);
+    expect(chunk.newLines).toEqual(['context before', '', 'context after']);
+  });
+});
+
+// ── Edge case: update hunk followed by another hunk ────────────────────────
+
+describe('update hunk followed by another hunk', () => {
+  it('should finalize update and start new hunk', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.py',
+      '@@',
+      '+line',
+      '*** Add File: other.py',
+      '+content',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    expect(result.hunks).toHaveLength(2);
+
+    const updateHunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(updateHunk.type).toBe('update');
+    expect(updateHunk.chunks[0].newLines).toEqual(['line']);
+
+    const addHunk = result.hunks[1] as Extract<PatchHunk, { type: 'add' }>;
+    expect(addHunk.type).toBe('add');
+    expect(addHunk.contents).toBe('content\n');
+  });
+});
+
+// ── Edge case: indented update markers as context ──────────────────────────
+
+describe('indented update markers', () => {
+  it('should treat indented *** Update File as context line', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: a.txt',
+      '@@',
+      '-old a',
+      '+new a',
+      ' *** Update File: b.txt',
+      '@@',
+      '-old b',
+      '+new b',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = parsePatch(patch);
+    expect(result.hunks).toHaveLength(1);
+
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(hunk.chunks).toHaveLength(2);
+    expect(hunk.chunks[0].oldLines).toEqual(['old a', '*** Update File: b.txt']);
+    expect(hunk.chunks[0].newLines).toEqual(['new a', '*** Update File: b.txt']);
+  });
+});
+
+// ── Error: missing Begin Patch ─────────────────────────────────────────────
+
+describe('missing *** Begin Patch', () => {
+  it('should throw ParseError', () => {
+    expect(() => parsePatch('bad')).toThrow(ParseError);
+    expect(() => parsePatch('bad')).toThrow(
+      "The first line of the patch must be '*** Begin Patch'",
+    );
+  });
+});
+
+// ── Error: missing End Patch ───────────────────────────────────────────────
+
+describe('missing *** End Patch', () => {
+  it('should throw ParseError', () => {
+    expect(() => parsePatch('*** Begin Patch\nbad')).toThrow(ParseError);
+    expect(() => parsePatch('*** Begin Patch\nbad')).toThrow(
+      "The last line of the patch must be '*** End Patch'",
+    );
+  });
+});
+
+// ── Error: empty update hunk ───────────────────────────────────────────────
+
+describe('empty update hunk', () => {
+  it('should throw ParseError for update with no chunks', () => {
+    const patch = '*** Begin Patch\n*** Update File: test.py\n*** End Patch';
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+    expect(() => parsePatch(patch)).toThrow(
+      "Update file hunk for path 'test.py' is empty",
+    );
+  });
+
+  it('should throw ParseError for update with Move to but no chunks', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: old.txt',
+      '*** Move to: new.txt',
+      '*** Delete File: other.txt',
+      '*** End Patch',
+    ].join('\n');
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+  });
+
+  it('should throw ParseError for @@ with no lines before End Patch', () => {
+    const patch = '*** Begin Patch\n*** Update File: file.txt\n@@\n*** End Patch';
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+    expect(() => parsePatch(patch)).toThrow('Update hunk does not contain any lines');
+  });
+});
+
+// ── Error: mismatched heredoc quotes ───────────────────────────────────────
+
+describe('mismatched heredoc quotes', () => {
+  it('should throw ParseError (not stripped)', () => {
+    const innerPatch = [
+      '*** Begin Patch',
+      '*** Update File: file2.py',
+      ' import foo',
+      '+bar',
+      '*** End Patch',
+    ].join('\n');
+    const wrapped = `<<"EOF'\n${innerPatch}\nEOF`;
+
+    expect(() => parsePatch(wrapped)).toThrow(ParseError);
+    expect(() => parsePatch(wrapped)).toThrow(
+      "The first line of the patch must be '*** Begin Patch'",
+    );
+  });
+});
+
+// ── Error: invalid lines in add/delete mode ────────────────────────────────
+
+describe('invalid lines in add/delete mode', () => {
+  it('should throw for non-+ line in Add File', () => {
+    const patch = '*** Begin Patch\n*** Add File: file.txt\nbad\n*** End Patch';
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+  });
+
+  it('should throw for any line after Delete File', () => {
+    const patch = '*** Begin Patch\n*** Delete File: file.txt\nbad\n*** End Patch';
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+  });
+});
+
+// ── Error: invalid line in update hunk ─────────────────────────────────────
+
+describe('invalid line in update hunk', () => {
+  it('should throw for unrecognized line after change lines', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.txt',
+      '@@',
+      '-old',
+      'bad',
+      '*** End Patch',
+    ].join('\n');
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+    expect(() => parsePatch(patch)).toThrow(
+      "Expected update hunk to start with a @@ context marker, got: 'bad'",
+    );
+  });
+
+  it('should throw for consecutive @@ with empty chunk between', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: file.txt',
+      '@@',
+      '@@',
+      '*** End Patch',
+    ].join('\n');
+    expect(() => parsePatch(patch)).toThrow(ParseError);
+  });
+});
+
+// ── Edge case: CRLF handling ───────────────────────────────────────────────
+
+describe('CRLF handling', () => {
+  it('should strip trailing \\r from lines', () => {
+    const patch = '*** Begin Patch\r\n*** Update File: file.txt\r\n@@\r\n-old\r\n+new\r\n*** End Patch\r\n';
+    const result = parsePatch(patch);
+    const hunk = result.hunks[0] as Extract<PatchHunk, { type: 'update' }>;
+    expect(hunk.chunks[0].oldLines).toEqual(['old']);
+    expect(hunk.chunks[0].newLines).toEqual(['new']);
+  });
+});
+
+// ── Edge case: leading/trailing whitespace on boundaries ───────────────────
+
+describe('whitespace on boundaries', () => {
+  it('should trim boundary markers', () => {
+    const patch = ' *** Begin Patch \n*** Add File: foo\n+hi\n *** End Patch ';
+    const result = parsePatch(patch);
+    expect(result.hunks).toHaveLength(1);
+  });
+});
+
+// ── ParseError properties ──────────────────────────────────────────────────
+
+describe('ParseError', () => {
+  it('should have correct name and lineNumber', () => {
+    try {
+      parsePatch('*** Begin Patch\n*** Update File: test.py\n*** End Patch');
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ParseError);
+      const err = e as ParseError;
+      expect(err.name).toBe('ParseError');
+      expect(err.lineNumber).toBe(2);
+    }
+  });
+});

--- a/electron/tests/unit/apply-patch.test.ts
+++ b/electron/tests/unit/apply-patch.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { applyPatchHandler } from '../../src/main/tools/filesystem/apply-patch';
+import { applyPatchHandler, applyPatchDefinition } from '../../src/main/tools/filesystem/apply-patch';
 import type { ToolExecutionContext } from '../../src/main/tools/types';
 import type { ApplyPatchResultData } from '../../src/shared/types/tool-result-apply-patch';
+import type { CanonicalToolResult } from '../../src/shared/types/tool-result';
+import type { FileChangeData } from '../../src/shared/types/tool-result-filesystem';
 
 let tmpDir: string;
 
@@ -247,5 +249,284 @@ describe('apply_patch handler', () => {
     if (result.status === 'error') {
       expect(result.error.code).toBe('parse_error');
     }
+  });
+
+  it('move-path traversal leaves source unchanged', async () => {
+    writeFile('source.ts', 'const x = 1;\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: source.ts',
+      '*** Move to: ../../outside.ts',
+      '@@',
+      '-const x = 1;',
+      '+const x = 2;',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('path_traversal');
+    expect(readFile('source.ts')).toBe('const x = 1;\n');
+    expect(fs.existsSync(path.join(tmpDir, '..', 'outside.ts'))).toBe(false);
+  });
+
+  it('move-path absolute path leaves source unchanged', async () => {
+    writeFile('source.ts', 'const x = 1;\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: source.ts',
+      '*** Move to: /tmp/evil.ts',
+      '@@',
+      '-const x = 1;',
+      '+const x = 2;',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('path_traversal');
+    expect(readFile('source.ts')).toBe('const x = 1;\n');
+  });
+
+  it('add file onto existing file fails with already_exists', async () => {
+    writeFile('target.ts', 'original content\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: target.ts',
+      '+overwritten content',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('already_exists');
+    expect(readFile('target.ts')).toBe('original content\n');
+  });
+});
+
+describe('apply_patch agentProjector', () => {
+  const projector = applyPatchDefinition.agentProjector!;
+
+  function canonical(data: ApplyPatchResultData, status: 'complete' | 'error' = 'complete'): CanonicalToolResult {
+    return {
+      schemaVersion: 1,
+      family: 'generic',
+      status,
+      completeness: 'complete',
+      data,
+    };
+  }
+
+  function fileChange(overrides: Partial<FileChangeData> & { hunks: FileChangeData['hunks'] }): FileChangeData {
+    return {
+      path: 'file.ts',
+      operation: 'update',
+      addedLines: 0,
+      removedLines: 0,
+      resultingContent: '',
+      ...overrides,
+    };
+  }
+
+  it('renders mixed success/error multi-file result', () => {
+    const data: ApplyPatchResultData = {
+      files: [
+        {
+          path: 'new.ts',
+          operation: 'create',
+          status: 'complete',
+          fileChange: fileChange({
+            path: 'new.ts',
+            operation: 'create',
+            addedLines: 1,
+            hunks: [{ oldStart: 0, oldLines: 0, newStart: 1, newLines: 1, lines: [{ kind: 'add', content: 'export const x = 1;', newLineNumber: 1 }] }],
+            resultingContent: 'export const x = 1;\n',
+          }),
+        },
+        {
+          path: 'src/app.ts',
+          operation: 'update',
+          status: 'complete',
+          fileChange: fileChange({
+            path: 'src/app.ts',
+            operation: 'update',
+            addedLines: 1,
+            removedLines: 1,
+            hunks: [{
+              oldStart: 1, oldLines: 3, newStart: 1, newLines: 3,
+              lines: [
+                { kind: 'context', content: 'import { a } from "./a";', oldLineNumber: 1, newLineNumber: 1 },
+                { kind: 'remove', content: 'const old = true;', oldLineNumber: 2 },
+                { kind: 'add', content: 'const updated = true;', newLineNumber: 2 },
+                { kind: 'context', content: 'export default old;', oldLineNumber: 3, newLineNumber: 3 },
+              ],
+            }],
+            resultingContent: 'import { a } from "./a";\nconst updated = true;\nexport default old;\n',
+          }),
+        },
+        {
+          path: 'bad.ts',
+          operation: 'update',
+          status: 'error',
+          error: { code: 'match_failed', message: 'Could not match hunk' },
+        },
+      ],
+      added: 1,
+      modified: 1,
+      deleted: 0,
+      failed: 1,
+    };
+
+    const result = projector(canonical(data));
+
+    expect(result.content).toContain('<tool_result name="apply_patch"');
+    expect(result.content).toContain('<file path="new.ts" operation="create" status="complete"');
+    expect(result.content).toContain('<file path="src/app.ts" operation="update" status="complete"');
+    expect(result.content).toContain('<file path="bad.ts" operation="update" status="error"');
+    expect(result.content).toContain('<error code="match_failed"');
+    expect(result.content).toContain('3 files');
+    expect(result.content).toContain('1 failed');
+  });
+
+  it('renders move_path attribute', () => {
+    const data: ApplyPatchResultData = {
+      files: [
+        {
+          path: 'old.ts',
+          operation: 'update',
+          status: 'complete',
+          movePath: 'new-location.ts',
+          fileChange: fileChange({
+            path: 'old.ts',
+            operation: 'update',
+            addedLines: 1,
+            removedLines: 1,
+            hunks: [{
+              oldStart: 1, oldLines: 1, newStart: 1, newLines: 1,
+              lines: [
+                { kind: 'remove', content: 'const a = 1;', oldLineNumber: 1 },
+                { kind: 'add', content: 'const a = 2;', newLineNumber: 1 },
+              ],
+            }],
+            resultingContent: 'const a = 2;\n',
+          }),
+        },
+      ],
+      added: 0,
+      modified: 1,
+      deleted: 0,
+      failed: 0,
+    };
+
+    const result = projector(canonical(data));
+
+    expect(result.content).toContain('move_path="new-location.ts"');
+  });
+
+  it('renders delete-only result with empty file body', () => {
+    const data: ApplyPatchResultData = {
+      files: [
+        { path: 'obsolete.txt', operation: 'delete', status: 'complete' },
+      ],
+      added: 0,
+      modified: 0,
+      deleted: 1,
+      failed: 0,
+    };
+
+    const result = projector(canonical(data));
+
+    expect(result.content).toContain('<file path="obsolete.txt" operation="delete" status="complete"');
+    expect(result.content).toContain('<file path="obsolete.txt" operation="delete" status="complete">\n</file>');
+    expect(result.content).not.toContain('<old_string>');
+    expect(result.content).not.toContain('<new_string>');
+  });
+
+  it('omits failed attribute when failed=0', () => {
+    const data: ApplyPatchResultData = {
+      files: [
+        { path: 'a.ts', operation: 'create', status: 'complete' },
+        { path: 'b.ts', operation: 'delete', status: 'complete' },
+      ],
+      added: 1,
+      modified: 0,
+      deleted: 1,
+      failed: 0,
+    };
+
+    const result = projector(canonical(data));
+
+    expect(result.content).not.toContain('failed=');
+  });
+
+  it('escapes XML metacharacters in paths', () => {
+    const data: ApplyPatchResultData = {
+      files: [
+        { path: 'src/say "hi" & <bye>.ts', operation: 'delete', status: 'complete' },
+      ],
+      added: 0,
+      modified: 0,
+      deleted: 1,
+      failed: 0,
+    };
+
+    const result = projector(canonical(data));
+
+    expect(result.content).toContain('&quot;');
+    expect(result.content).toContain('&amp;');
+    expect(result.content).toContain('&lt;');
+    expect(result.content).not.toContain('path="src/say "hi"');
+    expect(result.content).not.toContain('<bye>');
+  });
+
+  it('renders old_string/new_string from hunks', () => {
+    const data: ApplyPatchResultData = {
+      files: [
+        {
+          path: 'src/util.ts',
+          operation: 'update',
+          status: 'complete',
+          fileChange: fileChange({
+            path: 'src/util.ts',
+            operation: 'update',
+            addedLines: 1,
+            removedLines: 1,
+            hunks: [{
+              oldStart: 10, oldLines: 4, newStart: 10, newLines: 4,
+              lines: [
+                { kind: 'context', content: 'function greet() {', oldLineNumber: 10, newLineNumber: 10 },
+                { kind: 'remove', content: '  return "hi";', oldLineNumber: 11 },
+                { kind: 'add', content: '  return "hello";', newLineNumber: 11 },
+                { kind: 'context', content: '}', oldLineNumber: 12, newLineNumber: 12 },
+              ],
+            }],
+            resultingContent: '',
+          }),
+        },
+      ],
+      added: 0,
+      modified: 1,
+      deleted: 0,
+      failed: 0,
+    };
+
+    const result = projector(canonical(data));
+
+    expect(result.content).toContain('<old_string>');
+    expect(result.content).toContain('function greet() {\n  return "hi";\n}');
+    expect(result.content).toContain('<new_string>');
+    expect(result.content).toContain('function greet() {\n  return "hello";\n}');
   });
 });

--- a/electron/tests/unit/apply-patch.test.ts
+++ b/electron/tests/unit/apply-patch.test.ts
@@ -251,6 +251,43 @@ describe('apply_patch handler', () => {
     }
   });
 
+  it('rejects a premature End Patch marker before creating any files', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: first.txt',
+      '+first',
+      '*** End Patch',
+      '*** Add File: second.txt',
+      '+second',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('error');
+    if (result.status === 'error') {
+      expect(result.error.code).toBe('parse_error');
+    }
+    expect(fs.existsSync(path.join(tmpDir, 'first.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, 'second.txt'))).toBe(false);
+  });
+
+  it('rejects Windows absolute paths with path_traversal error', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: C:\\repo\\evil.conf',
+      '+malicious',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('path_traversal');
+  });
+
   it('move-path traversal leaves source unchanged', async () => {
     writeFile('source.ts', 'const x = 1;\n');
 
@@ -281,6 +318,28 @@ describe('apply_patch handler', () => {
       '*** Begin Patch',
       '*** Update File: source.ts',
       '*** Move to: /tmp/evil.ts',
+      '@@',
+      '-const x = 1;',
+      '+const x = 2;',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('path_traversal');
+    expect(readFile('source.ts')).toBe('const x = 1;\n');
+  });
+
+  it('Windows absolute move path leaves source unchanged', async () => {
+    writeFile('source.ts', 'const x = 1;\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: source.ts',
+      '*** Move to: C:\\repo\\evil.ts',
       '@@',
       '-const x = 1;',
       '+const x = 2;',

--- a/electron/tests/unit/apply-patch.test.ts
+++ b/electron/tests/unit/apply-patch.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { applyPatchHandler } from '../../src/main/tools/filesystem/apply-patch';
+import type { ToolExecutionContext } from '../../src/main/tools/types';
+import type { ApplyPatchResultData } from '../../src/shared/types/tool-result-apply-patch';
+
+let tmpDir: string;
+
+function toolCtx(): ToolExecutionContext {
+  return { cwd: tmpDir };
+}
+
+function writeFile(relPath: string, content: string): string {
+  const fullPath = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf-8');
+  return fullPath;
+}
+
+function readFile(relPath: string): string {
+  return fs.readFileSync(path.join(tmpDir, relPath), 'utf-8');
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'apply-patch-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('apply_patch handler', () => {
+  it('applies a single-file update', async () => {
+    writeFile('hello.ts', 'const a = 1;\nconst b = 2;\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: hello.ts',
+      '@@',
+      '-const a = 1;',
+      '+const a = 42;',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.modified).toBe(1);
+    expect(data.added).toBe(0);
+    expect(data.deleted).toBe(0);
+    expect(data.failed).toBe(0);
+    expect(readFile('hello.ts')).toBe('const a = 42;\nconst b = 2;\n');
+  });
+
+  it('applies a multi-file patch (add + update + delete)', async () => {
+    writeFile('existing.ts', 'old content\n');
+    writeFile('remove-me.txt', 'delete this\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: new-file.ts',
+      '+export const x = 1;',
+      '*** Update File: existing.ts',
+      '@@',
+      '-old content',
+      '+new content',
+      '*** Delete File: remove-me.txt',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.added).toBe(1);
+    expect(data.modified).toBe(1);
+    expect(data.deleted).toBe(1);
+    expect(data.failed).toBe(0);
+    expect(readFile('new-file.ts')).toBe('export const x = 1;\n');
+    expect(readFile('existing.ts')).toBe('new content\n');
+    expect(fs.existsSync(path.join(tmpDir, 'remove-me.txt'))).toBe(false);
+  });
+
+  it('renames a file via *** Move to:', async () => {
+    writeFile('old-name.ts', 'const val = 1;\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: old-name.ts',
+      '*** Move to: new-name.ts',
+      '@@',
+      '-const val = 1;',
+      '+const val = 2;',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.modified).toBe(1);
+    expect(data.files[0].movePath).toBe('new-name.ts');
+    expect(fs.existsSync(path.join(tmpDir, 'old-name.ts'))).toBe(false);
+    expect(readFile('new-name.ts')).toBe('const val = 2;\n');
+  });
+
+  it('creates parent directories for added files', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: deep/nested/dir/file.ts',
+      '+export const deep = true;',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    expect(readFile('deep/nested/dir/file.ts')).toBe('export const deep = true;\n');
+  });
+
+  it('returns error for a patch with no hunks', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('error');
+    if (result.status === 'error') {
+      expect(result.error.code).toBe('empty_patch');
+    }
+  });
+
+  it('returns per-file error for updating a nonexistent file', async () => {
+    writeFile('exists.ts', 'content\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: missing.ts',
+      '@@',
+      '-foo',
+      '+bar',
+      '*** Update File: exists.ts',
+      '@@',
+      '-content',
+      '+updated',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.modified).toBe(1);
+    expect(data.files[0].status).toBe('error');
+    expect(data.files[1].status).toBe('complete');
+    expect(readFile('exists.ts')).toBe('updated\n');
+  });
+
+  it('returns per-file error for deleting a nonexistent file', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Delete File: ghost.txt',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].status).toBe('error');
+    expect(data.files[0].error?.code).toBe('not_found');
+  });
+
+  it('reports match failure for one file while others succeed', async () => {
+    writeFile('good.ts', 'alpha\nbeta\n');
+    writeFile('bad.ts', 'one\ntwo\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: bad.ts',
+      '@@',
+      '-THIS DOES NOT EXIST',
+      '+replacement',
+      '*** Update File: good.ts',
+      '@@',
+      '-alpha',
+      '+omega',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.modified).toBe(1);
+    expect(data.files[0].error?.code).toBe('match_failed');
+    expect(readFile('good.ts')).toBe('omega\nbeta\n');
+    expect(readFile('bad.ts')).toBe('one\ntwo\n');
+  });
+
+  it('rejects absolute paths with path_traversal error', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: /etc/evil.conf',
+      '+malicious',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('path_traversal');
+  });
+
+  it('rejects ../../ traversal with path_traversal error', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: ../../etc/passwd',
+      '+root:x:0:0',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('path_traversal');
+  });
+
+  it('returns error for invalid patch syntax', async () => {
+    const patch = 'this is not a valid patch at all';
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('error');
+    if (result.status === 'error') {
+      expect(result.error.code).toBe('parse_error');
+    }
+  });
+});

--- a/electron/tests/unit/apply-patch.test.ts
+++ b/electron/tests/unit/apply-patch.test.ts
@@ -314,6 +314,210 @@ describe('apply_patch handler', () => {
     expect(data.files[0].error?.code).toBe('already_exists');
     expect(readFile('target.ts')).toBe('original content\n');
   });
+
+  // ── F-tests from the comprehensive test report ─────────────────────────
+
+  it('F3: updating a symlink patches the target, preserves the symlink', async () => {
+    // Create a real target file and a symlink pointing to it.
+    const targetPath = path.join(tmpDir, 'real.txt');
+    const linkPath = path.join(tmpDir, 'link.txt');
+    fs.writeFileSync(targetPath, 'line1\nold\nline3\n', 'utf-8');
+    fs.symlinkSync(targetPath, linkPath);
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: link.txt',
+      '@@',
+      '-old',
+      '+new',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.modified).toBe(1);
+    // Symlink is preserved.
+    expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    // Target file has the patched content.
+    expect(fs.readFileSync(targetPath, 'utf-8')).toBe('line1\nnew\nline3\n');
+  });
+
+  it('F5: Move to existing destination fails with move_target_exists', async () => {
+    writeFile('source.ts', 'const x = 1;\n');
+    writeFile('dest.ts', 'existing content\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: source.ts',
+      '*** Move to: dest.ts',
+      '@@',
+      '-const x = 1;',
+      '+const x = 2;',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('move_target_exists');
+    // Both files are unchanged.
+    expect(readFile('source.ts')).toBe('const x = 1;\n');
+    expect(readFile('dest.ts')).toBe('existing content\n');
+  });
+
+  it('F9: no-op hunk (context only) does not increment modified', async () => {
+    writeFile('ctx.txt', 'aaa\nbbb\nccc\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: ctx.txt',
+      '@@',
+      ' aaa',
+      ' bbb',
+      ' ccc',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.modified).toBe(0);
+    expect(data.failed).toBe(0);
+    expect(data.files[0].status).toBe('complete');
+    // File content is unchanged.
+    expect(readFile('ctx.txt')).toBe('aaa\nbbb\nccc\n');
+  });
+
+  it('F10: Add File with trailing slash fails with invalid_path', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: dir/',
+      '+content',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('invalid_path');
+  });
+
+  it('F2: *** End of File anchor enforced — fails when match is not at EOF', async () => {
+    writeFile('f.txt', 'aaa\nbbb\nccc\nddd\neee\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: f.txt',
+      '@@',
+      '-bbb',
+      '-ccc',
+      '+BBB',
+      '+CCC',
+      '*** End of File',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('match_failed');
+    expect(data.files[0].error?.message).toContain('End of File anchor failed');
+  });
+
+  it('F6: ambiguous hunk without @@ fails with match_failed', async () => {
+    writeFile('amb.txt', 'foo\nbar\nfoo\nbar\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: amb.txt',
+      '-foo',
+      '-bar',
+      '+FOO',
+      '+BAR',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.failed).toBe(1);
+    expect(data.files[0].error?.code).toBe('match_failed');
+    expect(data.files[0].error?.message).toContain('matches multiple locations');
+  });
+
+  it('F4: CRLF line endings preserved across the whole file', async () => {
+    writeFile('crlf.txt', 'line1\r\nline2\r\nline3\r\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: crlf.txt',
+      '@@',
+      '-line2',
+      '+LINE2',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.modified).toBe(1);
+    expect(readFile('crlf.txt')).toBe('line1\r\nLINE2\r\nline3\r\n');
+  });
+
+  it('F7: file without trailing newline stays without one', async () => {
+    writeFile('nonl.txt', 'first\nsecond\nthird');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: nonl.txt',
+      '@@',
+      '-second',
+      '+SECOND',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.modified).toBe(1);
+    expect(readFile('nonl.txt')).toBe('first\nSECOND\nthird');
+  });
+
+  it('F1: context line whitespace preserved from file, not patch', async () => {
+    // File has trailing spaces on a context line; the patch's context line
+    // lacks them. The file's version must be preserved.
+    writeFile('ws.txt', 'hello   \nold\nworld\n');
+
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: ws.txt',
+      ' hello',
+      '-old',
+      '+new',
+      ' world',
+      '*** End Patch',
+    ].join('\n');
+
+    const result = await applyPatchHandler({ patch }, toolCtx());
+
+    expect(result.status).toBe('complete');
+    const data = result.data as ApplyPatchResultData;
+    expect(data.modified).toBe(1);
+    // The trailing spaces on 'hello   ' are preserved (file's version).
+    expect(readFile('ws.txt')).toBe('hello   \nnew\nworld\n');
+  });
 });
 
 describe('apply_patch agentProjector', () => {
@@ -528,5 +732,60 @@ describe('apply_patch agentProjector', () => {
     expect(result.content).toContain('function greet() {\n  return "hi";\n}');
     expect(result.content).toContain('<new_string>');
     expect(result.content).toContain('function greet() {\n  return "hello";\n}');
+  });
+
+  it('F11: counts unique file paths in summary (not operations)', () => {
+    // Two operations on the same file — the summary should say "1 file", not "2 files".
+    const data: ApplyPatchResultData = {
+      files: [
+        {
+          path: 'same.ts',
+          operation: 'update',
+          status: 'complete',
+          fileChange: fileChange({
+            path: 'same.ts',
+            operation: 'update',
+            addedLines: 1,
+            removedLines: 1,
+            hunks: [{
+              oldStart: 1, oldLines: 1, newStart: 1, newLines: 1,
+              lines: [
+                { kind: 'remove', content: 'old', oldLineNumber: 1 },
+                { kind: 'add', content: 'new1', newLineNumber: 1 },
+              ],
+            }],
+            resultingContent: '',
+          }),
+        },
+        {
+          path: 'same.ts',
+          operation: 'update',
+          status: 'complete',
+          fileChange: fileChange({
+            path: 'same.ts',
+            operation: 'update',
+            addedLines: 1,
+            removedLines: 1,
+            hunks: [{
+              oldStart: 5, oldLines: 1, newStart: 5, newLines: 1,
+              lines: [
+                { kind: 'remove', content: 'x', oldLineNumber: 5 },
+                { kind: 'add', content: 'y', newLineNumber: 5 },
+              ],
+            }],
+            resultingContent: '',
+          }),
+        },
+      ],
+      added: 0,
+      modified: 2,
+      deleted: 0,
+      failed: 0,
+    };
+
+    const result = projector(canonical(data));
+
+    expect(result.content).toContain('1 file:');
+    expect(result.content).not.toContain('2 files');
   });
 });

--- a/electron/tests/unit/filesystem-tool-results.test.ts
+++ b/electron/tests/unit/filesystem-tool-results.test.ts
@@ -25,6 +25,9 @@ import {
   globHandler,
 } from '../../src/main/tools/filesystem/glob';
 import {
+  applyPatchDefinition,
+} from '../../src/main/tools/filesystem/apply-patch';
+import {
   grepHandler,
   grepToolDefinition,
 } from '../../src/main/tools/search/grep';
@@ -53,6 +56,7 @@ import {
   type GrepResultsData,
   type SearchResultsData,
 } from '../../src/shared/types/tool-result-filesystem';
+import { applyPatchResultDataSchema } from '../../src/shared/types/tool-result-apply-patch';
 
 let tmpDir: string;
 
@@ -86,6 +90,7 @@ describe('filesystem result metadata', () => {
     [readDirectoryDefinition, 'directory-entries', directoryEntriesDataSchema],
     [globDefinition, 'search-results', searchResultsDataSchema],
     [grepToolDefinition, 'search-results', searchResultsDataSchema],
+    [applyPatchDefinition, 'generic', applyPatchResultDataSchema],
   ] as const)('declares the typed family for %s', (definition, family, schema) => {
     expect(definition.resultFamily).toBe(family);
     expect(definition.outputDataSchema).toBe(schema);

--- a/electron/tests/unit/tool-result-rendering.test.ts
+++ b/electron/tests/unit/tool-result-rendering.test.ts
@@ -21,6 +21,7 @@ import { FileContentToolResult } from '../../src/renderer/components/ToolResults
 import { DirectoryToolResult, buildDirectoryTree } from '../../src/renderer/components/ToolResults/DirectoryToolResult';
 import { SearchToolResult, groupGrepMatches } from '../../src/renderer/components/ToolResults/SearchToolResult';
 import { GenericToolResult } from '../../src/renderer/components/ToolResults/GenericToolResult';
+import { ApplyPatchToolResult } from '../../src/renderer/components/ToolResults/ApplyPatchToolResult';
 
 const rendererDir = path.resolve(__dirname, '../../src/renderer/components');
 
@@ -219,5 +220,78 @@ describe('shared canonical tool-result renderer', () => {
     );
     expect(shellSource).toContain('aria-controls={panelId}');
     expect(shellSource).toContain('id={panelId}');
+  });
+
+  it('resolves apply_patch to the dedicated multi-file renderer', () => {
+    expect(resolveToolResultRenderer('apply_patch', 'generic')).toBe(ApplyPatchToolResult);
+  });
+
+  it('renders a multi-file apply_patch result with diffs and error sections', () => {
+    const patchResult = {
+      schemaVersion: 1 as const,
+      family: 'generic' as const,
+      status: 'complete' as const,
+      completeness: 'complete' as const,
+      data: {
+        files: [
+          {
+            path: 'src/new.ts',
+            operation: 'create' as const,
+            status: 'complete' as const,
+            fileChange: {
+              path: 'src/new.ts',
+              operation: 'create' as const,
+              addedLines: 1,
+              removedLines: 0,
+              resultingContent: 'export const x = 1;\n',
+              hunks: [{
+                oldStart: 0, oldLines: 0, newStart: 1, newLines: 1,
+                lines: [{ kind: 'add' as const, content: 'export const x = 1;', newLineNumber: 1 }],
+              }],
+            },
+          },
+          {
+            path: 'src/existing.ts',
+            operation: 'update' as const,
+            status: 'complete' as const,
+            fileChange: {
+              path: 'src/existing.ts',
+              operation: 'update' as const,
+              addedLines: 1,
+              removedLines: 1,
+              resultingContent: 'const y = 2;\n',
+              hunks: [{
+                oldStart: 1, oldLines: 1, newStart: 1, newLines: 1,
+                lines: [
+                  { kind: 'remove' as const, content: 'const y = 1;', oldLineNumber: 1 },
+                  { kind: 'add' as const, content: 'const y = 2;', newLineNumber: 1 },
+                ],
+              }],
+            },
+          },
+          {
+            path: 'src/broken.ts',
+            operation: 'update' as const,
+            status: 'error' as const,
+            error: { code: 'match_failed', message: 'Failed to find expected lines' },
+          },
+        ],
+        added: 1,
+        modified: 1,
+        deleted: 0,
+        failed: 1,
+      },
+    };
+    const markup = renderToStaticMarkup(createElement(ApplyPatchToolResult, { canonical: patchResult, toolName: 'apply_patch' }));
+    expect(markup).toContain('src/new.ts');
+    expect(markup).toContain('src/existing.ts');
+    expect(markup).toContain('src/broken.ts');
+    expect(markup).toContain('export const x = 1;');
+    expect(markup).toContain('const y = 2;');
+    expect(markup).toContain('Failed to find expected lines');
+    expect(markup).toContain('3 files');
+    expect(markup).toContain('1 added');
+    expect(markup).toContain('1 modified');
+    expect(markup).toContain('1 failed');
   });
 });

--- a/electron/tests/unit/tool-title.test.ts
+++ b/electron/tests/unit/tool-title.test.ts
@@ -153,4 +153,34 @@ describe('tool widget titles', () => {
       }),
     ).toBe('Preparing custom tool name');
   });
+
+  it('uses lifecycle titles for apply_patch', () => {
+    expect(titleText({
+      toolName: 'apply_patch',
+      status: 'generating',
+      args: '',
+      partialArgs: '{"patch":"*** Begin Patch",',
+    })).toBe('Preparing to apply patch');
+
+    expect(titleText({
+      toolName: 'apply_patch',
+      status: 'running',
+      args: JSON.stringify({ patch: '*** Begin Patch\n*** End Patch' }),
+      partialArgs: '',
+    })).toBe('Applying patch');
+
+    expect(titleText({
+      toolName: 'apply_patch',
+      status: 'completed',
+      args: JSON.stringify({ patch: '*** Begin Patch\n*** End Patch' }),
+      partialArgs: '',
+    })).toBe('Applied patch');
+
+    expect(titleText({
+      toolName: 'apply_patch',
+      status: 'failed',
+      args: JSON.stringify({ patch: '*** Begin Patch\n*** End Patch' }),
+      partialArgs: '',
+    })).toBe('Couldn’t apply patch');
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `apply_patch` tool for creating, updating, deleting, and moving multiple files from a single patch.
  * Added patch validation, flexible matching, path safety checks, and preservation of line-ending and symlink behavior.
  * Added detailed per-file results, summary counts, status messages, and dedicated diff views.
* **Bug Fixes**
  * Improved handling of ambiguous matches, invalid anchors, malformed patches, and filesystem errors.
  * Added safeguards against path traversal and unsafe file operations.
* **Tests**
  * Added comprehensive coverage for patch parsing, application, rendering, security, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->