### PR TITLE
perf(electron): collapse session switching into one IPC round-trip

### DIFF
--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -321,6 +321,18 @@ function snapshotForAgent(active: ActiveAgent): ChatSnapshot {
   };
 }
 
+/**
+ * In-flight turn snapshot for a session, or null when idle/finalized.
+ *
+ * Shared by chat:snapshot and session:open so both hydrate the renderer from
+ * one source. Finalization and persistence share one synchronous callback, so
+ * a finalized actor is already represented by history when IPC observes it.
+ */
+export function getLiveChatSnapshot(sessionId: string): ChatSnapshot | null {
+  const active = activeAgents.get(sessionId);
+  return active && !active.finalized ? snapshotForAgent(active) : null;
+}
+
 function attachUsageToLatestAssistant(messages: Message[], usage: Usage): boolean {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
@@ -1652,13 +1664,10 @@ export function registerChatIPC(): void {
       if (!sessionId) return null;
       const session = getSessionManager().getSession(sessionId);
       if (!session) return null;
-      const active = activeAgents.get(sessionId);
       return {
         sessionId,
         messages: flattenSessionMessages(session),
-        // Finalization and persistence share one synchronous callback, so a
-        // finalized actor is already represented by history when IPC observes it.
-        live: active && !active.finalized ? snapshotForAgent(active) : null,
+        live: getLiveChatSnapshot(sessionId),
       };
     },
   );

--- a/electron/src/main/ipc/payload-schemas.ts
+++ b/electron/src/main/ipc/payload-schemas.ts
@@ -80,6 +80,10 @@ export const sessionLoadSchema = z.object({
   activate: z.boolean().optional().default(true),
 });
 
+export const sessionOpenSchema = z.object({
+  id: z.string().uuid(),
+});
+
 export const sessionDeleteSchema = z.object({
   id: z.string().uuid(),
 });

--- a/electron/src/main/ipc/session.ts
+++ b/electron/src/main/ipc/session.ts
@@ -32,6 +32,7 @@ import {
   sessionChangeModelSchema,
   sessionDeleteSchema,
   sessionLoadSchema,
+  sessionOpenSchema,
   sessionRenameSchema,
   sessionSetWorkspaceSchema,
 } from './payload-schemas';
@@ -183,6 +184,55 @@ export function registerSessionIPC(): void {
 
     emitWorkspaceChanged(event.sender, workspace);
     return session;
+  });
+
+  // session:open — activate a session and return its full view payload in one
+  // round-trip (session + flattened messages + live snapshot + workspace).
+  // Replaces the prior peek + chat:snapshot + activate sequence so a switch
+  // reads/parses the session file once and serializes it across IPC once.
+  ipcMain.handle(IPC_CHANNELS.SESSION_OPEN, async (event, payload: unknown) => {
+    const parsed = sessionOpenSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw new Error(`Invalid session:open payload: ${parsed.error.message}`);
+    }
+
+    const manager = getSessionManager();
+    const { id } = parsed.data;
+    const windowId = String(event.sender.id);
+
+    // Selecting a session is view navigation. Work in the previously selected
+    // session continues and remains addressed by its own session id.
+    const session = manager.switchTo(id, windowId);
+
+    if (session) {
+      workingSetOpenOrFocus(session.id, windowId);
+    } else {
+      // Drop ghost tabs when the session cannot be loaded (missing/corrupt).
+      workingSetRemove(id, windowId);
+    }
+
+    // Session owns workspace now — clear draft so it doesn't shadow session.cwd.
+    // Sticky default is intentionally NOT updated on open (matches session:load).
+    clearDraftCwd(windowId);
+
+    // Flatten once and reuse for both the seeded chat history (so the next
+    // chat:send continues the full conversation) and the renderer payload.
+    const messages = session ? flattenSessionMessages(session) : [];
+    if (session) {
+      seedChatHistory(session.id, messages);
+    } else {
+      clearChatHistory(id);
+    }
+
+    const workspace = resolveWindowWorkspace(windowId);
+    emitWorkspaceChanged(event.sender, workspace);
+
+    // Live in-flight snapshot (chat.ts owns the active-agent registry). Dynamic
+    // import avoids the session.ts <-> chat.ts circular dependency.
+    const { getLiveChatSnapshot } = await import('./chat');
+    const live = getLiveChatSnapshot(id);
+
+    return { session, messages, live, workspace };
   });
 
   // session:create — eagerly create + activate a session (writes to disk).
@@ -405,6 +455,7 @@ export function registerSessionIPC(): void {
 export function unregisterSessionIPC(): void {
   ipcMain.removeHandler(IPC_CHANNELS.SESSION_LIST);
   ipcMain.removeHandler(IPC_CHANNELS.SESSION_LOAD);
+  ipcMain.removeHandler(IPC_CHANNELS.SESSION_OPEN);
   ipcMain.removeHandler(IPC_CHANNELS.SESSION_CREATE);
   ipcMain.removeHandler(IPC_CHANNELS.SESSION_CLEAR_ACTIVE);
   ipcMain.removeHandler(IPC_CHANNELS.SESSION_DELETE);

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -40,6 +40,8 @@ import type {
   ProviderDisconnectMessage,
   ProviderStatusRefreshMessage,
   SessionLoadMessage,
+  SessionOpenMessage,
+  SessionOpenResult,
   SessionDeleteMessage,
   SessionRenamedEvent,
   SessionCreatedEvent,
@@ -277,6 +279,9 @@ const orchidAPI: OrchidAPI = {
 
     load: (id: SessionLoadMessage) =>
       invoke(IPC_CHANNELS.SESSION_LOAD, id),
+
+    open: (message: SessionOpenMessage) =>
+      invoke<SessionOpenResult>(IPC_CHANNELS.SESSION_OPEN, message),
 
     create: () =>
       invoke(IPC_CHANNELS.SESSION_CREATE),

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -23,7 +23,7 @@ import { useFocusTrap, useGlobalShortcuts } from '../keyboard';
 import type { ModelSelection } from '../../shared/types/provider';
 import { flattenSessionMessages, type Session } from '../../shared/types/session';
 import type { MCPServerStatus, RAGStoreStatus, ASTStoreStatus, CommandContext } from '../../shared/types/ipc-boundary';
-import type { ProviderModelOption } from '../../shared/types/ipc';
+import type { ProviderModelOption, SessionOpenResult } from '../../shared/types/ipc';
 import { ChatStream } from './ChatStream';
 import { InputArea } from './InputArea';
 import { Footer } from './Footer';
@@ -271,18 +271,6 @@ export function ChatView() {
     [chat, subagents.applyFromSession, todos.applyFromSession],
   );
 
-  /**
-   * Commit a fully-loaded session in one paint: messages, sidebar lists, and
-   * live snapshot. Call only after peek + snapshot are both ready.
-   */
-  const commitSessionView = useCallback(
-    (loadedSession: Session | null, snapshot: Awaited<ReturnType<typeof chat.getSnapshot>>) => {
-      applySessionMessages(loadedSession);
-      chat.hydrateSnapshot(snapshot);
-    },
-    [applySessionMessages, chat],
-  );
-
   const handleSessionSelect = useCallback(
     async (id: string) => {
       // Already focused this session (not draft) — skip full reload to avoid flicker.
@@ -297,43 +285,36 @@ export function ChatView() {
       // the full target payload is ready (no intermediate empty/zero state).
       chat.beginSessionSwitch(id);
 
-      // Peek without activating so activeSession / left rail stay on the
-      // previous session until we commit.
-      let loadedSession: Session | null = null;
+      // Single round-trip: activate the session and fetch its full view payload
+      // (session + flattened messages + live snapshot + workspace) at once.
+      // Replaces the prior peek + chat:snapshot + activate sequence.
+      let result: SessionOpenResult | null = null;
       try {
-        if (window.orchid?.session?.load) {
-          loadedSession = await window.orchid.session.load({ id, activate: false });
-        }
+        result = await session.open(id);
       } catch {
-        loadedSession = null;
+        // result stays null on failure — handled by the !result guard below.
       }
       if (gen !== sessionSwitchGen.current) return;
 
-      if (!loadedSession) {
-        console.error('Failed to load session:', id);
-        // Fall back to activating load so workspace still updates if possible.
-        const activated = await session.load(id);
-        if (gen !== sessionSwitchGen.current) return;
-        if (!activated) {
-          // Keep previous paint; clear switch hold without blanking the pane.
-          chat.hydrateSnapshot(null);
-          return;
-        }
-        commitSessionView(activated, null);
-        setDraftTabVisible(false);
+      if (!result || !result.session) {
+        // Could not load (missing/corrupt) — keep the previous paint and release
+        // the switch hold without blanking the pane.
+        chat.hydrateSnapshot(null);
         return;
       }
 
-      const snapshot = await chat.getSnapshot(loadedSession.id);
-      if (gen !== sessionSwitchGen.current) return;
-
-      // Activate only after data is ready so UI swaps in one commit.
-      const activated = await session.load(id);
-      if (gen !== sessionSwitchGen.current) return;
       setDraftTabVisible(false);
-      commitSessionView(activated ?? loadedSession, snapshot);
+      // Commit once: sidebar lists from the session, chat (messages + live) via
+      // hydrate. hydrateSnapshot owns the single message replace (no double set).
+      subagents.applyFromSession(result.session.subagentChains);
+      todos.applyFromSession(result.session.todoStore.tasks);
+      chat.hydrateSnapshot({
+        sessionId: result.session.id,
+        messages: result.messages,
+        live: result.live,
+      });
     },
-    [session, chat, commitSessionView, draftTabVisible],
+    [session, chat, subagents.applyFromSession, todos.applyFromSession, draftTabVisible],
   );
 
   // ConfigView left-rail pick: same hydrate path as sidebar (not store-only load).

--- a/electron/src/renderer/components/MessageWidget.tsx
+++ b/electron/src/renderer/components/MessageWidget.tsx
@@ -5,7 +5,7 @@
  * chrome; tool call/result messages fall back to ToolCallBlock for edge cases.
  * ChatStream normally converts them into ToolBlocks for consistent ordering.
  */
-import { useState, useCallback, useMemo, useEffect, useId } from 'react';
+import { memo, useState, useCallback, useMemo, useEffect, useId } from 'react';
 import type { Message } from '../../shared/types/message';
 import { MessageRole, MessageType } from '../../shared/types/message';
 import {
@@ -24,7 +24,7 @@ interface MessageWidgetProps {
   isStreaming?: boolean;
 }
 
-export function MessageWidget({ message, isStreaming }: MessageWidgetProps) {
+export const MessageWidget = memo(function MessageWidget({ message, isStreaming }: MessageWidgetProps) {
   if (message.hidden) return null;
 
   switch (message.type) {
@@ -50,7 +50,7 @@ export function MessageWidget({ message, isStreaming }: MessageWidgetProps) {
     default:
       return <DefaultMessage message={message} />;
   }
-}
+});
 
 function UserMessage({ message }: { message: Message }) {
   return (

--- a/electron/src/renderer/hooks/useSession.ts
+++ b/electron/src/renderer/hooks/useSession.ts
@@ -14,7 +14,7 @@ import { useCallback, useSyncExternalStore } from 'react';
 import type { Session } from '../../shared/types/session';
 import type { ModelSelection } from '../../shared/types/provider';
 import type { SessionSummary } from '../../shared/types/ipc-boundary';
-import type { WorkspaceInfo } from '../../shared/types/ipc';
+import type { WorkspaceInfo, SessionOpenResult } from '../../shared/types/ipc';
 import { ChainStatus } from '../../shared/types/chain';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -35,6 +35,11 @@ export interface UseSessionReturn {
   workspace: WorkspaceInfo | null;
   /** Load a session by ID. Returns the loaded session (or null on failure). */
   load: (id: string) => Promise<Session | null>;
+  /**
+   * Activate a session and return its full view payload (session, flattened
+   * messages, live snapshot, workspace) in one round-trip. Used by switching.
+   */
+  open: (id: string) => Promise<SessionOpenResult | null>;
   /**
    * Eagerly create a session file (legacy / tests). Prefer `enterDraft` for
    * the New Chat button — session is created on first message instead.
@@ -294,6 +299,35 @@ async function loadShared(id: string): Promise<Session | null> {
   }
 }
 
+async function openShared(id: string): Promise<SessionOpenResult | null> {
+  if (!window.orchid?.session?.open) {
+    return null;
+  }
+
+  const generation = ++loadGeneration;
+  advanceDraftGeneration();
+  setIsLoading(true);
+  try {
+    const result = await window.orchid.session.open({ id });
+    // Drop stale responses when a newer load (or draft) superseded this one.
+    if (generation !== loadGeneration) {
+      return result;
+    }
+    setActiveSession(result.session);
+    // session:open resolves the workspace itself; adopt it directly instead of
+    // a second get_workspace round-trip.
+    setWorkspaceState(result.workspace);
+    return result;
+  } catch (err) {
+    console.error('Failed to open session:', err);
+    return null;
+  } finally {
+    if (generation === loadGeneration) {
+      setIsLoading(false);
+    }
+  }
+}
+
 async function createShared(): Promise<Session> {
   if (!window.orchid?.session?.create) {
     const session = makeLocalSession();
@@ -514,9 +548,10 @@ export const __sessionCacheTest = {
   getWorkspace: () => workspace,
   getDraftGeneration: () => draftGeneration,
   getLoadGeneration: () => loadGeneration,
-  refresh: refreshShared,
-  load: loadShared,
-  enterDraft: enterDraftShared,
+    refresh: refreshShared,
+    load: loadShared,
+    open: openShared,
+    enterDraft: enterDraftShared,
   create: createShared,
   deleteSession: deleteSessionShared,
   rename: renameShared,
@@ -536,6 +571,7 @@ export function useSession(): UseSessionReturn {
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const load = useCallback((id: string) => loadShared(id), []);
+  const open = useCallback((id: string) => openShared(id), []);
   const create = useCallback(() => createShared(), []);
   const enterDraft = useCallback(() => enterDraftShared(), []);
   const deleteSession = useCallback((id: string) => deleteSessionShared(id), []);
@@ -556,6 +592,7 @@ export function useSession(): UseSessionReturn {
     listState: snapshot.listState,
     workspace: snapshot.workspace,
     load,
+    open,
     create,
     enterDraft,
     deleteSession,

--- a/electron/src/renderer/hooks/useSession.ts
+++ b/electron/src/renderer/hooks/useSession.ts
@@ -313,10 +313,12 @@ async function openShared(id: string): Promise<SessionOpenResult | null> {
     if (generation !== loadGeneration) {
       return result;
     }
-    setActiveSession(result.session);
-    // session:open resolves the workspace itself; adopt it directly instead of
-    // a second get_workspace round-trip.
-    setWorkspaceState(result.workspace);
+    if (result.session) {
+      setActiveSession(result.session);
+      // session:open resolves the workspace itself; adopt it directly instead of
+      // a second get_workspace round-trip.
+      setWorkspaceState(result.workspace);
+    }
     return result;
   } catch (err) {
     console.error('Failed to open session:', err);

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -161,6 +161,23 @@ export interface ChatSessionSnapshot {
   live: ChatSnapshot | null;
 }
 
+/**
+ * Full view payload for activating a session in one round-trip.
+ *
+ * Replaces the prior peek + chat:snapshot + activate sequence so a session
+ * switch reads/parses the session file once and serializes it across IPC once.
+ */
+export interface SessionOpenResult {
+  /** The activated session, or null when missing/corrupt. */
+  session: Session | null;
+  /** Flattened chain messages for the chat pane (empty when no session). */
+  messages: Message[];
+  /** In-flight turn snapshot when the session is currently running. */
+  live: ChatSnapshot | null;
+  /** Resolved workspace after activation (session → sticky → unbound). */
+  workspace: WorkspaceInfo;
+}
+
 export interface SubagentSnapshotRequest { sessionId: string; }
 export interface SubagentSnapshot {
   sessionId: string;
@@ -490,6 +507,11 @@ export interface SessionLoadMessage {
   activate?: boolean;
 }
 
+/** Activate a session and return its full view payload in one round-trip. */
+export interface SessionOpenMessage {
+  id: string;
+}
+
 export interface SessionDeleteMessage {
   id: string;
 }
@@ -704,6 +726,12 @@ export interface OrchidAPI {
   session: {
     list: () => Promise<SessionSummary[]>;
     load: (id: SessionLoadMessage) => Promise<Session | null>;
+    /**
+     * Activate a session and return its full view payload (session, flattened
+     * messages, live snapshot, workspace) in one round-trip. Replaces the prior
+     * peek + chat:snapshot + activate sequence for session switching.
+     */
+    open: (message: SessionOpenMessage) => Promise<SessionOpenResult>;
     create: () => Promise<Session>;
     /**
      * Enter draft mode: clear active session, abort in-flight chat, clear
@@ -862,6 +890,8 @@ export const IPC_CHANNELS = {
   // Session
   SESSION_LIST: 'session:list',
   SESSION_LOAD: 'session:load',
+  /** Activate a session and return its full view payload in one round-trip. */
+  SESSION_OPEN: 'session:open',
   SESSION_CREATE: 'session:create',
   /** Clear active session without creating a file (draft / new chat). */
   SESSION_CLEAR_ACTIVE: 'session:clear_active',
@@ -966,6 +996,7 @@ export const ALLOWED_INVOKE_CHANNELS = [
   IPC_CHANNELS.PROVIDERS_STATUS_REFRESH,
   IPC_CHANNELS.SESSION_LIST,
   IPC_CHANNELS.SESSION_LOAD,
+  IPC_CHANNELS.SESSION_OPEN,
   IPC_CHANNELS.SESSION_CREATE,
   IPC_CHANNELS.SESSION_CLEAR_ACTIVE,
   IPC_CHANNELS.SESSION_DELETE,


### PR DESCRIPTION
Switching sessions previously ran three sequential IPC calls (peek + chat:snapshot + activate), reading/parsing the session file twice and serializing the full conversation across the boundary three times, then committed the message list into React state twice. Large sessions took seconds to open.

Add session:open, which activates the session and returns its full view payload (session, flattened messages, live snapshot, workspace) in a single call. The renderer now commits once via hydrateSnapshot, and MessageWidget is memoized so streaming tokens no longer re-render every history message.

- disk read + parse per cold switch: 2 -> 1
- IPC serialization of the conversation: 3 -> 1
- full-list React commits per switch: 2 -> 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster, unified session switching that loads the session, chat history, workspace, and in-progress response together.
  * Preserves the current chat view if a selected session cannot be loaded.
  * Session changes now correctly update workspace context and remove stale tabs.

* **Performance**
  * Improved chat message rendering efficiency for smoother updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->