### PR TITLE
feat(tools): add ask_question tool for interactive user clarification

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,16 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
   - Todo: `todo_create`, `todo_update`, `todo_list`, `todo_delete`
   - Web / subagents / skills: `web_fetch`, `delegate_to_subagent`, `wait_for_subagent`, `interrupt_subagents`, `skill`
   - MCP: `read_mcp_resource`, `list_mcp_resources`, and dynamically registered MCP tools
+- Notifications / sounds when:
+  - Chain ends
+  - Needs user input (Ex: ask_question)
+- Verify if thinking blocks:
+  - Are collapsed by default
+  - Allow line breaks
+- Add thinking duration while thinking (Not only Thinking...)
+- Subagent selection on the right sidebar keeps re-selecting without user input (Cant have no subagent selected)
+- Clicking on the content of tool results are not collapsing the widget
+
 
 ## General backlog
 
@@ -62,17 +72,6 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - **Do not change this until the design is clearer**
 - Multiple primary agent types (general, plan, etc.) that can be switched mid-conversation
 
-## `ask_question` tool
-
-- Support multiple multiple-choice questions
-  - Each with a title and description
-- Always allow a free-text answer option
-- Allow several questions in one tool call
-  - e.g. two 4-option questions plus one 2-option question
-- Under consideration: let subagents use this tool to ask the main agent / user
-  - Main agent must notice immediately (status update + leave `wait_for_subagent` if any subagent has a question)
-  - Main agent must be able to decline answering (e.g. research-only, or forward to the user)
-
 ## Approval / permission system
 
 - Evaluate integrating checks from [destructive_command_guard](https://github.com/Dicklesworthstone/destructive_command_guard)
@@ -97,6 +96,12 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
   - Multi-turn? Still under consideration
   - Useful for clarifications without stopping work
     - e.g. “How does function X interact with system Y?”
+- Close subagent
+  - Remove it from the dynamic system prompt, the agent information is not needed anymore
+  - Does not actually deletes anything from the session
+- A tool to continue the work / follow up input
+  - Ex: Agent implemented something and created a bug, send an input telling it to fix
+  - Cannot be used with closed agents
 
 ## Needs improvement
 

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - Add dedicated UI handling instead of the generic structured viewer for:
   - RAG: `rag_search`, `rag_index`
   - Process: `read_output`, `send_input`, `terminate_command`
-  - AST: `ast_index`, `get_file_skeleton`, `get_function`, `find_symbol_references`, `replace_symbol`, `rename_symbol`
+  - AST / semantic graph: `ast_index`, `explore_code`, `get_symbol`, `trace_calls`, `analyze_change_impact`, `get_file_skeleton`, `get_function`, `find_symbol_references`, `replace_symbol`, `rename_symbol`
   - Todo: `todo_create`, `todo_update`, `todo_list`, `todo_delete`
   - Web / subagents / skills: `web_fetch`, `delegate_to_subagent`, `wait_for_subagent`, `interrupt_subagents`, `skill`
   - MCP: `read_mcp_resource`, `list_mcp_resources`, and dynamically registered MCP tools
@@ -51,7 +51,7 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - **P1: `apply_patch` sync matching can block the event loop** — `seekSequence` is O(n×m×4) synchronous. Large file + non-matching pattern blocks the main process indefinitely; `Promise.race` timeout cannot fire. Add a line-count guard in `applyChunksToContent` and `.max()` on the patch Zod schema. (code review 2026-07-19, P1)
 - **P1: `apply_patch` agent projector emits redundant full diffs** — full `<old_string>` / `<new_string>` per file can exceed the 20KB offload threshold, stripping per-file error info the agent needs. Make the projector compact: per-file status + errors only; omit diffs (UI renderer keeps them). (code review 2026-07-19, P1)
 - Tools should start executing as soon as their generation is complete, even if the model is still generating output for other tool calls
-- RAG/AST post-write callback + automatic reindex when changes are detected (also support reindex via commands / manual triggers that the post-write path does not cover)
+- RAG post-write callback + automatic reindex when changes are detected (AST freshness is covered by the native semantic code graph workstream below; also support reindex via commands / manual triggers that the post-write path does not cover)
 - `wait_for_subagent` can send duplicated information
 - Remaining work from `docs/code-review-reports/2026-07-15-electron-simplification-review.md`
 - Verify remote embedding models work correctly
@@ -66,6 +66,87 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - User message queue (queue follow-ups while the agent is busy)
 - Session compaction / compression (summarize or drop older turns so long sessions stay within context limits)
 - Analytics dashboard
+
+## Native semantic code graph / AST tool improvements
+
+- Evolve the flat AST symbol index into a versioned semantic graph
+  - Store files, definition nodes, exact definition/reference occurrences, typed edges, unresolved references, and index metadata
+  - Add stable qualified symbol IDs that do not depend on line numbers
+  - Add edge kinds for `contains`, `calls`, `imports`, `exports`, `references`, `extends`, `implements`, `instantiates`, `overrides`, `decorates`, `returns`, and `type_of`
+  - Record call-site line/column plus provenance/confidence so syntax-derived and heuristic edges can be distinguished
+  - Add FTS5 search over symbol names, qualified names, signatures, and docstrings
+  - Track schema and extractor versions; rebuild incompatible derived indexes instead of maintaining complex data migrations
+- Replace flat name capture with richer language adapters for Orchid's existing Python, JavaScript, JSX, TypeScript, and TSX support
+  - Extract definitions, scopes, qualified names, signatures, imports/exports, calls, member access, inheritance, type relationships, decorators, and JSX component usage
+  - Associate each reference/call with its enclosing executable symbol so edges represent actual call flow
+  - Keep exact occurrence ranges compatible with `find_symbol_references`, `rename_symbol`, and `replace_symbol`
+  - Add languages only after the initial five have accuracy fixtures and acceptable indexing performance
+- Add conservative cross-file resolution
+  - Resolve lexical definitions, import aliases, module paths, re-exports, constructors, qualified members when the receiver is known, and inheritance/interface relationships
+  - Preserve ambiguous references as unresolved instead of guessing
+  - Retry unresolved references in unchanged files when changed files introduce matching symbols
+  - Remove or re-resolve incoming edges when a target file or symbol is deleted or renamed
+- Add isolated Orchid-specific relationship synthesizers with explicit heuristic provenance
+  - React/JSX component rendering and event-handler wiring
+  - Electron preload/renderer calls to matching main-process IPC handlers by channel
+  - XState actions, guards, actors, and state-machine references
+  - Tool definitions and other registry entries to their registered handlers
+- Add project-scoped traversal and context services
+  - Cycle-safe callers, callees, bidirectional call-flow, type-hierarchy, file-dependency, and reverse-impact traversal
+  - Configurable depth and node/file caps with deterministic ordering and duplicate suppression
+  - Return dependency paths, direct/transitive classification, edge locations, and provenance instead of flat symbol lists
+  - Read source from the current on-disk file after path-scope validation; never treat indexed source positions as proof that cached content is current
+- Add `explore_code` as the primary graph-backed code-understanding tool
+  - Accept natural-language questions, symbol names, file names, or mixed queries
+  - Seed retrieval from exact/qualified-name lookup and FTS; use the existing Orchid RAG index as an optional fallback/augmentation for prose queries
+  - Map RAG file/line hits to enclosing graph nodes, expand through weighted graph relationships, and rank bridge symbols and co-located files
+  - Group selected source ranges by file, merge overlaps, add current line-numbered source, and include a compact relationship/impact summary
+  - Keep the agent-facing payload below the tool offload threshold and state omissions/truncation explicitly
+- Add `get_symbol` for targeted symbol inspection
+  - Resolve symbols project-wide with optional file/line/kind disambiguation
+  - Return every plausible definition when a name is ambiguous rather than silently choosing one
+  - Optionally include signature, current source or container outline, direct callers/callees, and edge provenance
+  - Preserve `get_function` for compatibility, but make `get_symbol` the general function/class/interface/component lookup tool
+- Add `trace_calls` for explicit call-flow queries
+  - Support `callers`, `callees`, and `both` directions with bounded depth
+  - Include call sites and one path from the requested symbol to every returned node
+  - Distinguish direct calls, generic references, construction, and synthesized callback/framework hops
+- Add `analyze_change_impact` for pre-edit blast-radius analysis
+  - Traverse callers, importers, instantiation sites, subclasses/implementers, overrides, decorators, component consumers, and synthesized registrations in the reverse dependency direction
+  - Group direct and transitive impact by file and edge type, with paths explaining why each result is included
+  - Cap high-fan-out generic-reference/import expansion and report when results are partial
+- Improve existing AST tools around the graph
+  - `find_symbol_references`: return definition/reference classification, resolved target where known, ambiguity details, and current source locations
+  - `get_function`: reuse graph resolution and current-source validation while keeping its existing compatibility contract
+  - `get_file_skeleton`: use graph nodes/signatures and optionally summarize dependents/dependencies without dumping source
+  - `rename_symbol`: use resolved occurrences to reduce same-name false positives, present ambiguity/impact before mutation, and keep conservative fallback behavior
+  - `replace_symbol`: invalidate and synchronously enqueue the changed file for graph refresh after a successful write
+  - `ast_index`: add `sync` alongside `status`, `index`, and `clear`; report nodes, occurrences, edges, unresolved counts, extraction version, pending files, and freshness/watcher health
+- Add automatic graph freshness and lifecycle management
+  - Maintain one leased index service/worker per project runtime with single-flight indexing and safe shutdown
+  - Notify it immediately after Orchid `write`, `edit`, `apply_patch`, `rename_symbol`, and `replace_symbol` mutations
+  - Add a debounced filesystem watcher for external editor changes and command-driven writes that bypass Orchid file tools
+  - Incrementally extract changed files, delete removed-file data, rerun affected resolution, and batch bursts of edits
+  - Before graph queries, cheaply reconcile pending Orchid-originated writes or return an explicit stale/partial warning while sync is still running
+  - Surface degraded watcher state rather than silently serving a frozen index
+- Integrate the new tools with Orchid's agent and output contracts
+  - Register them as built-in read-only tools with exact names and Zod schemas; do not route them through MCP
+  - Add compact tool-specific XML renderers using the exact registered name in the `<tool_result>` envelope
+  - Add generating/running/completed UI states and dedicated widgets or compact summaries
+  - Add the tools to the appropriate general, explorer, implementer, architecture, reviewer, testing, reliability, security, and other relevant agent allowlists
+  - Update agent instructions so `explore_code` is the first choice for architecture/flow questions, while `grep`, `read`, `rag_search`, and exact AST tools remain explicit fallbacks
+  - Extend the Index sidebar and AST IPC/shared status types with graph counts, resolving/linking progress, pending files, and freshness state
+- Add correctness, performance, and integration coverage
+  - Fixture tests for nested scopes, duplicate names, overloads, aliased imports, re-exports, calls, member calls, constructors, inheritance, JSX, IPC, XState, ambiguous references, and parse failures
+  - Incremental tests for modify/add/delete/rename, stale-edge removal, unresolved-reference retry, watcher batching/degradation, and concurrent query/index behavior
+  - Traversal tests for cycles, duplicate edges, depth/node caps, deterministic ordering, provenance, and direct/transitive paths
+  - Tool-contract tests for schemas, exact result names, XML escaping, path containment, current-source line accuracy, output budgets, cancellation, and missing/uninitialized indexes
+  - Project-runtime tests proving concurrent sessions query only their frozen workspace and that retired index services remain alive until active turn leases finish
+  - Retrieval evaluation comparing `explore_code` against `grep`/`read`/`rag_search` on architecture, call-flow, bug-localization, and refactor-impact tasks; measure relevance, missing/wrong edges, tool calls, tokens, latency, database size, and indexing time
+- Explicit non-goals for the initial implementation
+  - No separate file-tree or generic file-read tools; reuse `read_directory`, `glob`, `read`, and `get_file_skeleton`
+  - No duplicate semantic embedding system; optionally consume Orchid's existing RAG results
+  - No broad framework-heuristic or language expansion until the core graph's precision, freshness, and evaluation gates pass
 
 ## Compound system improvements
 

--- a/docs/brainstorms/2026-07-21-ask-question-tool-requirements.md
+++ b/docs/brainstorms/2026-07-21-ask-question-tool-requirements.md
@@ -1,0 +1,123 @@
+---
+title: "ask_question Tool"
+date: 2026-07-21
+type: requirements
+status: confirmed
+---
+
+# ask_question Tool
+
+## Summary
+
+A new tool that pauses an agent's turn to present the user (or the main agent, for subagent calls) with a stepper of single-choice and multi-choice questions. Each question always includes a free-text field. The widget overlays the input area — the user can navigate the UI and chat history but cannot send messages until they answer or cancel.
+
+---
+
+## Problem Frame
+
+Agents currently have no way to ask the user a structured question mid-turn. When an agent needs clarification or a decision, it can only emit text and end its turn, forcing the user to read a wall of prose, formulate a response, and re-prompt. This loses the agent's train of thought and adds round-trip latency.
+
+For subagents, the problem is worse: a subagent that needs guidance must either guess or fail. The main agent has no visibility into subagent uncertainty until the subagent completes (or errors), and no way to intervene mid-flight.
+
+---
+
+## Requirements
+
+**Question model**
+
+- R1. A tool call contains one or more questions, presented as a stepper (one at a time, Next/Back navigation, submit on the last question).
+- R2. Each question has a type: single-choice (exactly one selection) or multi-choice (zero or more selections).
+- R3. Each question has a title (required) and a description (optional).
+- R4. Each choice has a label (required) and a description (optional).
+- R5. Every question always includes a free-text input field, regardless of type.
+- R6. The agent receives both the selection(s) and the free-text content for each answered question.
+
+**User interaction (main agent → user)**
+
+- R7. The question widget overlays the input area. The user can navigate the UI, browse chat history, and move around, but cannot send a message until the questions are answered or cancelled.
+- R8. The user can skip an individual question. A skipped question returns "skipped" as its answer to the agent. The stepper advances to the next question.
+- R9. The user can cancel the entire question set. Cancelling closes the widget, saves a cancelled tool result to the session history (so the agent sees it on future turns), and aborts the current turn/chain — the result is not fed back to the LLM in the current turn.
+- R10. After answering, the completed widget persists in chat history showing what was selected and written.
+
+**Subagent escalation (subagent → main agent)**
+
+- R11. Subagents can call `ask_question`. The question routes to the main agent, not directly to the user.
+- R12. When the main agent is in `wait_for_subagent` and a subagent asks a question, `wait_for_subagent` returns early with the pending question(s).
+- R13. When the main agent is not in `wait_for_subagent`, the question queues. The dynamic system prompt is updated to reflect the pending question on the main agent's next turn.
+- R14. A new `answer_subagent` tool lets the main agent respond to a subagent's pending question with answers or a decline.
+- R15. The main agent can forward a subagent's question to the user by calling `ask_question` itself, then relay the user's answer via `answer_subagent`.
+- R16. When the main agent declines, the subagent's `ask_question` resolves with a declined status. The subagent continues its work without an answer.
+- R17. Multiple subagents can have pending questions simultaneously. `wait_for_subagent` surfaces all pending questions for the requested subagent IDs.
+
+---
+
+## Key Decisions
+
+- **Cancel aborts the stream.** Cancelling the question set terminates the turn via the existing AbortController plumbing rather than returning a tool result. This is the first tool that can end a turn from within.
+- **Main agent is an active decision-maker.** Subagent questions route to the main agent, which chooses to answer directly, search/investigate first, forward to the user, or decline. The user never answers a subagent's question directly.
+- **Queue, don't interrupt.** When the main agent is mid-turn, subagent questions queue silently. Awareness comes from the dynamic system prompt on the next turn, not mid-stream interruption.
+- **Stepper, not scrollable list.** Multiple questions are presented one at a time with Next/Back navigation, not as a scrollable form.
+
+---
+
+## Actors
+
+- A1. **User** — answers or cancels questions from the main agent. Navigates the UI freely while the widget is active but cannot send messages.
+- A2. **Main agent** — asks the user questions mid-turn. Receives and responds to subagent questions (answer, forward, or decline).
+- A3. **Subagent** — asks questions that route to the main agent. Receives answers, declines, or skips as tool results.
+
+---
+
+## Key Flows
+
+- F1. Main agent asks the user
+  - **Trigger:** Main agent calls `ask_question` with one or more questions.
+  - **Actors:** A1, A2
+  - **Steps:** Agent turn pauses. Widget overlays the input area. User steps through questions (select, type, skip, or cancel). On submit, the tool result returns all answers to the agent and the turn resumes. On cancel, a cancelled result is saved to session history and the turn aborts.
+  - **Covered by:** R1–R10
+
+- F2. Subagent asks the main agent (main agent waiting)
+  - **Trigger:** Subagent calls `ask_question` while the main agent is in `wait_for_subagent`.
+  - **Actors:** A2, A3
+  - **Steps:** Subagent's handler pauses. `wait_for_subagent` returns early with the pending question. Main agent decides: answer via `answer_subagent`, forward to user (F3), or decline. Subagent's handler resolves with the answer or declined status.
+  - **Covered by:** R11, R12, R14, R16, R17
+
+- F3. Main agent forwards a subagent question to the user
+  - **Trigger:** Main agent receives a subagent question and calls `ask_question` itself.
+  - **Actors:** A1, A2, A3
+  - **Steps:** Main agent calls `ask_question` with the subagent's questions. User answers via F1. Main agent relays the answer to the subagent via `answer_subagent`. Subagent's handler resolves.
+  - **Covered by:** R15
+
+- F4. Subagent asks while main agent is busy
+  - **Trigger:** Subagent calls `ask_question` while the main agent is mid-turn (not in `wait_for_subagent`).
+  - **Actors:** A2, A3
+  - **Steps:** Question queues. Subagent's handler awaits. Dynamic system prompt updated. On the main agent's next turn, it sees the pending question and responds via `answer_subagent` (or lets it queue further).
+  - **Covered by:** R13, R14
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- `ask_question` tool for main agent and subagents
+- `answer_subagent` tool for the main agent
+- Question widget overlaying the input area with stepper navigation
+- Dynamic system prompt updates for pending subagent questions
+
+**Out of scope:**
+- Mid-turn interruption of the main agent for subagent questions
+- User answering a subagent's question directly (always routed through the main agent)
+- Conditional questions (show Q2 based on Q1's answer)
+- Question timeouts or auto-skip
+- Required-answer validation (all questions are skippable)
+
+---
+
+## Outstanding Questions
+
+**Deferred to planning:**
+- Exact widget rendering: how the overlay integrates with the existing input component and chat stream layout.
+- How the completed question widget renders in chat history (collapsed summary vs. full replay).
+- Whether the main agent's `ask_question` call for forwarding should visually indicate it originated from a subagent.
+- Subagent system prompt guidance for handling declined answers gracefully.
+- How `wait_for_subagent` formats multiple pending questions from different subagents in a single early return.

--- a/docs/plans/2026-07-21-001-feat-ask-question-tool-plan.md
+++ b/docs/plans/2026-07-21-001-feat-ask-question-tool-plan.md
@@ -1,0 +1,346 @@
+---
+title: "feat: Add ask_question tool with interactive stepper widget"
+type: feat
+date: 2026-07-21
+deepened: 2026-07-21
+origin: docs/brainstorms/2026-07-21-ask-question-tool-requirements.md
+---
+
+# feat: Add ask_question tool with interactive stepper widget
+
+## Summary
+
+Add an `ask_question` tool that pauses an agent's turn to present the user with a stepper of single/multi-choice questions (each with optional descriptions and a free-text field). The widget overlays the input area, blocking message sends until answered or cancelled. A parallel subagent escalation path lets subagents route questions to the main agent via `wait_for_subagent` early return, a new `answer_subagent` tool, and a dynamic system prompt section.
+
+## Problem Frame
+
+The agent currently has no mechanism to pause and ask the user a structured question mid-turn. When the agent needs clarification or a decision, it can only ask in free-form text and hope the user's next message answers it — losing the turn's context and forcing a new round-trip. A structured question tool with an interactive widget enables the agent to get precise answers without ending its turn, and enables subagents to escalate decisions to the main agent without completing blindly.
+
+## Requirements
+
+Carried from origin: `docs/brainstorms/2026-07-21-ask-question-tool-requirements.md`
+
+**Question model**
+
+- R1. The tool accepts an array of one or more questions. Each question has a type (single-choice or multi-choice), a title, an optional description, and an array of options. Each option has a label and an optional description.
+- R2. Every question includes a free-form text input. The agent receives both the selection(s) and the free text.
+- R3. The tool result is structured: for each question, the selected option labels, the free text (or null), and a skipped flag.
+
+**Widget behavior**
+
+- R4. Multiple questions render as a stepper: one question at a time, Next/Back navigation, Submit on the last question.
+- R5. Single-choice questions allow exactly one selection. Multi-choice questions allow multiple selections.
+- R6. The widget overlays the input area. The user can navigate the UI and browse chat history but cannot send a message until the questions are answered or cancelled.
+- R7. The user can skip an individual question (returns "skipped", advances the stepper).
+- R8. The user can cancel the entire question set. Cancelling saves a cancelled tool result to session history (hidden from LLM context) and aborts the current turn/chain.
+- R9. After answering, the completed widget persists in chat history showing what was selected and written.
+
+**Subagent escalation**
+
+- R10. When a subagent calls `ask_question` while the main agent is in `wait_for_subagent`, the wait returns early with the pending question.
+- R11. When the main agent calls or is in `wait_for_subagent` and a target subagent has a pending question, the wait returns immediately regardless of whether the question arrived before or during the wait.
+- R12. When a subagent calls `ask_question` and the main agent is not in `wait_for_subagent`, the question queues. The dynamic system prompt reflects pending questions on the main agent's next turn.
+- R13. A new `answer_subagent` tool lets the main agent answer a subagent's pending question or decline it.
+- R14. The main agent can forward a subagent's question to the user by calling `ask_question` itself, then relaying the answer via `answer_subagent`.
+- R15. A declined question resolves the subagent's `ask_question` with `{ status: "declined" }`. The subagent continues without an answer.
+- R16. Multiple subagents can have pending questions simultaneously.
+
+## Key Technical Decisions
+
+- **Promise-based question store**: The tool handler awaits a Promise stored in a per-session question store. The renderer's answer IPC invoke resolves the Promise. This mirrors the existing `SubagentManager._resolveWait` waiter pattern and requires no changes to the AI SDK tool execution model.
+- **Cancel = abort + hidden persistence**: Cancel triggers the existing `AbortController` to abort the stream (first tool that can terminate a turn from within). The cancelled tool result is saved to `turnMessages` with `hidden: true` so it persists in session history but is filtered from LLM context by `toApiMessages`.
+- **Subagent questions resolve existing waiters**: When a subagent asks a question, `SubagentManager` stores the question on the record and calls `_resolveWaiters` — the same mechanism used for completion. The `wait()` caller distinguishes "completed" from "has pending question" by checking the record state. No parallel notification channel needed.
+- **Widget is a new interactive tool result renderer**: Registered in the existing `ToolResults/registry.tsx` pattern. First interactive widget in the codebase — sets the pattern for future interactive tool results.
+- **IPC uses a dedicated channel pair**: `ask_question:asked` (main→renderer event) pushes the question payload. `ask_question:answer` (renderer→main invoke) submits the answer. Follows the existing 4-file IPC pattern (shared/types/ipc.ts, preload/index.ts, main/ipc/, renderer hook).
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+    participant LLM as LLM (AI SDK)
+    participant Handler as ask_question handler
+    participant Store as QuestionStore
+    participant IPC as IPC Bridge
+    participant Widget as Renderer Widget
+    participant User as User
+
+    LLM->>Handler: execute(questions)
+    Handler->>Store: create(toolCallId, questions) → Promise
+    Handler->>IPC: emit ask_question:asked (payload)
+    IPC->>Widget: render stepper overlay
+    User->>Widget: select / type / skip / cancel
+    alt Answer or Skip
+        Widget->>IPC: invoke ask_question:answer (answers)
+        IPC->>Store: resolve(toolCallId, answers)
+        Store->>Handler: Promise resolves
+        Handler->>LLM: return ToolHandlerOutcome (answers)
+    else Cancel
+        Widget->>IPC: invoke ask_question:cancel (toolCallId)
+        IPC->>Store: resolve(toolCallId, {cancelled: true})
+        Store->>Handler: Promise resolves with cancel flag
+        Handler->>Handler: abort via AbortController
+        Note over Handler: Cancelled result saved as hidden message
+    end
+```
+
+```mermaid
+sequenceDiagram
+    participant Sub as Subagent
+    participant Mgr as SubagentManager
+    participant Wait as wait_for_subagent
+    participant Main as Main Agent
+    participant User as User
+
+    Sub->>Mgr: ask_question handler → markQuestionPending(id, questions)
+    Mgr->>Wait: _resolveWaiters (early return)
+    Wait->>Main: return {status: "question_pending", questions}
+    alt Answer directly
+        Main->>Mgr: answer_subagent(id, answers)
+        Mgr->>Sub: resolve question Promise
+    else Forward to user
+        Main->>User: ask_question (same questions)
+        User->>Main: answers
+        Main->>Mgr: answer_subagent(id, answers)
+        Mgr->>Sub: resolve question Promise
+    else Decline
+        Main->>Mgr: answer_subagent(id, {declined: true})
+        Mgr->>Sub: resolve with {status: "declined"}
+    end
+```
+
+## Implementation Units
+
+### U1. Tool definition and Zod schema
+
+- **Goal:** Define the `ask_question` tool with input/output schemas and register it in the tool registry.
+- **Requirements:** R1, R2, R3
+- **Dependencies:** None
+- **Files:**
+  - `electron/src/main/tools/ask-question/ask-question.ts` (create)
+  - `electron/src/main/tools/ask-question/index.ts` (create)
+  - `electron/src/main/tools/index.ts` (modify — register tool)
+  - `electron/src/main/agents/AGENT.md` (modify — add to main agent's allowed tools)
+- **Approach:**
+  - Input schema: `{ questions: z.array(z.object({ type: z.enum(['single', 'multi']), title: z.string(), description: z.string().optional(), options: z.array(z.object({ label: z.string(), description: z.string().optional() })) })) }`
+  - Output data schema: `{ answers: z.array(z.object({ selected: z.array(z.string()), text: z.string().nullable(), skipped: z.boolean() })) }`
+  - Result family: `'generic'`
+  - Handler is a stub initially (returns empty answers) — fleshed out in U2.
+- **Patterns to follow:** `electron/src/main/tools/todo/create.ts` for tool definition shape; `electron/src/main/tools/index.ts` for registration.
+- **Test files:** `electron/tests/unit/ask-question-schema.test.ts`
+- **Test scenarios:**
+  - Schema validates a well-formed multi-question input
+  - Schema rejects missing type, empty options array, empty title
+  - Tool appears in registry after registration
+  - Tool is in main agent's allowed tools list
+- **Verification:** Tool is registered, schema validates/rejects correctly, stub handler returns a result.
+
+### U2. Question store, IPC channels, and tool handler
+
+- **Goal:** Implement the Promise-based question store, IPC channels for bidirectional communication, and the full tool handler that awaits user answers.
+- **Requirements:** R1, R2, R3, R8
+- **Dependencies:** U1
+- **Files:**
+  - `electron/src/main/tools/ask-question/store.ts` (create — QuestionStore)
+  - `electron/src/main/tools/ask-question/ask-question.ts` (modify — full handler)
+  - `electron/src/shared/types/ipc.ts` (modify — add channels)
+  - `electron/src/preload/index.ts` (modify — add bridge methods)
+  - `electron/src/main/ipc/ask-question.ts` (create — IPC handlers)
+  - `electron/src/main/ipc/index.ts` (modify — register handlers)
+- **Approach:**
+  - `QuestionStore`: per-session Map of `toolCallId → { questions, resolve, reject }`. Methods: `create(toolCallId, questions)` returns a Promise; `answer(toolCallId, answers)` resolves it; `cancel(toolCallId)` resolves with cancel flag; `cleanup(toolCallId)` removes entry. The store extends `EventEmitter` — on `create()`, it emits a `'question-asked'` event with `{ sessionId, toolCallId, questions }`.
+  - `ToolExecutionContext` carries `sessionId`, `agentScopeId`, and `abortSignal` but NOT `webContents`. The tool handler cannot emit IPC events directly. Instead, the IPC layer (which has webContents access) subscribes to the store's `'question-asked'` event and forwards it to the renderer via `webContents.send`. The store is the bridge between the tool handler and the IPC layer.
+  - Handler flow: validate input → `store.create()` (emits event, IPC layer forwards to renderer) → await Promise → on answer: return `ToolHandlerOutcome` with answers → on cancel: save hidden cancelled result to turnMessages, trigger abort via `ctx.abortSignal`.
+  - IPC channels: `ask_question:asked` (main→renderer event, carries `{ sessionId, toolCallId, questions }`), `ask_question:answer` (renderer→main invoke, carries `{ toolCallId, answers }`), `ask_question:cancel` (renderer→main invoke, carries `{ toolCallId }`).
+- **Patterns to follow:** `SubagentManager._resolveWait` for the Promise waiter pattern; `electron/src/main/ipc/chat.ts` for IPC handler registration; `electron/src/shared/types/ipc.ts` for channel definition pattern (4-file change).
+- **Test files:** `electron/tests/unit/ask-question-store.test.ts`, `electron/tests/unit/ask-question-handler.test.ts`
+- **Test scenarios:**
+  - `store.create()` returns a Promise that resolves when `store.answer()` is called
+  - `store.cancel()` resolves the Promise with a cancel flag
+  - `store.cleanup()` removes the entry; answering a cleaned-up entry is a no-op or error
+  - Handler returns structured answers when store resolves with answers
+  - Handler triggers abort when store resolves with cancel
+  - IPC `ask_question:answer` handler resolves the correct store entry
+  - IPC `ask_question:cancel` handler triggers cancel flow
+- **Verification:** Full round-trip works in isolation: handler creates question → store holds Promise → IPC answer resolves it → handler returns result.
+
+### U3. Renderer stepper widget
+
+- **Goal:** Build the interactive question stepper widget that overlays the input area.
+- **Requirements:** R4, R5, R6, R7, R8, R9
+- **Dependencies:** U2
+- **Files:**
+  - `electron/src/renderer/components/ToolResults/AskQuestionToolResult.tsx` (create)
+  - `electron/src/renderer/components/ToolResults/registry.tsx` (modify — register)
+  - `electron/src/renderer/hooks/useAskQuestion.ts` (create — IPC subscription + state)
+  - `electron/src/renderer/components/Footer.tsx` or input component (modify — overlay + input blocking)
+- **Approach:**
+  - `useAskQuestion` hook: subscribes to `ask_question:asked` event, holds active question state (`{ toolCallId, questions, currentIndex, answers[] }`), exposes `submitAnswer`, `skipQuestion`, `cancelAll` actions that call `window.orchid.askQuestion.answer/cancel`.
+  - Widget component: renders when `useAskQuestion` has an active question. Stepper UI: question title + description, option list (radio for single, checkbox for multi), free-text textarea, Back/Next/Skip buttons, Submit on last question, Cancel button.
+  - Overlay: the widget renders in the Footer/input area position, replacing the input. Chat history remains scrollable. The `useChat` send function is gated by `activeQuestion !== null`.
+  - After answer/cancel: widget unmounts, input reappears. The terminal tool result renders in chat history via the standard `ToolResultShell` → registry path (showing a summary of selections).
+  - Terminal (historical) rendering: a non-interactive summary showing each question's selected options and text. Registered as the `ask_question` tool renderer in `registry.tsx`.
+- **Patterns to follow:** `LiveCommandInline.tsx` for a live widget with ongoing main-process contact; `ToolResultShell.tsx` for the shell contract; `Footer.tsx` for the input area layout; existing `useChat.ts` for IPC event subscription pattern (`onParsed`).
+- **Test files:** `electron/tests/unit/ask-question-widget.test.ts`
+- **Test scenarios:**
+  - Single-choice question renders radio buttons; selecting one deselects others
+  - Multi-choice question renders checkboxes; multiple selections allowed
+  - Free-text input is always present below options
+  - Stepper shows question N of M; Next advances, Back returns
+  - Skip marks current question as skipped and advances
+  - Submit on last question calls `ask_question:answer` with all answers
+  - Cancel calls `ask_question:cancel`
+  - Input area is blocked (send disabled) while question is active
+  - After answer, widget unmounts and input reappears
+  - Historical rendering shows a non-interactive summary
+- **Verification:** Widget renders on `ask_question:asked` event, stepper navigation works, answer/cancel IPC calls fire correctly, input is blocked during active question.
+
+### U4. Cancel flow and session persistence
+
+- **Goal:** Implement the cancel path: save a cancelled tool result as a hidden message in session history and abort the turn.
+- **Requirements:** R8
+- **Dependencies:** U2, U3
+- **Files:**
+  - `electron/src/main/tools/ask-question/ask-question.ts` (modify — cancel handling)
+  - `electron/src/main/ipc/chat.ts` (modify — hidden message persistence)
+  - `electron/src/main/llm/history.ts` (verify/modify — filter hidden messages from LLM context)
+- **Approach:**
+  - When the handler receives a cancel from the store: create a `CanonicalToolResult` with `status: 'cancelled'`, push a `makeToolResultMessage` with `hidden: true` to `turnMessages`, then trigger the `AbortController.abort()`.
+  - Verify `toApiMessages` in `history.ts` filters `hidden: true` messages. If not, add a filter at the top of the message loop.
+  - The abort propagates through the existing stream cancellation path (agent machine CANCEL → interrupted state → `persistTurnConversation` with `ChainStatus.INTERRUPTED`).
+  - The hidden cancelled result is already in `turnMessages` and gets persisted by the existing interrupt persistence path.
+- **Patterns to follow:** `flushPartialTurnContent` in `chat.ts` for the interrupt persistence path; `history.ts:43-45` for the ERROR message filter pattern.
+- **Test files:** `electron/tests/unit/ask-question-cancel.test.ts`
+- **Test scenarios:**
+  - Cancel saves a tool result message with `hidden: true` and `status: 'cancelled'`
+  - `toApiMessages` excludes hidden messages from LLM context
+  - Hidden message is present in persisted session history (visible on reload)
+  - Abort terminates the stream; agent machine transitions to interrupted
+  - Next turn's LLM context does not include the cancelled result
+- **Verification:** Cancel persists a hidden cancelled result, aborts the turn, and the result is invisible to the LLM on subsequent turns.
+
+### U5. SubagentManager question support
+
+- **Goal:** Add pending question tracking to SubagentManager so subagent questions resolve waiters and are queryable.
+- **Requirements:** R10, R11, R12, R15, R16
+- **Dependencies:** U2
+- **Files:**
+  - `electron/src/main/agents/manager.ts` (modify — SubagentRecord + methods)
+  - `electron/src/main/tools/ask-question/store.ts` (modify — subagent question routing)
+- **Approach:**
+  - Add to `SubagentRecord`: `pendingQuestion: { toolCallId: string, questions: Question[] } | null` and `questionResolve: ((answer: QuestionAnswer[] | { declined: true }) => void) | null`.
+  - New method `markQuestionPending(subagentId, toolCallId, questions)`: stores the question on the record, then calls `_resolveWaiters(record)` to unblock any active `wait()`. The record stays in RUNNING state (not terminal).
+  - New method `answerSubagentQuestion(subagentId, answers)`: resolves `questionResolve`, clears `pendingQuestion`, sets `questionResolve` to null.
+  - New method `getPendingQuestions(sessionId)`: returns all records for the session with non-null `pendingQuestion`.
+  - The subagent's `ask_question` handler detects it's running as a subagent (via `ctx.agentScopeId !== 'main'` or similar) and routes to `markQuestionPending` instead of the user-facing IPC path. The handler awaits a Promise that `answerSubagentQuestion` resolves.
+  - If the subagent is cancelled while a question is pending, the question Promise rejects with an abort error (handled by existing cancel cleanup).
+- **Patterns to follow:** `markCompleted` / `_resolveWaiters` in `manager.ts` for the waiter resolution pattern.
+- **Test files:** `electron/tests/unit/subagent-question.test.ts`
+- **Test scenarios:**
+  - `markQuestionPending` stores question and resolves waiters
+  - Record stays in RUNNING state after `markQuestionPending` (not terminal)
+  - `answerSubagentQuestion` resolves the question Promise and clears pending state
+  - `getPendingQuestions` returns only records with pending questions for the session
+  - Multiple subagents can have pending questions simultaneously
+  - Cancelling a subagent with a pending question rejects the question Promise
+- **Verification:** Subagent question flow works: markQuestionPending → waiter resolves → answerSubagentQuestion → subagent handler gets answer.
+
+### U6. answer_subagent tool
+
+- **Goal:** New tool that lets the main agent answer or decline a subagent's pending question.
+- **Requirements:** R13, R14, R15
+- **Dependencies:** U5
+- **Files:**
+  - `electron/src/main/tools/subagent/answer.ts` (create)
+  - `electron/src/main/tools/subagent/index.ts` (modify — export)
+  - `electron/src/main/tools/index.ts` (modify — register)
+  - `electron/src/main/agents/AGENT.md` (modify — add to main agent's allowed tools)
+- **Approach:**
+  - Input schema: `{ subagent_id: z.string(), answers: z.array(answerSchema).optional(), decline: z.boolean().optional() }`. Exactly one of `answers` or `decline: true` must be provided.
+  - Handler: look up the subagent record via `SubagentManager`, verify it has a pending question, call `answerSubagentQuestion(id, answers)` or `answerSubagentQuestion(id, { declined: true })`.
+  - Error cases: subagent not found, no pending question, both answers and decline provided, neither provided.
+  - Only available to the main agent (not subagents — subagents can't answer other subagents' questions).
+- **Patterns to follow:** `electron/src/main/tools/subagent/wait.ts` for the subagent tool shape and manager access pattern.
+- **Test files:** `electron/tests/unit/answer-subagent.test.ts`
+- **Test scenarios:**
+  - Answering a subagent with a pending question resolves it
+  - Declining resolves with `{ status: "declined" }`
+  - Error when subagent has no pending question
+  - Error when subagent not found
+  - Error when both answers and decline provided
+  - Tool is not available to subagents
+- **Verification:** Main agent can answer or decline a subagent's pending question via the tool.
+
+### U7. wait_for_subagent early return
+
+- **Goal:** Modify `wait_for_subagent` to detect pending questions and return early with question data.
+- **Requirements:** R10, R11, R16
+- **Dependencies:** U5
+- **Files:**
+  - `electron/src/main/agents/manager.ts` (modify — `wait()` method)
+  - `electron/src/main/tools/subagent/wait.ts` (modify — output format)
+- **Approach:**
+  - In `SubagentManager.wait()`: after `Promise.all(pending)` resolves (via `_resolveWaiters`), check each record for `pendingQuestion !== null`. If any have pending questions, return early with those records flagged.
+  - Also check for pending questions BEFORE creating wait Promises: if a target subagent already has a pending question when `wait()` is called, return immediately without blocking (R11).
+  - In `wait.ts` handler: after `manager.wait()` returns, check each record's state. For records with `pendingQuestion`, include a `<pending_question>` XML block in the output alongside the existing `<result>` / `<error>` blocks.
+  - Output format for pending questions:
+    ```xml
+    <subagent id="..." name="..." status="question_pending">
+      <task>...</task>
+      <pending_question tool_call_id="...">
+        <question type="single" title="...">
+          <option label="..." description="..." />
+        </question>
+      </pending_question>
+    </subagent>
+    ```
+- **Patterns to follow:** Existing `wait()` Promise race pattern in `manager.ts:324-414`; existing XML output format in `wait.ts:112-155`.
+- **Test files:** `electron/tests/unit/wait-subagent-question.test.ts`
+- **Test scenarios:**
+  - `wait()` returns early when a subagent gets a pending question during the wait
+  - `wait()` returns immediately when a target subagent already has a pending question
+  - Output includes `<pending_question>` XML for question-pending subagents
+  - Completed subagents in the same wait batch still show their results
+  - Multiple pending questions from different subagents are all included
+- **Verification:** `wait_for_subagent` returns early with question data when any target subagent has a pending question.
+
+### U8. Dynamic system prompt section
+
+- **Goal:** Add a `<pending_subagent_questions>` section to the dynamic system prompt so the main agent is aware of pending questions across turns.
+- **Requirements:** R12
+- **Dependencies:** U5
+- **Files:**
+  - `electron/src/main/llm/system-prompt.ts` (modify — SystemPromptContext + rendering)
+  - `electron/src/main/llm/build-prompt-context.ts` (modify — populate field)
+- **Approach:**
+  - Add `pendingSubagentQuestions?: PendingSubagentQuestion[]` to `SystemPromptContext` interface.
+  - In `buildDynamicSystemPrompt`: after the `<subagents>` block, render `<pending_subagent_questions>` with each question's subagent ID, name, and question summary. Follow the existing conditional section pattern.
+  - In `buildSystemPromptContext`: call `SubagentManager.getPendingQuestions(sessionId)` and map to the context field.
+  - The section is only present when there are pending questions (conditional, like `<subagents>`).
+- **Patterns to follow:** The `<subagents>` section in `system-prompt.ts:134-143` for the conditional rendering pattern; `mapSubagents()` in `build-prompt-context.ts` for the data mapping pattern.
+- **Test files:** `electron/tests/unit/build-prompt-context.test.ts` (extend existing)
+- **Test scenarios:**
+  - System prompt includes `<pending_subagent_questions>` when questions are pending
+  - System prompt omits the section when no questions are pending
+  - Each pending question includes subagent ID, name, and question titles
+  - Section appears after `<subagents>` in the prompt
+- **Verification:** Main agent's system prompt reflects pending subagent questions on each turn.
+
+## Scope Boundaries
+
+- No mid-turn interruption of the main agent for subagent questions — awareness comes via system prompt on the next turn.
+- No direct user-to-subagent answering — always routed through the main agent.
+- No conditional questions (show Q2 based on Q1's answer).
+- No question timeout or auto-skip.
+- No question validation (required fields).
+- The `ask_question` tool is not available to subagents in this plan's initial units — U5 adds the routing infrastructure, but the tool's availability in subagent AGENT.md configs is a follow-up.
+
+## Open Questions
+
+Deferred to implementation:
+
+- Exact widget rendering: how the overlay integrates with the existing Footer/input component layout.
+- How the completed question widget renders in chat history (collapsed summary vs. full replay).
+- Whether the main agent's `ask_question` call for forwarding should visually indicate it originated from a subagent.
+- Subagent system prompt guidance for handling declined answers gracefully.
+- How `wait_for_subagent` formats multiple pending questions from different subagents in a single early return.
+- Whether `toApiMessages` already filters `hidden: true` messages or needs a new filter.

--- a/electron/src/main/agents/defaults/adversarial-document-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/adversarial-document-reviewer/AGENT.md
@@ -12,6 +12,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/adversarial-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/adversarial-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/agent-native-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/agent-native-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 ---
 
 # Agent-Native Architecture Reviewer

--- a/electron/src/main/agents/defaults/api-contract-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/api-contract-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/architecture-strategist/AGENT.md
+++ b/electron/src/main/agents/defaults/architecture-strategist/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/code-simplicity-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/code-simplicity-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/coherence-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/coherence-reviewer/AGENT.md
@@ -12,6 +12,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/correctness-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/correctness-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/data-integrity-guardian/AGENT.md
+++ b/electron/src/main/agents/defaults/data-integrity-guardian/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/explorer/AGENT.md
+++ b/electron/src/main/agents/defaults/explorer/AGENT.md
@@ -13,6 +13,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 ---
 
 You are a file search specialist. You excel at thoroughly navigating and exploring codebases to produce structured findings that another agent can use without re-reading the files you explored.

--- a/electron/src/main/agents/defaults/feasibility-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/feasibility-reviewer/AGENT.md
@@ -12,6 +12,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/general/AGENT.md
+++ b/electron/src/main/agents/defaults/general/AGENT.md
@@ -36,6 +36,8 @@ allowed_tools:
   - replace_symbol
   - rename_symbol
   - ast_index
+  - ask_question
+  - answer_subagent
 allowed_skills:
   - '*'
 ---

--- a/electron/src/main/agents/defaults/implementer/AGENT.md
+++ b/electron/src/main/agents/defaults/implementer/AGENT.md
@@ -21,6 +21,7 @@ allowed_tools:
   - find_symbol_references
   - replace_symbol
   - rename_symbol
+  - ask_question
 allowed_skills:
   - work
   - plan

--- a/electron/src/main/agents/defaults/learnings-researcher/AGENT.md
+++ b/electron/src/main/agents/defaults/learnings-researcher/AGENT.md
@@ -13,6 +13,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/maintainability-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/maintainability-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/performance-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/performance-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/pr-comment-resolver/AGENT.md
+++ b/electron/src/main/agents/defaults/pr-comment-resolver/AGENT.md
@@ -17,6 +17,7 @@ allowed_tools:
   - find_symbol_references
   - replace_symbol
   - rename_symbol
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/product-lens-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/product-lens-reviewer/AGENT.md
@@ -12,6 +12,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/reliability-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/reliability-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/reviewer/AGENT.md
@@ -15,6 +15,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills:
   - code-review
 ---

--- a/electron/src/main/agents/defaults/scope-guardian-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/scope-guardian-reviewer/AGENT.md
@@ -12,6 +12,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 ---
 
 You ask two questions about every plan: "Is this right-sized for its goals?" and "Does every abstraction earn its keep?" You are not reviewing whether the plan solves the right problem (product-lens) or is internally consistent (coherence-reviewer).

--- a/electron/src/main/agents/defaults/security-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/security-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/spec-flow-analyzer/AGENT.md
+++ b/electron/src/main/agents/defaults/spec-flow-analyzer/AGENT.md
@@ -12,6 +12,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 ---
 
 Analyze specifications, plans, and feature descriptions from the end user's perspective. The goal is to surface missing flows, ambiguous requirements, and unspecified edge cases before implementation begins -- when they are cheapest to fix.

--- a/electron/src/main/agents/defaults/testing-reviewer/AGENT.md
+++ b/electron/src/main/agents/defaults/testing-reviewer/AGENT.md
@@ -16,6 +16,7 @@ allowed_tools:
   - get_file_skeleton
   - get_function
   - find_symbol_references
+  - ask_question
 allowed_skills: []
 ---
 

--- a/electron/src/main/agents/defaults/web-researcher/AGENT.md
+++ b/electron/src/main/agents/defaults/web-researcher/AGENT.md
@@ -13,6 +13,7 @@ allowed_tools:
   - read_output
   - send_input
   - terminate_command
+  - ask_question
 ---
 
 The `web_fetch` tool is available in the main tool ecosystem for fetching external web pages. When the caller provides fetched content or asks you to analyze it, incorporate that content alongside local RAG and documentation findings. If you need a web page that was not provided, ask the caller to fetch it first.

--- a/electron/src/main/agents/manager.ts
+++ b/electron/src/main/agents/manager.ts
@@ -52,6 +52,11 @@ export const SubagentState = {
 
 export type SubagentState = (typeof SubagentState)[keyof typeof SubagentState];
 
+/** Result of answering (or declining) a subagent's pending question. */
+export type SubagentQuestionResult =
+  | { type: 'answered'; answers: Array<{ selected: string[]; text: string | null; skipped: boolean }> }
+  | { type: 'declined' };
+
 /** Terminal states — subagents in these states cannot be cancelled. */
 const TERMINAL_STATES = new Set<SubagentState>([
   SubagentState.COMPLETED,
@@ -157,6 +162,17 @@ export interface SubagentRecord {
   live: SubagentLiveProjection;
   _liveCommittedSegmentCount: number;
   _liveTerminalEmitted: boolean;
+  /** Pending question routed to the main agent (null when no question is outstanding). */
+  pendingQuestion: {
+    toolCallId: string;
+    questions: Array<{
+      type: 'single' | 'multi';
+      title: string;
+      description?: string;
+      options: Array<{ label: string; description?: string }>;
+    }>;
+    resolve: (result: SubagentQuestionResult) => void;
+  } | null;
 }
 
 // ── SubagentResult ──────────────────────────────────────────────────────────
@@ -252,6 +268,7 @@ export class SubagentManager {
       live: makeLiveProjection(id, options.sessionId ?? null, 'pending'),
       _liveCommittedSegmentCount: 0,
       _liveTerminalEmitted: false,
+      pendingQuestion: null,
     };
 
     this._subagents.set(id, record);
@@ -456,6 +473,10 @@ export class SubagentManager {
     record.error = record.error ?? 'Interrupted by user';
     record.endTime = record.endTime ?? Date.now();
     record.abortController?.abort();
+    if (record.pendingQuestion) {
+      record.pendingQuestion.resolve({ type: 'declined' });
+      record.pendingQuestion = null;
+    }
     // The runner owns the async interruption boundary. It must materialize its
     // partial live tail before the terminal projection is emitted; otherwise
     // the terminal event can make the renderer flush an incomplete record.
@@ -555,6 +576,78 @@ export class SubagentManager {
 
   getRecord(subagentId: string): SubagentRecord | undefined {
     return this._subagents.get(subagentId);
+  }
+
+  /**
+   * Store a pending question on the subagent record and unblock waiters.
+   *
+   * The record stays RUNNING — `_resolveWaiters` lets `wait_for_subagent`
+   * return early so the main agent can see and answer the question.
+   */
+  markQuestionPending(
+    subagentId: string,
+    toolCallId: string,
+    questions: Array<{
+      type: 'single' | 'multi';
+      title: string;
+      description?: string;
+      options: Array<{ label: string; description?: string }>;
+    }>,
+  ): Promise<SubagentQuestionResult> {
+    const record = this._subagents.get(subagentId);
+    if (!record) throw new Error(`Subagent '${subagentId}' not found`);
+
+    return new Promise((resolve) => {
+      record.pendingQuestion = { toolCallId, questions, resolve };
+      this._resolveWaiters(record);
+    });
+  }
+
+  /**
+   * Resolve a subagent's pending question with the given result.
+   *
+   * Returns false if the subagent has no pending question.
+   */
+  answerSubagentQuestion(subagentId: string, result: SubagentQuestionResult): boolean {
+    const record = this._subagents.get(subagentId);
+    if (!record?.pendingQuestion) return false;
+    record.pendingQuestion.resolve(result);
+    record.pendingQuestion = null;
+    return true;
+  }
+
+  /**
+   * Return all records for a session that have a pending question.
+   *
+   * Used by the dynamic system prompt builder to surface outstanding
+   * questions to the main agent.
+   */
+  getPendingQuestions(sessionId: string): Array<{
+    subagentId: string;
+    name: string;
+    type: string;
+    toolCallId: string;
+    questions: unknown[];
+  }> {
+    const results: Array<{
+      subagentId: string;
+      name: string;
+      type: string;
+      toolCallId: string;
+      questions: unknown[];
+    }> = [];
+    for (const [id, record] of this._subagents) {
+      if (record.sessionId === sessionId && record.pendingQuestion) {
+        results.push({
+          subagentId: id,
+          name: record.label,
+          type: record.agent.type,
+          toolCallId: record.pendingQuestion.toolCallId,
+          questions: record.pendingQuestion.questions,
+        });
+      }
+    }
+    return results;
   }
 
   getLiveProjection(subagentId: string): SubagentLiveProjection | undefined {

--- a/electron/src/main/agents/manager.ts
+++ b/electron/src/main/agents/manager.ts
@@ -88,6 +88,7 @@ export type SubagentStreamRunner = (params: {
 
 export type SubagentChangeListener = (records: readonly SubagentRecord[]) => void;
 export type SubagentLiveChangeListener = (change: SubagentLiveChange) => void;
+type SubagentWaiterReason = 'state-change' | 'flush';
 
 /** Default max time `wait_for_subagent` will block (5 minutes). */
 export const DEFAULT_WAIT_TIMEOUT_MS = 300_000;
@@ -155,7 +156,7 @@ export interface SubagentRecord {
   /** Abort controller for the in-flight run. */
   abortController: AbortController | null;
   /** Pending completion promise resolvers. */
-  _resolveWait: Array<(record: SubagentRecord) => void> | null;
+  _resolveWait: Array<(reason: SubagentWaiterReason) => void> | null;
   /** In-flight run promise (for debugging / optional await). */
   _runPromise: Promise<void> | null;
   /** Runtime-only live projection; durable history remains in `chain`. */
@@ -328,7 +329,8 @@ export class SubagentManager {
   }
 
   /**
-   * Wait for all specified subagents to reach a terminal state.
+   * Wait until all specified subagents are terminal or any target asks a
+   * question that requires the main agent's response.
    *
    * Optional `timeoutMs` races the wait without cancelling subagents.
    * Optional `signal` unblocks the wait when the parent turn is aborted
@@ -348,36 +350,17 @@ export class SubagentManager {
       throw new DOMException('Wait aborted', 'AbortError');
     }
 
-    const pending: Promise<void>[] = [];
-    const waiterCleanups: Array<() => void> = [];
+    const records = subagentIds
+      .map((id) => this._subagents.get(id))
+      .filter((record): record is SubagentRecord => record !== undefined);
+    const shouldReturn = () =>
+      records.some((record) => record.pendingQuestion !== null) ||
+      records.every((record) => TERMINAL_STATES.has(record.state));
 
-    for (const id of subagentIds) {
-      const record = this._subagents.get(id);
-      if (!record) continue;
-
-      if (TERMINAL_STATES.has(record.state)) continue;
-
-      const promise = new Promise<void>((resolve) => {
-        if (!record._resolveWait) {
-          record._resolveWait = [];
-        }
-        const entry = () => resolve();
-        record._resolveWait.push(entry);
-        waiterCleanups.push(() => {
-          if (!record._resolveWait) return;
-          const idx = record._resolveWait.indexOf(entry);
-          if (idx >= 0) record._resolveWait.splice(idx, 1);
-          if (record._resolveWait.length === 0) {
-            record._resolveWait = null;
-          }
-        });
-      });
-      pending.push(promise);
-    }
-
-    if (pending.length > 0) {
+    if (!shouldReturn()) {
       let timer: ReturnType<typeof setTimeout> | undefined;
       let onAbort: (() => void) | undefined;
+      const waiterCleanups: Array<() => void> = [];
 
       try {
         await new Promise<void>((resolve, reject) => {
@@ -388,10 +371,36 @@ export class SubagentManager {
             fn();
           };
 
-          void Promise.all(pending).then(
-            () => settle(() => resolve()),
-            (err: unknown) => settle(() => reject(err)),
-          );
+          const checkPredicate = () => {
+            if (shouldReturn()) {
+              settle(resolve);
+            }
+          };
+
+          for (const record of records) {
+            if (TERMINAL_STATES.has(record.state)) continue;
+            if (!record._resolveWait) {
+              record._resolveWait = [];
+            }
+            const entry = (reason: SubagentWaiterReason) => {
+              if (reason === 'flush') {
+                settle(resolve);
+                return;
+              }
+              checkPredicate();
+            };
+            record._resolveWait.push(entry);
+            waiterCleanups.push(() => {
+              if (!record._resolveWait) return;
+              const idx = record._resolveWait.indexOf(entry);
+              if (idx >= 0) record._resolveWait.splice(idx, 1);
+              if (record._resolveWait.length === 0) {
+                record._resolveWait = null;
+              }
+            });
+          }
+
+          checkPredicate();
 
           if (timeoutMs !== undefined && timeoutMs >= 0) {
             timer = setTimeout(() => {
@@ -416,12 +425,9 @@ export class SubagentManager {
             signal.addEventListener('abort', onAbort, { once: true });
           }
         });
-      } catch (err) {
-        // Timed out or aborted: detach this wait's resolvers only.
-        // Subagents keep their current state (still RUNNING, etc.).
-        for (const cleanup of waiterCleanups) cleanup();
-        throw err;
       } finally {
+        // Detach only this wait's callbacks. Other concurrent waits remain.
+        for (const cleanup of waiterCleanups) cleanup();
         if (timer !== undefined) clearTimeout(timer);
         if (signal && onAbort) signal.removeEventListener('abort', onAbort);
       }
@@ -524,11 +530,7 @@ export class SubagentManager {
     const flushed: string[] = [];
 
     for (const record of this._subagents.values()) {
-      if (record._resolveWait && record._resolveWait.length > 0) {
-        for (const resolve of record._resolveWait) {
-          resolve(record);
-        }
-        record._resolveWait = null;
+      if (this._resolveWaiters(record, 'flush')) {
         flushed.push(record.id);
       }
     }
@@ -596,6 +598,9 @@ export class SubagentManager {
   ): Promise<SubagentQuestionResult> {
     const record = this._subagents.get(subagentId);
     if (!record) throw new Error(`Subagent '${subagentId}' not found`);
+    if (record.pendingQuestion) {
+      return Promise.resolve({ type: 'declined' });
+    }
 
     return new Promise((resolve) => {
       record.pendingQuestion = { toolCallId, questions, resolve };
@@ -606,11 +611,18 @@ export class SubagentManager {
   /**
    * Resolve a subagent's pending question with the given result.
    *
-   * Returns false if the subagent has no pending question.
+   * Returns false if the subagent has no pending question or the supplied
+   * tool-call identity does not match the currently pending question.
    */
-  answerSubagentQuestion(subagentId: string, result: SubagentQuestionResult): boolean {
+  answerSubagentQuestion(
+    subagentId: string,
+    toolCallId: string,
+    result: SubagentQuestionResult,
+  ): boolean {
     const record = this._subagents.get(subagentId);
-    if (!record?.pendingQuestion) return false;
+    if (!record?.pendingQuestion || record.pendingQuestion.toolCallId !== toolCallId) {
+      return false;
+    }
     record.pendingQuestion.resolve(result);
     record.pendingQuestion = null;
     return true;
@@ -960,13 +972,20 @@ export class SubagentManager {
     };
   }
 
-  private _resolveWaiters(record: SubagentRecord): void {
-    if (record._resolveWait) {
-      for (const resolve of record._resolveWait) {
-        resolve(record);
+  private _resolveWaiters(
+    record: SubagentRecord,
+    reason: SubagentWaiterReason = 'state-change',
+  ): boolean {
+    const waiters = record._resolveWait;
+    if (reason === 'flush' && waiters?.length === 0) return false;
+    if (waiters) {
+      for (const resolve of waiters) {
+        resolve(reason);
       }
       record._resolveWait = null;
+      return waiters.length > 0;
     }
+    return false;
   }
 
   private _appendLiveText(record: SubagentRecord, kind: 'text' | 'thinking', content: string): void {

--- a/electron/src/main/agents/subagent-runner.ts
+++ b/electron/src/main/agents/subagent-runner.ts
@@ -32,6 +32,7 @@ const SUBAGENT_FORBIDDEN_TOOLS = new Set([
   'delegate_to_subagent',
   'wait_for_subagent',
   'interrupt_subagents',
+  'answer_subagent',
 ]);
 
 /**

--- a/electron/src/main/ipc/ask-question.ts
+++ b/electron/src/main/ipc/ask-question.ts
@@ -1,14 +1,26 @@
 /**
  * ask_question IPC — bridge pending questions between tool handler and renderer.
  *
- * Subscribes to QuestionStore events and forwards them to all renderer windows.
- * Handles answer/cancel invoke channels from the renderer.
+ * Subscribes to QuestionStore events and forwards them only to renderer
+ * windows currently viewing the owning session. Handles answer/cancel invoke
+ * channels from a renderer that still owns that selected session.
  */
-import { BrowserWindow, ipcMain } from 'electron';
+import { ipcMain } from 'electron';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
-import type { QuestionAnswer } from '../tools/ask-question/store';
-import { questionStore } from '../tools/ask-question/store';
-import { forceAbortSession } from './chat';
+import {
+  questionStore,
+  type QuestionSettledEvent,
+} from '../tools/ask-question/store';
+import {
+  forceAbortMainTurn,
+  getActiveMainTurnWindowId,
+  webContentsForWindowId,
+} from './chat';
+import { getSessionManager } from './session';
+import {
+  askQuestionAnswerSchema,
+  askQuestionCancelSchema,
+} from './payload-schemas';
 
 interface QuestionAskedPayload {
   sessionId: string;
@@ -16,33 +28,103 @@ interface QuestionAskedPayload {
   questions: unknown[];
 }
 
+function abortUndeliverableQuestion(sessionId: string, toolCallId: string): void {
+  questionStore.cancel(toolCallId);
+  forceAbortMainTurn(sessionId);
+}
+
 function onQuestionAsked({ sessionId, toolCallId, questions }: QuestionAskedPayload): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (!win.isDestroyed()) {
-      win.webContents.send(IPC_CHANNELS.ASK_QUESTION_ASKED, { sessionId, toolCallId, questions });
-    }
+  const ownerWindowId = getActiveMainTurnWindowId(sessionId);
+  if (ownerWindowId == null || !questionStore.bindOwnerWindow(toolCallId, ownerWindowId)) {
+    abortUndeliverableQuestion(sessionId, toolCallId);
+    return;
   }
+
+  const ownerWebContents = webContentsForWindowId(ownerWindowId);
+  if (!ownerWebContents) {
+    abortUndeliverableQuestion(sessionId, toolCallId);
+    return;
+  }
+
+  try {
+    ownerWebContents.send(
+      IPC_CHANNELS.ASK_QUESTION_ASKED,
+      { sessionId, toolCallId, questions },
+    );
+  } catch {
+    abortUndeliverableQuestion(sessionId, toolCallId);
+  }
+}
+
+function onQuestionSettled({
+  sessionId,
+  toolCallId,
+  ownerWindowId,
+  result,
+}: QuestionSettledEvent): void {
+  if (ownerWindowId == null) return;
+  const ownerWebContents = webContentsForWindowId(ownerWindowId);
+  if (!ownerWebContents) return;
+  try {
+    ownerWebContents.send(
+      IPC_CHANNELS.ASK_QUESTION_SETTLED,
+      { sessionId, toolCallId, result },
+    );
+  } catch {
+    // The store is already settled; a dead renderer must not reopen the wait.
+  }
+}
+
+function selectedSessionId(senderId: number): string | null {
+  return getSessionManager().getActive(String(senderId))?.id ?? null;
+}
+
+function senderOwnsQuestion(senderId: number, toolCallId: string): boolean {
+  const entry = questionStore.get(toolCallId);
+  return (
+    entry != null &&
+    entry.ownerWindowId === String(senderId) &&
+    entry.sessionId === selectedSessionId(senderId)
+  );
 }
 
 /** Register ask_question IPC handlers and store event forwarding. */
 export function registerAskQuestionIPC(): void {
   questionStore.on('question-asked', onQuestionAsked);
+  questionStore.on('question-settled', onQuestionSettled);
+
+  ipcMain.handle(IPC_CHANNELS.ASK_QUESTION_SNAPSHOT, (event) => {
+    const sessionId = selectedSessionId(event.sender.id);
+    return {
+      questions: sessionId == null
+        ? []
+        : questionStore.listForOwner(sessionId, String(event.sender.id)),
+    };
+  });
 
   ipcMain.handle(
     IPC_CHANNELS.ASK_QUESTION_ANSWER,
-    (_event, payload: { toolCallId: string; answers: QuestionAnswer[] }) => {
-      const ok = questionStore.answer(payload.toolCallId, payload.answers);
+    (event, payload: unknown) => {
+      const parsed = askQuestionAnswerSchema.parse(payload);
+      if (!senderOwnsQuestion(event.sender.id, parsed.toolCallId)) {
+        return { ok: false };
+      }
+      const ok = questionStore.answer(parsed.toolCallId, parsed.answers);
       return { ok };
     },
   );
 
   ipcMain.handle(
     IPC_CHANNELS.ASK_QUESTION_CANCEL,
-    (_event, payload: { toolCallId: string }) => {
-      const entry = questionStore.get(payload.toolCallId);
-      const ok = questionStore.cancel(payload.toolCallId);
+    (event, payload: unknown) => {
+      const parsed = askQuestionCancelSchema.parse(payload);
+      if (!senderOwnsQuestion(event.sender.id, parsed.toolCallId)) {
+        return { ok: false };
+      }
+      const entry = questionStore.get(parsed.toolCallId);
+      const ok = questionStore.cancel(parsed.toolCallId);
       if (ok && entry) {
-        setImmediate(() => forceAbortSession(entry.sessionId));
+        setImmediate(() => forceAbortMainTurn(entry.sessionId, { emitTerminalEvents: true }));
       }
       return { ok };
     },
@@ -51,7 +133,10 @@ export function registerAskQuestionIPC(): void {
 
 /** Unregister ask_question IPC handlers and store event forwarding. */
 export function unregisterAskQuestionIPC(): void {
+  questionStore.cleanupAll();
   questionStore.off('question-asked', onQuestionAsked);
+  questionStore.off('question-settled', onQuestionSettled);
+  ipcMain.removeHandler(IPC_CHANNELS.ASK_QUESTION_SNAPSHOT);
   ipcMain.removeHandler(IPC_CHANNELS.ASK_QUESTION_ANSWER);
   ipcMain.removeHandler(IPC_CHANNELS.ASK_QUESTION_CANCEL);
 }

--- a/electron/src/main/ipc/ask-question.ts
+++ b/electron/src/main/ipc/ask-question.ts
@@ -1,0 +1,57 @@
+/**
+ * ask_question IPC — bridge pending questions between tool handler and renderer.
+ *
+ * Subscribes to QuestionStore events and forwards them to all renderer windows.
+ * Handles answer/cancel invoke channels from the renderer.
+ */
+import { BrowserWindow, ipcMain } from 'electron';
+import { IPC_CHANNELS } from '../../shared/types/ipc';
+import type { QuestionAnswer } from '../tools/ask-question/store';
+import { questionStore } from '../tools/ask-question/store';
+import { forceAbortSession } from './chat';
+
+interface QuestionAskedPayload {
+  sessionId: string;
+  toolCallId: string;
+  questions: unknown[];
+}
+
+function onQuestionAsked({ sessionId, toolCallId, questions }: QuestionAskedPayload): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(IPC_CHANNELS.ASK_QUESTION_ASKED, { sessionId, toolCallId, questions });
+    }
+  }
+}
+
+/** Register ask_question IPC handlers and store event forwarding. */
+export function registerAskQuestionIPC(): void {
+  questionStore.on('question-asked', onQuestionAsked);
+
+  ipcMain.handle(
+    IPC_CHANNELS.ASK_QUESTION_ANSWER,
+    (_event, payload: { toolCallId: string; answers: QuestionAnswer[] }) => {
+      const ok = questionStore.answer(payload.toolCallId, payload.answers);
+      return { ok };
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.ASK_QUESTION_CANCEL,
+    (_event, payload: { toolCallId: string }) => {
+      const entry = questionStore.get(payload.toolCallId);
+      const ok = questionStore.cancel(payload.toolCallId);
+      if (ok && entry) {
+        setImmediate(() => forceAbortSession(entry.sessionId));
+      }
+      return { ok };
+    },
+  );
+}
+
+/** Unregister ask_question IPC handlers and store event forwarding. */
+export function unregisterAskQuestionIPC(): void {
+  questionStore.off('question-asked', onQuestionAsked);
+  ipcMain.removeHandler(IPC_CHANNELS.ASK_QUESTION_ANSWER);
+  ipcMain.removeHandler(IPC_CHANNELS.ASK_QUESTION_CANCEL);
+}

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -1579,13 +1579,16 @@ export function registerChatIPC(): void {
               m.tool_call_id === update.toolCallId,
           );
           if (!hasResult) {
+            const toolResultMsg = makeToolResultMessage(
+              update.toolCallId,
+              update.toolName ?? 'unknown',
+              update.content ?? '',
+              update.toolResult!,
+            );
             activeAgent.turnMessages.push(
-              makeToolResultMessage(
-                update.toolCallId,
-                update.toolName ?? 'unknown',
-                update.content ?? '',
-                update.toolResult!,
-              ),
+              update.toolResult?.status === 'cancelled'
+                ? { ...toolResultMsg, hidden: true }
+                : toolResultMsg,
             );
           }
         }

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -336,6 +336,12 @@ export function getLiveChatSnapshot(sessionId: string): ChatSnapshot | null {
   return active && !active.finalized ? snapshotForAgent(active) : null;
 }
 
+/** Originating renderer window for the active main-agent turn. */
+export function getActiveMainTurnWindowId(sessionId: string): string | null {
+  const active = activeAgents.get(sessionId);
+  return active && !active.finalized ? active.windowId : null;
+}
+
 function attachUsageToLatestAssistant(messages: Message[], usage: Usage): boolean {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
@@ -379,7 +385,7 @@ function flushPartialTurnContent(agent: ActiveAgent, context: AgentContext | und
 }
 
 /** Resolve WebContents for a window id (forceAbort / SESSION_UPDATED). */
-function webContentsForWindowId(windowId: string): WebContents | null {
+export function webContentsForWindowId(windowId: string): WebContents | null {
   try {
     const id = Number(windowId);
     if (!Number.isFinite(id)) return null;
@@ -426,6 +432,25 @@ export function forceAbortSession(sessionId: string): void {
     );
   }
 
+  forceAbortMainTurn(sessionId);
+}
+
+export interface ForceAbortMainTurnOptions {
+  /** Notify the originating renderer that its visible turn was interrupted. */
+  emitTerminalEvents?: boolean;
+}
+
+/**
+ * Abort and persist only the main-agent turn for one session.
+ *
+ * Interactive-question cancellation uses this narrower path so declining a
+ * main-agent question cannot terminate independent subagents or background
+ * commands owned by the same session.
+ */
+export function forceAbortMainTurn(
+  sessionId: string,
+  options: ForceAbortMainTurnOptions = {},
+): void {
   const existing = activeAgents.get(sessionId);
   if (!existing) return;
 
@@ -437,9 +462,10 @@ export function forceAbortSession(sessionId: string): void {
     return;
   }
 
+  let context: AgentContext | undefined;
   try {
     const snapshot = existing.actor.getSnapshot();
-    const context = snapshot?.context as AgentContext | undefined;
+    context = snapshot?.context as AgentContext | undefined;
     flushPartialTurnContent(existing, context);
 
     if (existing.messages.length > 0 || existing.turnMessages.length > 0) {
@@ -466,7 +492,7 @@ export function forceAbortSession(sessionId: string): void {
     }
   } catch (err) {
     console.debug(
-      'forceAbortSession persistence attempt failed (non-fatal):',
+      'forceAbortMainTurn persistence attempt failed (non-fatal):',
       err,
     );
   }
@@ -477,6 +503,36 @@ export function forceAbortSession(sessionId: string): void {
     sessionId,
     getSessionManager().getActive(existing.windowId)?.id !== sessionId,
   );
+
+  if (options.emitTerminalEvents) {
+    const ownerWebContents = webContentsForWindowId(existing.windowId);
+    if (ownerWebContents) {
+      const response = context?.response ?? '';
+      const usage = context?.usage ?? null;
+      try {
+        sendTurnEvent(ownerWebContents, existing, IPC_CHANNELS.CHAT_DONE, {
+          type: 'done',
+          response,
+          interrupted: true,
+          usage,
+        });
+      } catch (err) {
+        console.debug('Failed to emit CHAT_DONE on main-turn abort (non-fatal):', err);
+      }
+      try {
+        sendTurnEvent(ownerWebContents, existing, IPC_CHANNELS.CHAT_STATE, {
+          state: 'idle',
+          response,
+          error: null,
+          interruptState: 'idle',
+          cwd: existing.cwd,
+        });
+      } catch (err) {
+        console.debug('Failed to emit CHAT_STATE on main-turn abort (non-fatal):', err);
+      }
+    }
+  }
+
   nextAgentGeneration(sessionId);
   disposeActiveAgent(sessionId, existing);
 }
@@ -1587,7 +1643,7 @@ export function registerChatIPC(): void {
             );
             activeAgent.turnMessages.push(
               update.toolResult?.status === 'cancelled'
-                ? { ...toolResultMsg, hidden: true }
+                ? { ...toolResultMsg, excludeFromModel: true }
                 : toolResultMsg,
             );
           }

--- a/electron/src/main/ipc/index.ts
+++ b/electron/src/main/ipc/index.ts
@@ -27,6 +27,7 @@ import { registerRAGIPC, unregisterRAGIPC } from './rag';
 import { registerASTIPC, unregisterASTIPC } from './ast';
 import { registerProviderIPC, unregisterProviderIPC } from './providers';
 import { registerSubagentIPC, unregisterSubagentIPC } from './subagents';
+import { registerAskQuestionIPC, unregisterAskQuestionIPC } from './ask-question';
 
 /**
  * Register all IPC handlers.
@@ -45,6 +46,7 @@ export function registerAllIPC(): void {
   registerRAGIPC();
   registerASTIPC();
   registerSubagentIPC();
+  registerAskQuestionIPC();
 }
 
 /**
@@ -64,4 +66,5 @@ export function unregisterAllIPC(): void {
   unregisterRAGIPC();
   unregisterASTIPC();
   unregisterSubagentIPC();
+  unregisterAskQuestionIPC();
 }

--- a/electron/src/main/ipc/payload-schemas.ts
+++ b/electron/src/main/ipc/payload-schemas.ts
@@ -34,6 +34,21 @@ export const subagentSnapshotSchema = z.object({
   sessionId: z.string().uuid(),
 }).strict();
 
+// ── Ask Question ────────────────────────────────────────────────────────────
+
+export const askQuestionAnswerSchema = z.object({
+  toolCallId: z.string().uuid(),
+  answers: z.array(z.object({
+    selected: z.array(z.string()),
+    text: z.string().nullable(),
+    skipped: z.boolean(),
+  }).strict()),
+}).strict();
+
+export const askQuestionCancelSchema = z.object({
+  toolCallId: z.string().uuid(),
+}).strict();
+
 // ── Config ───────────────────────────────────────────────────────────────────
 
 /**

--- a/electron/src/main/llm/build-prompt-context.ts
+++ b/electron/src/main/llm/build-prompt-context.ts
@@ -126,6 +126,24 @@ function mapSubagents(
   }
 }
 
+/**
+ * Pending subagent questions surfaced so the main agent can answer or decline.
+ * Empty when there is no session or no outstanding questions.
+ */
+function mapPendingSubagentQuestions(
+  sessionId: string | null | undefined,
+): NonNullable<SystemPromptContext['pendingSubagentQuestions']> {
+  if (!sessionId) {
+    return [];
+  }
+  try {
+    return getSubagentManager().getPendingQuestions(sessionId) as
+      NonNullable<SystemPromptContext['pendingSubagentQuestions']>;
+  } catch {
+    return [];
+  }
+}
+
 function mapBackgroundCommands(
   sessionId: string | null | undefined,
   agentScopeId: string,
@@ -252,6 +270,7 @@ export async function buildSystemPromptContext(
     subagents: mapSubagents(sessionId, agentScopeId),
     todos: scopedTodos,
     backgroundCommands: mapBackgroundCommands(sessionId, agentScopeId),
+    pendingSubagentQuestions: mapPendingSubagentQuestions(sessionId),
   };
 }
 

--- a/electron/src/main/llm/build-prompt-context.ts
+++ b/electron/src/main/llm/build-prompt-context.ts
@@ -132,8 +132,9 @@ function mapSubagents(
  */
 function mapPendingSubagentQuestions(
   sessionId: string | null | undefined,
+  agentScopeId: string,
 ): NonNullable<SystemPromptContext['pendingSubagentQuestions']> {
-  if (!sessionId) {
+  if (!sessionId || !isMainAgentScope(agentScopeId)) {
     return [];
   }
   try {
@@ -270,7 +271,7 @@ export async function buildSystemPromptContext(
     subagents: mapSubagents(sessionId, agentScopeId),
     todos: scopedTodos,
     backgroundCommands: mapBackgroundCommands(sessionId, agentScopeId),
-    pendingSubagentQuestions: mapPendingSubagentQuestions(sessionId),
+    pendingSubagentQuestions: mapPendingSubagentQuestions(sessionId, agentScopeId),
   };
 }
 

--- a/electron/src/main/llm/history.ts
+++ b/electron/src/main/llm/history.ts
@@ -44,7 +44,7 @@ export function toApiMessages(messages: Message[]): ApiMessage[] {
       continue;
     }
 
-    if (msg.hidden) {
+    if (msg.hidden || msg.excludeFromModel) {
       continue;
     }
 
@@ -95,7 +95,7 @@ export function toApiMessages(messages: Message[]): ApiMessage[] {
       continue;
     }
 
-    if (msg.hidden) {
+    if (msg.hidden || msg.excludeFromModel) {
       continue;
     }
 

--- a/electron/src/main/llm/history.ts
+++ b/electron/src/main/llm/history.ts
@@ -44,6 +44,10 @@ export function toApiMessages(messages: Message[]): ApiMessage[] {
       continue;
     }
 
+    if (msg.hidden) {
+      continue;
+    }
+
     // Skip tool_call messages with no tool_calls
     if (msg.type === MessageType.TOOL_CALL && (!msg.tool_calls || msg.tool_calls.length === 0)) {
       continue;
@@ -88,6 +92,10 @@ export function toApiMessages(messages: Message[]): ApiMessage[] {
   for (const msg of messages) {
     // Skip error messages
     if (msg.type === MessageType.ERROR) {
+      continue;
+    }
+
+    if (msg.hidden) {
       continue;
     }
 

--- a/electron/src/main/llm/system-prompt.ts
+++ b/electron/src/main/llm/system-prompt.ts
@@ -164,7 +164,7 @@ ${escapeXml(context.directoryTree)}
         ).join('\n');
         return `      <question type="${escapeXmlAttr(question.type)}" title="${escapeXmlAttr(question.title)}"${question.description ? ` description="${escapeXmlAttr(question.description)}"` : ''}>\n${optionLines}\n      </question>`;
       }).join('\n');
-      return `  <pending_question subagent_id="${escapeXmlAttr(q.subagentId)}" name="${escapeXmlAttr(q.name)}" type="${escapeXmlAttr(q.type)}">\n${questionLines}\n  </pending_question>`;
+      return `  <pending_question subagent_id="${escapeXmlAttr(q.subagentId)}" tool_call_id="${escapeXmlAttr(q.toolCallId)}" name="${escapeXmlAttr(q.name)}" type="${escapeXmlAttr(q.type)}">\n${questionLines}\n  </pending_question>`;
     });
     content += `\n<pending_subagent_questions>\n${lines.join('\n')}\n</pending_subagent_questions>`;
   }

--- a/electron/src/main/llm/system-prompt.ts
+++ b/electron/src/main/llm/system-prompt.ts
@@ -29,6 +29,19 @@ export interface SystemPromptContext {
   todos?: TodoItem[];
   /** Active background commands. */
   backgroundCommands?: BackgroundCommand[];
+  /** Subagent questions awaiting a main-agent answer or decline. */
+  pendingSubagentQuestions?: Array<{
+    subagentId: string;
+    name: string;
+    type: string;
+    toolCallId: string;
+    questions: Array<{
+      type: string;
+      title: string;
+      description?: string;
+      options: Array<{ label: string; description?: string }>;
+    }>;
+  }>;
 }
 
 export interface SubagentState {
@@ -141,6 +154,19 @@ ${escapeXml(context.directoryTree)}
       return `  <subagent ${attrs}>${taskBlock}\n  </subagent>`;
     });
     content += `\n<subagents>\n${parts.join('\n')}\n</subagents>`;
+  }
+
+  if (context.pendingSubagentQuestions && context.pendingSubagentQuestions.length > 0) {
+    const lines = context.pendingSubagentQuestions.map((q) => {
+      const questionLines = q.questions.map((question) => {
+        const optionLines = question.options.map((opt) =>
+          `        <option label="${escapeXmlAttr(opt.label)}"${opt.description ? ` description="${escapeXmlAttr(opt.description)}"` : ''}/>`,
+        ).join('\n');
+        return `      <question type="${escapeXmlAttr(question.type)}" title="${escapeXmlAttr(question.title)}"${question.description ? ` description="${escapeXmlAttr(question.description)}"` : ''}>\n${optionLines}\n      </question>`;
+      }).join('\n');
+      return `  <pending_question subagent_id="${escapeXmlAttr(q.subagentId)}" name="${escapeXmlAttr(q.name)}" type="${escapeXmlAttr(q.type)}">\n${questionLines}\n  </pending_question>`;
+    });
+    content += `\n<pending_subagent_questions>\n${lines.join('\n')}\n</pending_subagent_questions>`;
   }
 
   // Todos

--- a/electron/src/main/tools/ask-question/ask-question.ts
+++ b/electron/src/main/tools/ask-question/ask-question.ts
@@ -1,0 +1,64 @@
+/**
+ * ask_question tool — pause the agent turn to ask the user interactive questions.
+ *
+ * The handler generates a unique question ID, registers a pending entry in the
+ * QuestionStore, and awaits the user's response (delivered via IPC). The store's
+ * EventEmitter bridges to the IPC layer which forwards to the renderer.
+ */
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import type { JsonValue } from '../../../shared/types/tool-result';
+import type { ToolDefinition, ToolHandler } from '../types';
+import { genericToolResultMetadata } from '../types';
+import { genericBuiltInToolOutcome, type GenericBuiltInToolOutcome } from '../result';
+import { questionStore } from './store';
+
+/** Result returned by the ask_question handler. */
+export type AskQuestionToolResult = GenericBuiltInToolOutcome;
+
+/** Build the ask_question tool definition and handler. */
+export function buildAskQuestionTool(): { definition: ToolDefinition; handler: ToolHandler } {
+  const definition: ToolDefinition = {
+    ...genericToolResultMetadata,
+    name: 'ask_question',
+    description:
+      'Ask the user or the agent responsible for you one or more questionss.' +
+      'Each question can be single-choice or multi-choice.' +
+      'Use this tool if you need clarifications before doing your work / assigned task' +
+      'You are paused from doing any more work until the question is answered' +
+      'If declined, the result contains { status: "declined" } ' +
+      '— continue with your best judgment rather than retrying.',
+    inputSchema: z.object({
+      questions: z.array(z.object({
+        type: z.enum(['single', 'multi']),
+        title: z.string().min(1),
+        description: z.string().optional(),
+        options: z.array(z.object({
+          label: z.string(),
+          description: z.string().optional(),
+        })).min(1),
+      })).min(1),
+    }),
+    actionLabel: 'Asking question...',
+    category: 'ask_question',
+    noTimeout: true,
+  };
+
+  const handler: ToolHandler = async (input: unknown, ctx): Promise<AskQuestionToolResult> => {
+    const { questions } = input as { questions: JsonValue[] };
+    const toolCallId = randomUUID();
+
+    const result = await questionStore.create(
+      toolCallId,
+      ctx.sessionId ?? '',
+      questions,
+    );
+
+    if (result.type === 'answered') {
+      return genericBuiltInToolOutcome('ask_question', { questions, answers: result.answers }, 'complete');
+    }
+    return genericBuiltInToolOutcome('ask_question', { questions, answers: [], cancelled: true }, 'cancelled');
+  };
+
+  return { definition, handler };
+}

--- a/electron/src/main/tools/ask-question/ask-question.ts
+++ b/electron/src/main/tools/ask-question/ask-question.ts
@@ -1,13 +1,16 @@
 /**
  * ask_question tool — pause the agent turn to ask the user interactive questions.
  *
- * The handler generates a unique question ID, registers a pending entry in the
- * QuestionStore, and awaits the user's response (delivered via IPC). The store's
- * EventEmitter bridges to the IPC layer which forwards to the renderer.
+ * Main-agent questions wait in QuestionStore for a renderer IPC response.
+ * Subagent questions wait on their shared SubagentManager record so the owning
+ * main agent can answer or decline them without emitting a renderer event.
  */
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
-import type { JsonValue } from '../../../shared/types/tool-result';
+
+import type { AskQuestionAskedEvent } from '../../../shared/types/ipc';
+import { isMainAgentScope } from '../../../shared/types/agent-scope';
+import type { SubagentManager } from '../../agents/manager';
 import type { ToolDefinition, ToolHandler } from '../types';
 import { genericToolResultMetadata } from '../types';
 import { genericBuiltInToolOutcome, type GenericBuiltInToolOutcome } from '../result';
@@ -17,7 +20,9 @@ import { questionStore } from './store';
 export type AskQuestionToolResult = GenericBuiltInToolOutcome;
 
 /** Build the ask_question tool definition and handler. */
-export function buildAskQuestionTool(): { definition: ToolDefinition; handler: ToolHandler } {
+export function buildAskQuestionTool(
+  manager: SubagentManager,
+): { definition: ToolDefinition; handler: ToolHandler } {
   const definition: ToolDefinition = {
     ...genericToolResultMetadata,
     name: 'ask_question',
@@ -45,13 +50,34 @@ export function buildAskQuestionTool(): { definition: ToolDefinition; handler: T
   };
 
   const handler: ToolHandler = async (input: unknown, ctx): Promise<AskQuestionToolResult> => {
-    const { questions } = input as { questions: JsonValue[] };
+    const { questions } = input as { questions: AskQuestionAskedEvent['questions'] };
     const toolCallId = randomUUID();
+
+    if (!isMainAgentScope(ctx.agentScopeId)) {
+      const result = await manager.markQuestionPending(
+        ctx.agentScopeId!,
+        toolCallId,
+        questions,
+      );
+      if (result.type === 'answered') {
+        return genericBuiltInToolOutcome(
+          'ask_question',
+          { questions, answers: result.answers },
+          'complete',
+        );
+      }
+      return genericBuiltInToolOutcome(
+        'ask_question',
+        { status: 'declined' },
+        'complete',
+      );
+    }
 
     const result = await questionStore.create(
       toolCallId,
       ctx.sessionId ?? '',
       questions,
+      ctx.abortSignal,
     );
 
     if (result.type === 'answered') {

--- a/electron/src/main/tools/ask-question/index.ts
+++ b/electron/src/main/tools/ask-question/index.ts
@@ -1,0 +1,8 @@
+export { buildAskQuestionTool, type AskQuestionToolResult } from './ask-question';
+export {
+  questionStore,
+  QuestionStore,
+  type QuestionAnswer,
+  type QuestionEntry,
+  type QuestionStoreResult,
+} from './store';

--- a/electron/src/main/tools/ask-question/store.ts
+++ b/electron/src/main/tools/ask-question/store.ts
@@ -22,43 +22,88 @@ export type QuestionStoreResult =
 export interface QuestionEntry {
   toolCallId: string;
   sessionId: string;
+  ownerWindowId: string | null;
   questions: unknown[];
   resolve: (result: QuestionStoreResult) => void;
+  abortSignal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+/** Serializable pending-question state exposed to the owning renderer. */
+export type PendingQuestion = Pick<QuestionEntry, 'toolCallId' | 'sessionId' | 'questions'>;
+
+/** Settlement identity retained long enough to notify the exact owning renderer. */
+export interface QuestionSettledEvent {
+  toolCallId: string;
+  sessionId: string;
+  ownerWindowId: string | null;
+  result: QuestionStoreResult['type'];
 }
 
 /**
  * In-memory store for pending ask_question tool calls.
  *
- * Emits `question-asked` with `{ sessionId, toolCallId, questions }` when a
- * new question is created. The IPC layer subscribes and forwards to renderers.
+ * Emits `question-asked` when a question is created and `question-settled`
+ * exactly once when it leaves the store. IPC forwards both to the owner.
  */
 export class QuestionStore extends EventEmitter {
   private pending = new Map<string, QuestionEntry>();
 
   /** Register a pending question and return a promise resolved by answer/cancel. */
-  create(toolCallId: string, sessionId: string, questions: unknown[]): Promise<QuestionStoreResult> {
+  create(
+    toolCallId: string,
+    sessionId: string,
+    questions: unknown[],
+    abortSignal?: AbortSignal,
+  ): Promise<QuestionStoreResult> {
+    if (abortSignal?.aborted) {
+      return Promise.resolve({ type: 'cancelled' });
+    }
+
+    this.cleanup(toolCallId);
     return new Promise((resolve) => {
-      this.pending.set(toolCallId, { toolCallId, sessionId, questions, resolve });
+      const onAbort = () => {
+        this.settle(toolCallId, { type: 'cancelled' });
+      };
+      this.pending.set(toolCallId, {
+        toolCallId,
+        sessionId,
+        ownerWindowId: null,
+        questions,
+        resolve,
+        abortSignal,
+        onAbort,
+      });
+      abortSignal?.addEventListener('abort', onAbort, { once: true });
       this.emit('question-asked', { sessionId, toolCallId, questions });
     });
   }
 
-  /** Resolve a pending question with user answers. Returns false if not found. */
-  answer(toolCallId: string, answers: QuestionAnswer[]): boolean {
+  private settle(toolCallId: string, result: QuestionStoreResult): boolean {
     const entry = this.pending.get(toolCallId);
     if (!entry) return false;
-    entry.resolve({ type: 'answered', answers });
     this.pending.delete(toolCallId);
+    if (entry.abortSignal && entry.onAbort) {
+      entry.abortSignal.removeEventListener('abort', entry.onAbort);
+    }
+    this.emit('question-settled', {
+      toolCallId: entry.toolCallId,
+      sessionId: entry.sessionId,
+      ownerWindowId: entry.ownerWindowId,
+      result: result.type,
+    } satisfies QuestionSettledEvent);
+    entry.resolve(result);
     return true;
+  }
+
+  /** Resolve a pending question with user answers. Returns false if not found. */
+  answer(toolCallId: string, answers: QuestionAnswer[]): boolean {
+    return this.settle(toolCallId, { type: 'answered', answers });
   }
 
   /** Cancel a pending question. Returns false if not found. */
   cancel(toolCallId: string): boolean {
-    const entry = this.pending.get(toolCallId);
-    if (!entry) return false;
-    entry.resolve({ type: 'cancelled' });
-    this.pending.delete(toolCallId);
-    return true;
+    return this.settle(toolCallId, { type: 'cancelled' });
   }
 
   /** Look up a pending question by ID. */
@@ -66,9 +111,36 @@ export class QuestionStore extends EventEmitter {
     return this.pending.get(toolCallId);
   }
 
-  /** Remove a pending question without resolving (cleanup on abort). */
-  cleanup(toolCallId: string): void {
-    this.pending.delete(toolCallId);
+  /** Bind a pending question to the renderer window that owns its main turn. */
+  bindOwnerWindow(toolCallId: string, ownerWindowId: string): boolean {
+    const entry = this.pending.get(toolCallId);
+    if (!entry) return false;
+    if (entry.ownerWindowId != null) {
+      return entry.ownerWindowId === ownerWindowId;
+    }
+    entry.ownerWindowId = ownerWindowId;
+    return true;
+  }
+
+  /** Replayable snapshot restricted to the exact originating renderer window. */
+  listForOwner(sessionId: string, ownerWindowId: string): PendingQuestion[] {
+    return [...this.pending.values()]
+      .filter((entry) => (
+        entry.sessionId === sessionId && entry.ownerWindowId === ownerWindowId
+      ))
+      .map(({ toolCallId, questions }) => ({ toolCallId, sessionId, questions }));
+  }
+
+  /** Cancel and remove a pending question during lifecycle cleanup. */
+  cleanup(toolCallId: string): boolean {
+    return this.settle(toolCallId, { type: 'cancelled' });
+  }
+
+  /** Cancel every pending question during IPC/app shutdown. */
+  cleanupAll(): void {
+    for (const toolCallId of [...this.pending.keys()]) {
+      this.cleanup(toolCallId);
+    }
   }
 }
 

--- a/electron/src/main/tools/ask-question/store.ts
+++ b/electron/src/main/tools/ask-question/store.ts
@@ -1,0 +1,76 @@
+/**
+ * QuestionStore — pending ask_question state bridging tool handler to IPC.
+ *
+ * The tool handler creates a pending entry and awaits its promise. The IPC
+ * layer resolves it when the renderer answers or cancels.
+ */
+import { EventEmitter } from 'node:events';
+
+/** A single answer to one question in an ask_question tool call. */
+export type QuestionAnswer = {
+  selected: string[];
+  text: string | null;
+  skipped: boolean;
+};
+
+/** Result of resolving a pending question. */
+export type QuestionStoreResult =
+  | { type: 'answered'; answers: QuestionAnswer[] }
+  | { type: 'cancelled' };
+
+/** A pending question entry awaiting user response. */
+export interface QuestionEntry {
+  toolCallId: string;
+  sessionId: string;
+  questions: unknown[];
+  resolve: (result: QuestionStoreResult) => void;
+}
+
+/**
+ * In-memory store for pending ask_question tool calls.
+ *
+ * Emits `question-asked` with `{ sessionId, toolCallId, questions }` when a
+ * new question is created. The IPC layer subscribes and forwards to renderers.
+ */
+export class QuestionStore extends EventEmitter {
+  private pending = new Map<string, QuestionEntry>();
+
+  /** Register a pending question and return a promise resolved by answer/cancel. */
+  create(toolCallId: string, sessionId: string, questions: unknown[]): Promise<QuestionStoreResult> {
+    return new Promise((resolve) => {
+      this.pending.set(toolCallId, { toolCallId, sessionId, questions, resolve });
+      this.emit('question-asked', { sessionId, toolCallId, questions });
+    });
+  }
+
+  /** Resolve a pending question with user answers. Returns false if not found. */
+  answer(toolCallId: string, answers: QuestionAnswer[]): boolean {
+    const entry = this.pending.get(toolCallId);
+    if (!entry) return false;
+    entry.resolve({ type: 'answered', answers });
+    this.pending.delete(toolCallId);
+    return true;
+  }
+
+  /** Cancel a pending question. Returns false if not found. */
+  cancel(toolCallId: string): boolean {
+    const entry = this.pending.get(toolCallId);
+    if (!entry) return false;
+    entry.resolve({ type: 'cancelled' });
+    this.pending.delete(toolCallId);
+    return true;
+  }
+
+  /** Look up a pending question by ID. */
+  get(toolCallId: string): QuestionEntry | undefined {
+    return this.pending.get(toolCallId);
+  }
+
+  /** Remove a pending question without resolving (cleanup on abort). */
+  cleanup(toolCallId: string): void {
+    this.pending.delete(toolCallId);
+  }
+}
+
+/** Process-wide singleton shared by the tool handler and IPC layer. */
+export const questionStore = new QuestionStore();

--- a/electron/src/main/tools/index.ts
+++ b/electron/src/main/tools/index.ts
@@ -41,9 +41,11 @@ import { buildWebFetchTool, type SummarizeCallback } from './web/fetch';
 import { buildSkillTool } from './skill/skill';
 import { buildMcpResourceTool } from './mcp/resource';
 import { buildListMcpResourcesTool } from './mcp/list-resources';
+import { buildAskQuestionTool } from './ask-question';
 import { buildDelegateTool } from './subagent/delegate';
 import { buildWaitTool } from './subagent/wait';
 import { buildInterruptTool } from './subagent/interrupt';
+import { buildAnswerSubagentTool } from './subagent/answer';
 import { SubagentManager } from '../agents/manager';
 import { getTierModelSelection } from '../config/loader';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
@@ -253,6 +255,8 @@ function registerBuiltinToolsInto(
   registry.register(wait.definition, wait.handler);
   const interrupt = buildInterruptTool(context.subagentManager);
   registry.register(interrupt.definition, interrupt.handler);
+  const answerSubagent = buildAnswerSubagentTool(context.subagentManager);
+  registry.register(answerSubagent.definition, answerSubagent.handler);
 
   const skill = buildSkillTool(context.skills);
   registry.register(skill.definition, skill.handler);
@@ -266,6 +270,8 @@ function registerBuiltinToolsInto(
   );
   registry.register(listMcpResources.definition, listMcpResources.handler);
 
+  const askQuestion = buildAskQuestionTool();
+  registry.register(askQuestion.definition, askQuestion.handler);
 }
 
 /** Build a dedicated, immutable-definition registry for one project runtime. */

--- a/electron/src/main/tools/index.ts
+++ b/electron/src/main/tools/index.ts
@@ -270,7 +270,7 @@ function registerBuiltinToolsInto(
   );
   registry.register(listMcpResources.definition, listMcpResources.handler);
 
-  const askQuestion = buildAskQuestionTool();
+  const askQuestion = buildAskQuestionTool(context.subagentManager);
   registry.register(askQuestion.definition, askQuestion.handler);
 }
 

--- a/electron/src/main/tools/subagent/answer.ts
+++ b/electron/src/main/tools/subagent/answer.ts
@@ -1,0 +1,88 @@
+/**
+ * answer_subagent tool — answers or declines a subagent's pending question.
+ *
+ * Params: subagent_id plus exactly one of `answers` or `decline`.
+ * Resolves the subagent's pending question so its paused turn can continue.
+ * Use after wait_for_subagent returns a subagent with a pending question.
+ */
+import { z } from 'zod';
+import type { ToolDefinition, ToolHandler } from '../types';
+import { genericToolResultMetadata } from '../types';
+import { genericBuiltInToolOutcome } from '../result';
+import type { SubagentManager, SubagentQuestionResult } from '../../agents/manager';
+import type { SubagentToolResult } from './delegate';
+
+/**
+ * Build the answer_subagent tool.
+ *
+ * @param manager - SubagentManager instance for resolving subagent questions
+ */
+export function buildAnswerSubagentTool(
+  manager: SubagentManager,
+): { definition: ToolDefinition; handler: ToolHandler } {
+  const definition: ToolDefinition = {
+    ...genericToolResultMetadata,
+    name: 'answer_subagent',
+    description:
+      "Answer or decline a subagent's pending question. " +
+      'Use after wait_for_subagent returns with a pending question.',
+    inputSchema: z.object({
+      subagent_id: z.string().describe('The subagent ID to answer.'),
+      answers: z
+        .array(
+          z.object({
+            selected: z.array(z.string()),
+            text: z.string().nullable(),
+            skipped: z.boolean(),
+          }),
+        )
+        .optional()
+        .describe('Answers to the subagent questions. Provide this OR decline, not both.'),
+      decline: z
+        .boolean()
+        .optional()
+        .describe('Decline to answer. The subagent receives a declined status.'),
+    }),
+    actionLabel: 'Answering subagent...',
+    category: 'subagent',
+  };
+
+  const handler: ToolHandler = async (input: unknown): Promise<SubagentToolResult> => {
+    const { subagent_id, answers, decline } = input as {
+      subagent_id: string;
+      answers?: Array<{ selected: string[]; text: string | null; skipped: boolean }>;
+      decline?: boolean;
+    };
+
+    const hasAnswers = answers !== undefined;
+    const hasDecline = decline !== undefined;
+    if (hasAnswers === hasDecline) {
+      return genericBuiltInToolOutcome(
+        'answer_subagent',
+        'Error: provide exactly one of "answers" or "decline".',
+        'error',
+      );
+    }
+
+    const result: SubagentQuestionResult = hasAnswers
+      ? { type: 'answered', answers: answers! }
+      : { type: 'declined' };
+
+    const resolved = manager.answerSubagentQuestion(subagent_id, result);
+    if (!resolved) {
+      return genericBuiltInToolOutcome(
+        'answer_subagent',
+        `Error: subagent '${subagent_id}' has no pending question.`,
+        'error',
+      );
+    }
+
+    return genericBuiltInToolOutcome(
+      'answer_subagent',
+      { subagent_id, status: hasAnswers ? 'answered' : 'declined' },
+      'complete',
+    );
+  };
+
+  return { definition, handler };
+}

--- a/electron/src/main/tools/subagent/answer.ts
+++ b/electron/src/main/tools/subagent/answer.ts
@@ -1,11 +1,13 @@
 /**
  * answer_subagent tool — answers or declines a subagent's pending question.
  *
- * Params: subagent_id plus exactly one of `answers` or `decline`.
+ * Params: subagent_id, tool_call_id, plus exactly one of `answers` or `decline`.
  * Resolves the subagent's pending question so its paused turn can continue.
  * Use after wait_for_subagent returns a subagent with a pending question.
  */
 import { z } from 'zod';
+
+import { isMainAgentScope } from '../../../shared/types/agent-scope';
 import type { ToolDefinition, ToolHandler } from '../types';
 import { genericToolResultMetadata } from '../types';
 import { genericBuiltInToolOutcome } from '../result';
@@ -25,9 +27,13 @@ export function buildAnswerSubagentTool(
     name: 'answer_subagent',
     description:
       "Answer or decline a subagent's pending question. " +
-      'Use after wait_for_subagent returns with a pending question.',
+      'Use after wait_for_subagent returns with a pending question, and pass ' +
+      'the exact tool_call_id from that pending_question block.',
     inputSchema: z.object({
       subagent_id: z.string().describe('The subagent ID to answer.'),
+      tool_call_id: z.string().describe(
+        'The exact tool_call_id from the current pending_question block.',
+      ),
       answers: z
         .array(
           z.object({
@@ -47,12 +53,30 @@ export function buildAnswerSubagentTool(
     category: 'subagent',
   };
 
-  const handler: ToolHandler = async (input: unknown): Promise<SubagentToolResult> => {
-    const { subagent_id, answers, decline } = input as {
+  const handler: ToolHandler = async (input: unknown, ctx): Promise<SubagentToolResult> => {
+    const { subagent_id, tool_call_id, answers, decline } = input as {
       subagent_id: string;
+      tool_call_id: string;
       answers?: Array<{ selected: string[]; text: string | null; skipped: boolean }>;
       decline?: boolean;
     };
+
+    if (!isMainAgentScope(ctx.agentScopeId)) {
+      return genericBuiltInToolOutcome(
+        'answer_subagent',
+        'Error: answer_subagent is available only to the main agent.',
+        'error',
+      );
+    }
+
+    const record = manager.getRecord(subagent_id);
+    if (!record || record.sessionId !== (ctx.sessionId ?? null)) {
+      return genericBuiltInToolOutcome(
+        'answer_subagent',
+        `Error: subagent '${subagent_id}' has no pending question.`,
+        'error',
+      );
+    }
 
     const hasAnswers = answers !== undefined;
     const hasDecline = decline !== undefined;
@@ -68,18 +92,18 @@ export function buildAnswerSubagentTool(
       ? { type: 'answered', answers: answers! }
       : { type: 'declined' };
 
-    const resolved = manager.answerSubagentQuestion(subagent_id, result);
+    const resolved = manager.answerSubagentQuestion(subagent_id, tool_call_id, result);
     if (!resolved) {
       return genericBuiltInToolOutcome(
         'answer_subagent',
-        `Error: subagent '${subagent_id}' has no pending question.`,
+        `Error: subagent '${subagent_id}' has no pending question matching tool_call_id '${tool_call_id}'.`,
         'error',
       );
     }
 
     return genericBuiltInToolOutcome(
       'answer_subagent',
-      { subagent_id, status: hasAnswers ? 'answered' : 'declined' },
+      { subagent_id, tool_call_id, status: hasAnswers ? 'answered' : 'declined' },
       'complete',
     );
   };

--- a/electron/src/main/tools/subagent/wait.ts
+++ b/electron/src/main/tools/subagent/wait.ts
@@ -76,6 +76,7 @@ export function buildWaitTool(
     description:
       'Wait for one or more subagents to complete and get their results. ' +
       "Returns the subagent's final output, status, and any errors. " +
+      'Pending questions include a tool_call_id that must be passed to answer_subagent. ' +
       'Use after delegate_to_subagent to collect results. ' +
       'If the wait times out, subagents keep running — call again or interrupt_subagents.',
     inputSchema: z.object({

--- a/electron/src/main/tools/subagent/wait.ts
+++ b/electron/src/main/tools/subagent/wait.ts
@@ -30,6 +30,38 @@ function formatElapsed(ms: number): string {
   return `${hours}h ${remainingMinutes}m`;
 }
 
+/** Render a subagent's pending question as a compact XML block. */
+function formatPendingQuestion(pending: {
+  toolCallId: string;
+  questions: Array<{
+    type: string;
+    title: string;
+    description?: string;
+    options: Array<{ label: string; description?: string }>;
+  }>;
+}): string {
+  const questionBlocks = pending.questions
+    .map((question) => {
+      const optionBlocks = question.options
+        .map((opt) =>
+          '<option label="' + escapeXmlAttribute(opt.label) + '"' +
+          (opt.description
+            ? ' description="' + escapeXmlAttribute(opt.description) + '"'
+            : '') +
+          '/>')
+        .join('');
+      return '<question type="' + escapeXmlAttribute(question.type) +
+        '" title="' + escapeXmlAttribute(question.title) + '"' +
+        (question.description
+          ? ' description="' + escapeXmlAttribute(question.description) + '"'
+          : '') +
+        '>' + optionBlocks + '</question>';
+    })
+    .join('');
+  return '<pending_question tool_call_id="' + escapeXmlAttribute(pending.toolCallId) + '">' +
+    questionBlocks + '</pending_question>';
+}
+
 /**
  * Build the wait_for_subagent tool.
  *
@@ -117,18 +149,25 @@ export function buildWaitTool(
           ? Date.now() - record.startTime
           : null;
 
+      const status = record.pendingQuestion ? 'question_pending' : record.state;
+
       const attrs =
         'id="' + escapeXmlAttribute(sid) +
         '" name="' + escapeXmlAttribute(record.label) +
         '" type="' + escapeXmlAttribute(record.agent.type) +
-        '" status="' + escapeXmlAttribute(record.state) + '"' +
+        '" status="' + escapeXmlAttribute(status) + '"' +
         (elapsed !== null ? ' elapsed="' + escapeXmlAttribute(formatElapsed(elapsed)) + '"' : '');
 
       const taskBlock = record.task
         ? '<task>' + escapeXmlText(record.task) + '</task>'
         : '';
 
-      if (record.result) {
+      if (record.pendingQuestion) {
+        parts.push(
+          '<subagent ' + attrs + '>' + taskBlock +
+            formatPendingQuestion(record.pendingQuestion) + '</subagent>',
+        );
+      } else if (record.result) {
         parts.push(
           '<subagent ' + attrs + '>' + taskBlock +
             '<result>' + escapeXmlText(record.result) + '</result></subagent>',

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -72,6 +72,10 @@ import type {
   SubagentSnapshotRequest,
   SubagentSnapshot,
   SubagentEvent,
+  AskQuestionAnswerMessage,
+  AskQuestionCancelMessage,
+  AskQuestionAskedEvent,
+  AskQuestionResult,
 } from '../shared/types/ipc';
 import {
   chatChunkEventSchema,
@@ -449,6 +453,17 @@ const orchidAPI: OrchidAPI = {
   bgCmd: {
     snapshot: (request: BgCommandSnapshotRequest) =>
       invoke(IPC_CHANNELS.BG_CMD_SNAPSHOT, request),
+  },
+
+  askQuestion: {
+    answer: (payload: AskQuestionAnswerMessage) =>
+      invoke<AskQuestionResult>(IPC_CHANNELS.ASK_QUESTION_ANSWER, payload),
+
+    cancel: (payload: AskQuestionCancelMessage) =>
+      invoke<AskQuestionResult>(IPC_CHANNELS.ASK_QUESTION_CANCEL, payload),
+
+    onAsked: (callback: (event: AskQuestionAskedEvent) => void) =>
+      on(IPC_CHANNELS.ASK_QUESTION_ASKED, (...args) => callback(args[0] as AskQuestionAskedEvent)),
   },
 };
 

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -75,7 +75,9 @@ import type {
   AskQuestionAnswerMessage,
   AskQuestionCancelMessage,
   AskQuestionAskedEvent,
+  AskQuestionSettledEvent,
   AskQuestionResult,
+  AskQuestionSnapshot,
 } from '../shared/types/ipc';
 import {
   chatChunkEventSchema,
@@ -456,6 +458,9 @@ const orchidAPI: OrchidAPI = {
   },
 
   askQuestion: {
+    snapshot: () =>
+      invoke<AskQuestionSnapshot>(IPC_CHANNELS.ASK_QUESTION_SNAPSHOT),
+
     answer: (payload: AskQuestionAnswerMessage) =>
       invoke<AskQuestionResult>(IPC_CHANNELS.ASK_QUESTION_ANSWER, payload),
 
@@ -464,6 +469,12 @@ const orchidAPI: OrchidAPI = {
 
     onAsked: (callback: (event: AskQuestionAskedEvent) => void) =>
       on(IPC_CHANNELS.ASK_QUESTION_ASKED, (...args) => callback(args[0] as AskQuestionAskedEvent)),
+
+    onSettled: (callback: (event: AskQuestionSettledEvent) => void) =>
+      on(
+        IPC_CHANNELS.ASK_QUESTION_SETTLED,
+        (...args) => callback(args[0] as AskQuestionSettledEvent),
+      ),
   },
 };
 

--- a/electron/src/renderer/components/AskQuestionOverlay.tsx
+++ b/electron/src/renderer/components/AskQuestionOverlay.tsx
@@ -1,0 +1,167 @@
+/**
+ * AskQuestionOverlay — interactive stepper shown in place of the composer
+ * while an ask_question tool call awaits the user.
+ *
+ * One question at a time: single-choice (radio-style) or multi-choice
+ * (checkbox-style) options, an optional free-text note, Back/Skip/Next
+ * navigation, and a persistent Cancel that aborts the pending tool call.
+ */
+import type { UseAskQuestionReturn } from '../hooks/useAskQuestion';
+import { Icon } from './Icon';
+import { Button } from './ui/Button';
+import { StatusBadge } from './ui/StatusBadge';
+
+export interface AskQuestionOverlayProps {
+  /** Stepper state + actions from useAskQuestion. */
+  question: UseAskQuestionReturn;
+}
+
+export function AskQuestionOverlay({ question }: AskQuestionOverlayProps) {
+  const { active } = question;
+  if (!active) return null;
+
+  const current = active.questions[active.currentIndex];
+  const answer = active.answers[active.currentIndex];
+  if (!current || !answer) return null;
+
+  const isFirst = active.currentIndex === 0;
+  const isLast = active.currentIndex === active.questions.length - 1;
+  const isMulti = current.type === 'multi';
+
+  return (
+    <section className="orchid-ask" aria-label="Agent question">
+      <header className="orchid-ask-header">
+        <span className="orchid-ask-eyebrow">
+          <Icon name="messageSquare" size={12} />
+          <span>Agent question</span>
+        </span>
+        <span className="orchid-ask-count">
+          Question {active.currentIndex + 1} of {active.questions.length}
+        </span>
+        <Button
+          variant="ghost"
+          size="xs"
+          icon="x"
+          className="orchid-ask-cancel"
+          onClick={() => {
+            void question.cancelAll();
+          }}
+        >
+          Cancel
+        </Button>
+      </header>
+
+      <div className="orchid-ask-progress" aria-hidden>
+        {active.questions.map((item, index) => (
+          <span
+            key={`${item.title}:${index}`}
+            className={`orchid-ask-progress-segment ${
+              index < active.currentIndex
+                ? 'orchid-ask-progress-done'
+                : index === active.currentIndex
+                  ? 'orchid-ask-progress-current'
+                  : ''
+            }`.trim()}
+          />
+        ))}
+      </div>
+
+      <div className="orchid-ask-body" key={active.currentIndex}>
+        <div className="orchid-ask-heading">
+          <h3 className="orchid-ask-title">{current.title}</h3>
+          {answer.skipped && (
+            <StatusBadge tone="ghost" size="xs">Skipped</StatusBadge>
+          )}
+        </div>
+        {current.description && (
+          <p className="orchid-ask-description">{current.description}</p>
+        )}
+
+        <div
+          className="orchid-ask-options"
+          role={isMulti ? 'group' : 'radiogroup'}
+          aria-label={current.title}
+        >
+          {current.options.map((option) => {
+            const selected = answer.selected.includes(option.label);
+            return (
+              <button
+                key={option.label}
+                type="button"
+                role={isMulti ? 'checkbox' : 'radio'}
+                aria-checked={selected}
+                className={`orchid-ask-option ${selected ? 'orchid-ask-option-selected' : ''}`.trim()}
+                onClick={() => question.selectOption(active.currentIndex, option.label)}
+              >
+                <span
+                  className={`orchid-ask-option-indicator ${
+                    isMulti
+                      ? 'orchid-ask-option-indicator-multi'
+                      : 'orchid-ask-option-indicator-single'
+                  }`}
+                  aria-hidden
+                >
+                  {isMulti && selected && <Icon name="check" size={10} />}
+                </span>
+                <span className="orchid-ask-option-text">
+                  <span className="orchid-ask-option-label">{option.label}</span>
+                  {option.description && (
+                    <span className="orchid-ask-option-hint">{option.description}</span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <label className="orchid-ask-note">
+          <span className="orchid-ask-note-label">Additional thoughts (optional)</span>
+          <textarea
+            className="orchid-ask-note-input"
+            value={answer.text}
+            onChange={(event) => question.setText(active.currentIndex, event.target.value)}
+            rows={2}
+          />
+        </label>
+      </div>
+
+      <footer className="orchid-ask-nav">
+        <div className="orchid-ask-nav-start">
+          <Button
+            variant="ghost"
+            size="sm"
+            icon="arrowLeft"
+            disabled={isFirst}
+            onClick={question.back}
+          >
+            Back
+          </Button>
+          <Button variant="ghost" size="sm" onClick={question.skip}>
+            Skip
+          </Button>
+        </div>
+        {isLast ? (
+          <Button
+            variant="primary"
+            size="sm"
+            iconRight="check"
+            onClick={() => {
+              void question.submit();
+            }}
+          >
+            Submit
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            size="sm"
+            iconRight="arrowRight"
+            onClick={question.next}
+          >
+            Next
+          </Button>
+        )}
+      </footer>
+    </section>
+  );
+}

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -1074,6 +1074,7 @@ export function ChatView() {
         />
         <InputArea
           key={composerDraftKey}
+          sessionId={session.activeSession?.id ?? null}
           status={chat.status}
           model={providerPickerValue}
           modelLabels={providerModelLabels}

--- a/electron/src/renderer/components/InputArea.tsx
+++ b/electron/src/renderer/components/InputArea.tsx
@@ -33,6 +33,8 @@ import { SlashCommandMenu } from './SlashCommandMenu';
 import { IconButton } from './ui/IconButton';
 
 interface InputAreaProps {
+  /** Session whose pending ask_question calls may own this composer. */
+  sessionId: string | null;
   status: ChatStatus;
   model: string;
   /** Display labels for opaque connection-scoped model picker keys. */
@@ -66,7 +68,24 @@ type SubPicker = '/theme' | '/personality' | '/model' | '/sessions' | null;
 const TEXTAREA_MIN_HEIGHT_PX = 36;
 const TEXTAREA_MAX_HEIGHT_PX = 160;
 
+export type InputEscapeAction = 'cancel-question' | 'cancel-chat' | 'none';
+
+/** Resolve global Escape ownership without allowing chat cancellation to race a question. */
+export function resolveInputEscapeAction(options: {
+  hasActiveQuestion: boolean;
+  canInterrupt: boolean;
+  isSlashMode: boolean;
+  isViewActive: boolean;
+  settingsOpen: boolean;
+}): InputEscapeAction {
+  if (options.isViewActive || options.settingsOpen) return 'none';
+  if (options.hasActiveQuestion) return 'cancel-question';
+  if (!options.canInterrupt || options.isSlashMode) return 'none';
+  return 'cancel-chat';
+}
+
 export function InputArea({
+  sessionId,
   status,
   model: _model,
   modelLabels,
@@ -95,7 +114,8 @@ export function InputArea({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [subPicker, setSubPicker] = useState<SubPicker>(null);
   /** Pending ask_question stepper; while active it owns the composer area. */
-  const askQuestion = useAskQuestion();
+  const askQuestion = useAskQuestion(sessionId);
+  const hasActiveQuestion = askQuestion.active !== null;
 
   const isStreaming = status === 'streaming';
   const hasInput = Boolean(input.trim());
@@ -375,18 +395,25 @@ export function InputArea({
       if (event.key !== 'Escape') return;
       if (isViewActive) return;
       if (document.documentElement.dataset.orchidSettingsOpen === '1') return;
-
-      if (!canInterrupt) return;
-      // Let slash-menu Esc handlers win when the menu is open on confirmSubagents
-      // with typed input — only intercept when cancel UI is active without slash.
-      if (isSlashMode) return;
+      const action = resolveInputEscapeAction({
+        hasActiveQuestion,
+        canInterrupt,
+        isSlashMode,
+        isViewActive: false,
+        settingsOpen: false,
+      });
+      if (action === 'none') return;
       event.preventDefault();
+      if (action === 'cancel-question') {
+        void askQuestion.cancelAll();
+        return;
+      }
       void onCancel();
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [canInterrupt, isSlashMode, isViewActive, onCancel]);
+  }, [askQuestion.cancelAll, canInterrupt, hasActiveQuestion, isSlashMode, isViewActive, onCancel]);
 
   const handleSend = useCallback(async () => {
     const trimmed = input.trim();

--- a/electron/src/renderer/components/InputArea.tsx
+++ b/electron/src/renderer/components/InputArea.tsx
@@ -12,6 +12,7 @@ import { useRef, useCallback, useEffect, useState, useMemo } from 'react';
 import type { CommandContext, SessionSummary } from '../../shared/types/ipc-boundary';
 import type { ProviderModelOption } from '../../shared/types/ipc';
 import type { ChatStatus, InterruptState } from '../hooks/useChat';
+import { useAskQuestion } from '../hooks/useAskQuestion';
 import {
   COMMANDS,
   trackRecentCommand,
@@ -27,6 +28,7 @@ import {
   evaluateComposerSend,
   shouldReleaseComposerSendLock,
 } from '../utils/composer-send-lock';
+import { AskQuestionOverlay } from './AskQuestionOverlay';
 import { SlashCommandMenu } from './SlashCommandMenu';
 import { IconButton } from './ui/IconButton';
 
@@ -92,6 +94,8 @@ export function InputArea({
   const [input, setInput] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [subPicker, setSubPicker] = useState<SubPicker>(null);
+  /** Pending ask_question stepper; while active it owns the composer area. */
+  const askQuestion = useAskQuestion();
 
   const isStreaming = status === 'streaming';
   const hasInput = Boolean(input.trim());
@@ -559,6 +563,16 @@ export function InputArea({
   // During confirmSubagents the agent is done — keep input editable for follow-ups.
   const inputDisabled = isStreaming || interruptState === 'confirmAgent';
   const plainChatBlocked = !workspaceBound || !providerAvailable || !modelSelected;
+
+  // A pending ask_question tool call owns the composer area; the composer (and
+  // every send path) stays unmounted until it is answered or cancelled.
+  if (askQuestion.active) {
+    return (
+      <div className="orchid-composer-area">
+        <AskQuestionOverlay question={askQuestion} />
+      </div>
+    );
+  }
 
   return (
     <div className="orchid-composer-area">

--- a/electron/src/renderer/components/ToolResults/AskQuestionToolResult.tsx
+++ b/electron/src/renderer/components/ToolResults/AskQuestionToolResult.tsx
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import {
+  genericToolResultDataSchema,
+  type CanonicalToolResult,
+} from '../../../shared/types/tool-result';
+import { StatusBadge } from '../ui/StatusBadge';
+import { GenericToolResult } from './GenericToolResult';
+
+export interface AskQuestionToolResultProps {
+  canonical: CanonicalToolResult;
+}
+
+const askQuestionAnswerSchema = z.object({
+  selected: z.array(z.string()),
+  text: z.string().nullable(),
+  skipped: z.boolean(),
+});
+
+const askQuestionQuestionSchema = z.object({
+  type: z.enum(['single', 'multi']),
+  title: z.string(),
+  description: z.string().optional(),
+  options: z.array(z.object({
+    label: z.string(),
+    description: z.string().optional(),
+  })),
+});
+
+const askQuestionValueSchema = z.object({
+  questions: z.array(askQuestionQuestionSchema).optional(),
+  answers: z.array(askQuestionAnswerSchema),
+  cancelled: z.boolean().optional(),
+}).passthrough();
+
+/** Non-interactive history summary of a completed ask_question tool call. */
+export function AskQuestionToolResult({ canonical }: AskQuestionToolResultProps) {
+  const outer = genericToolResultDataSchema.safeParse(canonical.data);
+  if (!outer.success) {
+    return <GenericToolResult canonical={canonical} />;
+  }
+  const parsed = askQuestionValueSchema.safeParse(outer.data.value);
+  if (!parsed.success) {
+    return <GenericToolResult canonical={canonical} />;
+  }
+
+  const { questions, answers, cancelled } = parsed.data;
+
+  if (cancelled || canonical.status === 'cancelled') {
+    return (
+      <div className="orchid-ask-result" data-result-family="generic">
+        <div className="orchid-ask-result-cancelled">
+          <StatusBadge tone="warning" size="xs">Cancelled</StatusBadge>
+          <span>Question was cancelled before it was answered.</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="orchid-ask-result" data-result-family="generic">
+      {answers.map((answer, index) => (
+        <section key={index} className="orchid-ask-result-item">
+          <header className="orchid-ask-result-item-header">
+            <span className="orchid-ask-result-item-title">
+              {questions?.[index]?.title ?? `Question ${index + 1}`}
+            </span>
+            {answer.skipped && (
+              <StatusBadge tone="ghost" size="xs">Skipped</StatusBadge>
+            )}
+          </header>
+          {answer.selected.length > 0 && (
+            <div className="orchid-ask-result-chips">
+              {answer.selected.map((label) => (
+                <span key={label} className="orchid-ask-result-chip">{label}</span>
+              ))}
+            </div>
+          )}
+          {answer.text && (
+            <blockquote className="orchid-ask-result-text">{answer.text}</blockquote>
+          )}
+          {answer.skipped && answer.selected.length === 0 && !answer.text && (
+            <span className="orchid-ask-result-empty">No answer provided</span>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/electron/src/renderer/components/ToolResults/registry.tsx
+++ b/electron/src/renderer/components/ToolResults/registry.tsx
@@ -9,6 +9,7 @@ import { FileContentToolResult } from './FileContentToolResult';
 import { DirectoryToolResult } from './DirectoryToolResult';
 import { SearchToolResult } from './SearchToolResult';
 import { ApplyPatchToolResult } from './ApplyPatchToolResult';
+import { AskQuestionToolResult } from './AskQuestionToolResult';
 import { LiveCommandInline } from '../ToolWidgets/LiveCommandInline';
 import { StatusBadge } from '../ui/StatusBadge';
 
@@ -109,6 +110,7 @@ toolRenderers.set('read_directory', DirectoryToolResult);
 toolRenderers.set('glob', SearchToolResult);
 toolRenderers.set('grep', SearchToolResult);
 toolRenderers.set('apply_patch', ApplyPatchToolResult);
+toolRenderers.set('ask_question', AskQuestionToolResult);
 const builtInToolRenderers = new Map(toolRenderers);
 
 export function registerToolResultRenderer(

--- a/electron/src/renderer/hooks/useAskQuestion.ts
+++ b/electron/src/renderer/hooks/useAskQuestion.ts
@@ -1,13 +1,16 @@
 /**
  * useAskQuestion — interactive ask_question stepper state.
  *
- * Subscribes to the `ask_question:asked` IPC event, holds the active question
- * set with per-question answer state, and exposes stepper actions. Submit and
- * cancel round-trip through the askQuestion bridge and clear the active state
- * so the overlay unmounts and the composer reappears.
+ * Subscribes to the `ask_question:asked` IPC event, hydrates pending calls for
+ * the selected session, and exposes stepper actions over a deduplicated FIFO.
+ * Successful submit/cancel round-trips promote the next pending call.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { AskQuestionAskedEvent } from '../../shared/types/ipc';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type {
+  AskQuestionAskedEvent,
+  AskQuestionResult,
+  AskQuestionSettledEvent,
+} from '../../shared/types/ipc';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -25,6 +28,7 @@ export interface AnswerState {
 }
 
 export interface ActiveQuestion {
+  sessionId: string;
   toolCallId: string;
   questions: Question[];
   currentIndex: number;
@@ -63,13 +67,91 @@ export interface UseAskQuestionReturn {
 export function createActiveQuestion(
   toolCallId: string,
   questions: Question[],
+  sessionId = '',
 ): ActiveQuestion {
   return {
+    sessionId,
     toolCallId,
     questions,
     currentIndex: 0,
     answers: questions.map(() => ({ selected: [], text: '', skipped: false })),
   };
+}
+
+function questionKey(question: Pick<ActiveQuestion, 'sessionId' | 'toolCallId'>): string {
+  return `${question.sessionId}\u0000${question.toolCallId}`;
+}
+
+function isUsableEvent(event: AskQuestionAskedEvent): boolean {
+  return Boolean(
+    event.sessionId &&
+    event.toolCallId &&
+    Array.isArray(event.questions) &&
+    event.questions.length > 0,
+  );
+}
+
+/** Append one pending question for the selected session without overwriting FIFO state. */
+export function enqueueQuestion(
+  queue: ActiveQuestion[],
+  event: AskQuestionAskedEvent,
+  selectedSessionId: string | null,
+): ActiveQuestion[] {
+  if (!selectedSessionId || event.sessionId !== selectedSessionId || !isUsableEvent(event)) {
+    return queue;
+  }
+  const pending = createActiveQuestion(event.toolCallId, event.questions, event.sessionId);
+  return queue.some((item) => questionKey(item) === questionKey(pending))
+    ? queue
+    : [...queue, pending];
+}
+
+/** Seed session-affine pending state, then replay events received during hydration. */
+export function reconcileQuestionSnapshot(
+  selectedSessionId: string | null,
+  snapshot: AskQuestionAskedEvent[],
+  buffered: AskQuestionAskedEvent[],
+  settledKeys: ReadonlySet<string> = new Set(),
+): ActiveQuestion[] {
+  return [...snapshot, ...buffered].reduce<ActiveQuestion[]>(
+    (queue, event) => settledKeys.has(questionKey(event))
+      ? queue
+      : enqueueQuestion(queue, event, selectedSessionId),
+    [],
+  );
+}
+
+/** Idempotently remove one question settled by the main-process store. */
+export function removeSettledQuestion(
+  queue: ActiveQuestion[],
+  settled: Pick<AskQuestionSettledEvent, 'sessionId' | 'toolCallId'>,
+): ActiveQuestion[] {
+  const settledKey = questionKey(settled);
+  const next = queue.filter((item) => questionKey(item) !== settledKey);
+  return next.length === queue.length ? queue : next;
+}
+
+/** Remove exactly one acknowledged question; rejected settlements retain the controls. */
+export function applyQuestionResult(
+  queue: ActiveQuestion[],
+  settled: Pick<ActiveQuestion, 'sessionId' | 'toolCallId'>,
+  result?: AskQuestionResult,
+): ActiveQuestion[] {
+  if (!result?.ok) return queue;
+  const settledKey = questionKey(settled);
+  return queue.filter((item) => questionKey(item) !== settledKey);
+}
+
+/** Update the active FIFO entry while rejecting stale session/tool identities. */
+export function updateActiveQuestion(
+  queue: ActiveQuestion[],
+  active: Pick<ActiveQuestion, 'sessionId' | 'toolCallId'>,
+  updater: (state: ActiveQuestion) => ActiveQuestion,
+): ActiveQuestion[] {
+  const current = queue[0];
+  if (!current || questionKey(current) !== questionKey(active)) return queue;
+  const updated = updater(current);
+  return updated === current ? queue : [updated, ...queue.slice(1)];
 }
 
 function withAnswer(
@@ -135,27 +217,122 @@ export function buildSubmissions(state: ActiveQuestion): AskQuestionSubmission[]
 
 // ── Hook ─────────────────────────────────────────────────────────────────────
 
-export function useAskQuestion(): UseAskQuestionReturn {
-  const [active, setActive] = useState<ActiveQuestion | null>(null);
+export function useAskQuestion(sessionId: string | null): UseAskQuestionReturn {
+  const [queue, setQueue] = useState<ActiveQuestion[]>([]);
+  const active = queue[0]?.sessionId === sessionId ? queue[0] : null;
   const activeRef = useRef<ActiveQuestion | null>(null);
-  /** Guards against overlapping submit/cancel round-trips. */
-  const busyRef = useRef(false);
+  const selectedSessionRef = useRef(sessionId);
+  const hydrationGenerationRef = useRef(0);
+  const hydrationRef = useRef<{
+    generation: number;
+    sessionId: string;
+    buffered: AskQuestionAskedEvent[];
+    settledKeys: Set<string>;
+  } | null>(null);
+  /** Identity of the question with an in-flight answer/cancel round-trip. */
+  const busyRef = useRef<string | null>(null);
 
-  useEffect(() => {
+  selectedSessionRef.current = sessionId;
+
+  useLayoutEffect(() => {
     activeRef.current = active;
   }, [active]);
 
+  // A snapshot makes pending questions replayable after remounts and session
+  // switches. Live events received while it is in flight are buffered, then
+  // appended in arrival order after the authoritative snapshot.
   useEffect(() => {
     const bridge = window.orchid?.askQuestion;
-    if (!bridge) return;
-    return bridge.onAsked((event: AskQuestionAskedEvent) => {
-      if (!Array.isArray(event.questions) || event.questions.length === 0) return;
-      setActive(createActiveQuestion(event.toolCallId, event.questions));
+    const generation = ++hydrationGenerationRef.current;
+    busyRef.current = null;
+    setQueue([]);
+
+    if (!bridge || !sessionId) {
+      hydrationRef.current = null;
+      return;
+    }
+
+    const pending = {
+      generation,
+      sessionId,
+      buffered: [] as AskQuestionAskedEvent[],
+      settledKeys: new Set<string>(),
+    };
+    hydrationRef.current = pending;
+    let cancelled = false;
+
+    const unsubscribeAsked = bridge.onAsked((event: AskQuestionAskedEvent) => {
+      if (event.sessionId !== sessionId || !isUsableEvent(event)) return;
+      const currentHydration = hydrationRef.current;
+      if (currentHydration?.sessionId === sessionId) {
+        const key = questionKey(event);
+        if (!currentHydration.buffered.some((item) => questionKey(item) === key)) {
+          currentHydration.buffered.push(event);
+        }
+        return;
+      }
+      setQueue((previous) => enqueueQuestion(previous, event, sessionId));
     });
-  }, []);
+    const unsubscribeSettled = bridge.onSettled((event: AskQuestionSettledEvent) => {
+      if (event.sessionId !== sessionId || !event.toolCallId) return;
+      const key = questionKey(event);
+      if (busyRef.current === key) busyRef.current = null;
+      const currentHydration = hydrationRef.current;
+      if (currentHydration?.sessionId === sessionId) {
+        currentHydration.settledKeys.add(key);
+        currentHydration.buffered = currentHydration.buffered.filter(
+          (item) => questionKey(item) !== key,
+        );
+      }
+      setQueue((previous) => removeSettledQuestion(previous, event));
+    });
+
+    void bridge.snapshot().then(
+      (snapshot) => {
+        if (
+          cancelled ||
+          hydrationGenerationRef.current !== generation ||
+          selectedSessionRef.current !== sessionId
+        ) return;
+        const buffered = hydrationRef.current === pending ? pending.buffered : [];
+        const settledKeys = hydrationRef.current === pending
+          ? pending.settledKeys
+          : new Set<string>();
+        hydrationRef.current = null;
+        setQueue(reconcileQuestionSnapshot(
+          sessionId,
+          snapshot.questions,
+          buffered,
+          settledKeys,
+        ));
+      },
+      () => {
+        if (
+          cancelled ||
+          hydrationGenerationRef.current !== generation ||
+          selectedSessionRef.current !== sessionId
+        ) return;
+        const buffered = hydrationRef.current === pending ? pending.buffered : [];
+        const settledKeys = hydrationRef.current === pending
+          ? pending.settledKeys
+          : new Set<string>();
+        hydrationRef.current = null;
+        setQueue(reconcileQuestionSnapshot(sessionId, [], buffered, settledKeys));
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      if (hydrationRef.current === pending) hydrationRef.current = null;
+      unsubscribeAsked();
+      unsubscribeSettled();
+    };
+  }, [sessionId]);
 
   const update = useCallback((updater: (state: ActiveQuestion) => ActiveQuestion) => {
-    setActive((prev) => (prev ? updater(prev) : prev));
+    const current = activeRef.current;
+    if (!current) return;
+    setQueue((previous) => updateActiveQuestion(previous, current, updater));
   }, []);
 
   const selectOption = useCallback(
@@ -188,69 +365,62 @@ export function useAskQuestion(): UseAskQuestionReturn {
     );
   }, [update]);
 
-  /** Clear the stepper only when the settled round-trip still owns it. */
-  const release = useCallback((toolCallId: string) => {
-    busyRef.current = false;
-    setActive((prev) => (prev && prev.toolCallId === toolCallId ? null : prev));
+  const finishRoundTrip = useCallback((state: ActiveQuestion, result?: AskQuestionResult) => {
+    const key = questionKey(state);
+    if (busyRef.current === key) busyRef.current = null;
+    setQueue((previous) => applyQuestionResult(previous, state, result));
   }, []);
 
   const sendAnswers = useCallback(
     async (state: ActiveQuestion) => {
       const bridge = window.orchid?.askQuestion;
-      if (!bridge) {
-        release(state.toolCallId);
-        return;
-      }
-      busyRef.current = true;
+      if (!bridge) return;
+      busyRef.current = questionKey(state);
       try {
-        await bridge.answer({
+        const result = await bridge.answer({
           toolCallId: state.toolCallId,
           answers: buildSubmissions(state),
         });
+        finishRoundTrip(state, result);
       } catch {
-        // The widget must release even when the bridge fails; main reports the
-        // turn-level error through the normal chat error path.
-      } finally {
-        release(state.toolCallId);
+        finishRoundTrip(state);
       }
     },
-    [release],
+    [finishRoundTrip],
   );
 
   const submit = useCallback(async () => {
     const state = activeRef.current;
-    if (!state || busyRef.current) return;
+    if (!state || busyRef.current !== null) return;
     await sendAnswers(state);
   }, [sendAnswers]);
 
   const skip = useCallback(() => {
     const state = activeRef.current;
-    if (!state || busyRef.current) return;
+    if (!state || busyRef.current !== null) return;
     const skipped = markAnswerSkipped(state, state.currentIndex);
     if (state.currentIndex >= state.questions.length - 1) {
+      setQueue((previous) => updateActiveQuestion(previous, state, () => skipped));
       void sendAnswers(skipped);
       return;
     }
-    setActive({ ...skipped, currentIndex: state.currentIndex + 1 });
+    const advanced = { ...skipped, currentIndex: state.currentIndex + 1 };
+    setQueue((previous) => updateActiveQuestion(previous, state, () => advanced));
   }, [sendAnswers]);
 
   const cancelAll = useCallback(async () => {
     const state = activeRef.current;
-    if (!state || busyRef.current) return;
+    if (!state || busyRef.current !== null) return;
     const bridge = window.orchid?.askQuestion;
-    if (!bridge) {
-      release(state.toolCallId);
-      return;
-    }
-    busyRef.current = true;
+    if (!bridge) return;
+    busyRef.current = questionKey(state);
     try {
-      await bridge.cancel({ toolCallId: state.toolCallId });
+      const result = await bridge.cancel({ toolCallId: state.toolCallId });
+      finishRoundTrip(state, result);
     } catch {
-      // Release regardless — a stuck overlay would block the composer forever.
-    } finally {
-      release(state.toolCallId);
+      finishRoundTrip(state);
     }
-  }, [release]);
+  }, [finishRoundTrip]);
 
   return useMemo(
     () => ({

--- a/electron/src/renderer/hooks/useAskQuestion.ts
+++ b/electron/src/renderer/hooks/useAskQuestion.ts
@@ -1,0 +1,268 @@
+/**
+ * useAskQuestion — interactive ask_question stepper state.
+ *
+ * Subscribes to the `ask_question:asked` IPC event, holds the active question
+ * set with per-question answer state, and exposes stepper actions. Submit and
+ * cancel round-trip through the askQuestion bridge and clear the active state
+ * so the overlay unmounts and the composer reappears.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { AskQuestionAskedEvent } from '../../shared/types/ipc';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface Question {
+  type: 'single' | 'multi';
+  title: string;
+  description?: string;
+  options: Array<{ label: string; description?: string }>;
+}
+
+export interface AnswerState {
+  selected: string[];
+  text: string;
+  skipped: boolean;
+}
+
+export interface ActiveQuestion {
+  toolCallId: string;
+  questions: Question[];
+  currentIndex: number;
+  answers: AnswerState[];
+}
+
+/** One answer serialized for the askQuestion.answer IPC payload. */
+export interface AskQuestionSubmission {
+  selected: string[];
+  text: string | null;
+  skipped: boolean;
+}
+
+export interface UseAskQuestionReturn {
+  /** Active stepper state; null when no question is pending. */
+  active: ActiveQuestion | null;
+  /** Select an option: single-choice replaces, multi-choice toggles. */
+  selectOption: (questionIndex: number, label: string) => void;
+  /** Set the free-text note for a question. */
+  setText: (questionIndex: number, text: string) => void;
+  /** Advance to the next question (no-op on the last). */
+  next: () => void;
+  /** Return to the previous question (no-op on the first). */
+  back: () => void;
+  /** Mark the current question skipped and advance, or submit on the last. */
+  skip: () => void;
+  /** Send all answers through the askQuestion bridge and close the stepper. */
+  submit: () => Promise<void>;
+  /** Cancel the pending tool call and close the stepper. */
+  cancelAll: () => Promise<void>;
+}
+
+// ── Pure state transitions ───────────────────────────────────────────────────
+
+/** Build a fresh stepper state with one empty answer per question. */
+export function createActiveQuestion(
+  toolCallId: string,
+  questions: Question[],
+): ActiveQuestion {
+  return {
+    toolCallId,
+    questions,
+    currentIndex: 0,
+    answers: questions.map(() => ({ selected: [], text: '', skipped: false })),
+  };
+}
+
+function withAnswer(
+  state: ActiveQuestion,
+  questionIndex: number,
+  answer: AnswerState,
+): ActiveQuestion {
+  const answers = state.answers.slice();
+  answers[questionIndex] = answer;
+  return { ...state, answers };
+}
+
+/** Apply an option click: single replaces the selection, multi toggles it. */
+export function applyOptionSelection(
+  state: ActiveQuestion,
+  questionIndex: number,
+  label: string,
+): ActiveQuestion {
+  const question = state.questions[questionIndex];
+  const answer = state.answers[questionIndex];
+  if (!question || !answer) return state;
+  const selected =
+    question.type === 'single'
+      ? [label]
+      : answer.selected.includes(label)
+        ? answer.selected.filter((item) => item !== label)
+        : [...answer.selected, label];
+  return withAnswer(state, questionIndex, { ...answer, selected, skipped: false });
+}
+
+/** Set free text for a question (independent of option selections). */
+export function applyText(
+  state: ActiveQuestion,
+  questionIndex: number,
+  text: string,
+): ActiveQuestion {
+  const answer = state.answers[questionIndex];
+  if (!answer) return state;
+  return withAnswer(state, questionIndex, { ...answer, text, skipped: false });
+}
+
+/** Mark one question as skipped without touching its selections or text. */
+export function markAnswerSkipped(
+  state: ActiveQuestion,
+  questionIndex: number,
+): ActiveQuestion {
+  const answer = state.answers[questionIndex];
+  if (!answer) return state;
+  return withAnswer(state, questionIndex, { ...answer, skipped: true });
+}
+
+/** Serialize answers for IPC: trimmed text, null when empty. */
+export function buildSubmissions(state: ActiveQuestion): AskQuestionSubmission[] {
+  return state.answers.map((answer) => {
+    const text = answer.text.trim();
+    return {
+      selected: answer.selected,
+      text: text ? text : null,
+      skipped: answer.skipped,
+    };
+  });
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useAskQuestion(): UseAskQuestionReturn {
+  const [active, setActive] = useState<ActiveQuestion | null>(null);
+  const activeRef = useRef<ActiveQuestion | null>(null);
+  /** Guards against overlapping submit/cancel round-trips. */
+  const busyRef = useRef(false);
+
+  useEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  useEffect(() => {
+    const bridge = window.orchid?.askQuestion;
+    if (!bridge) return;
+    return bridge.onAsked((event: AskQuestionAskedEvent) => {
+      if (!Array.isArray(event.questions) || event.questions.length === 0) return;
+      setActive(createActiveQuestion(event.toolCallId, event.questions));
+    });
+  }, []);
+
+  const update = useCallback((updater: (state: ActiveQuestion) => ActiveQuestion) => {
+    setActive((prev) => (prev ? updater(prev) : prev));
+  }, []);
+
+  const selectOption = useCallback(
+    (questionIndex: number, label: string) => {
+      update((state) => applyOptionSelection(state, questionIndex, label));
+    },
+    [update],
+  );
+
+  const setText = useCallback(
+    (questionIndex: number, text: string) => {
+      update((state) => applyText(state, questionIndex, text));
+    },
+    [update],
+  );
+
+  const next = useCallback(() => {
+    update((state) =>
+      state.currentIndex < state.questions.length - 1
+        ? { ...state, currentIndex: state.currentIndex + 1 }
+        : state,
+    );
+  }, [update]);
+
+  const back = useCallback(() => {
+    update((state) =>
+      state.currentIndex > 0
+        ? { ...state, currentIndex: state.currentIndex - 1 }
+        : state,
+    );
+  }, [update]);
+
+  /** Clear the stepper only when the settled round-trip still owns it. */
+  const release = useCallback((toolCallId: string) => {
+    busyRef.current = false;
+    setActive((prev) => (prev && prev.toolCallId === toolCallId ? null : prev));
+  }, []);
+
+  const sendAnswers = useCallback(
+    async (state: ActiveQuestion) => {
+      const bridge = window.orchid?.askQuestion;
+      if (!bridge) {
+        release(state.toolCallId);
+        return;
+      }
+      busyRef.current = true;
+      try {
+        await bridge.answer({
+          toolCallId: state.toolCallId,
+          answers: buildSubmissions(state),
+        });
+      } catch {
+        // The widget must release even when the bridge fails; main reports the
+        // turn-level error through the normal chat error path.
+      } finally {
+        release(state.toolCallId);
+      }
+    },
+    [release],
+  );
+
+  const submit = useCallback(async () => {
+    const state = activeRef.current;
+    if (!state || busyRef.current) return;
+    await sendAnswers(state);
+  }, [sendAnswers]);
+
+  const skip = useCallback(() => {
+    const state = activeRef.current;
+    if (!state || busyRef.current) return;
+    const skipped = markAnswerSkipped(state, state.currentIndex);
+    if (state.currentIndex >= state.questions.length - 1) {
+      void sendAnswers(skipped);
+      return;
+    }
+    setActive({ ...skipped, currentIndex: state.currentIndex + 1 });
+  }, [sendAnswers]);
+
+  const cancelAll = useCallback(async () => {
+    const state = activeRef.current;
+    if (!state || busyRef.current) return;
+    const bridge = window.orchid?.askQuestion;
+    if (!bridge) {
+      release(state.toolCallId);
+      return;
+    }
+    busyRef.current = true;
+    try {
+      await bridge.cancel({ toolCallId: state.toolCallId });
+    } catch {
+      // Release regardless — a stuck overlay would block the composer forever.
+    } finally {
+      release(state.toolCallId);
+    }
+  }, [release]);
+
+  return useMemo(
+    () => ({
+      active,
+      selectOption,
+      setText,
+      next,
+      back,
+      skip,
+      submit,
+      cancelAll,
+    }),
+    [active, selectOption, setText, next, back, skip, submit, cancelAll],
+  );
+}

--- a/electron/src/renderer/styles/components.css
+++ b/electron/src/renderer/styles/components.css
@@ -809,6 +809,212 @@
     @apply flex shrink-0 items-center gap-1.5 border-b border-base-content/10 px-2.5 py-1.5 text-xs uppercase tracking-wide text-base-content/60;
   }
 
+  /* ── Ask-question stepper (composer overlay) ────────────────────────────── */
+
+  .orchid-ask {
+    @apply flex flex-col overflow-hidden rounded-lg border border-base-300 bg-base-200 text-sm shadow-lg;
+    margin: 2px 0 6px;
+    animation: orchid-rise 240ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .orchid-ask-header {
+    @apply flex items-center gap-2 border-b border-base-content/10 px-3 py-2;
+  }
+
+  .orchid-ask-eyebrow {
+    @apply inline-flex min-w-0 items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-primary;
+  }
+
+  .orchid-ask-count {
+    @apply ml-auto shrink-0 text-xs tabular-nums text-base-content/60;
+  }
+
+  .orchid-ask-cancel {
+    @apply shrink-0;
+  }
+
+  .orchid-ask-progress {
+    @apply flex gap-1 px-3 pt-2.5;
+  }
+
+  .orchid-ask-progress-segment {
+    @apply h-1 flex-1 rounded-full bg-base-content/15;
+    transition: background-color 180ms ease;
+  }
+
+  .orchid-ask-progress-done {
+    @apply bg-primary/60;
+  }
+
+  .orchid-ask-progress-current {
+    @apply bg-primary;
+  }
+
+  .orchid-ask-body {
+    @apply flex flex-col gap-2.5 overflow-y-auto px-3 py-3;
+    max-height: 48vh;
+    animation: orchid-rise 200ms ease-out;
+  }
+
+  .orchid-ask-heading {
+    @apply flex items-start justify-between gap-2;
+  }
+
+  .orchid-ask-title {
+    @apply m-0 text-base font-semibold text-base-content;
+    font-family: var(--font-display, inherit);
+  }
+
+  .orchid-ask-description {
+    @apply -mt-1 m-0 text-xs text-base-content/65;
+  }
+
+  .orchid-ask-options {
+    @apply flex flex-col gap-1.5;
+  }
+
+  .orchid-ask-option {
+    @apply flex w-full cursor-pointer items-start gap-2.5 rounded-md border border-base-300 bg-base-100 px-2.5 py-2 text-left;
+    transition:
+      border-color var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1)),
+      background-color var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1)),
+      transform var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1));
+  }
+
+  .orchid-ask-option:hover {
+    border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-base-300));
+    background: color-mix(in srgb, var(--color-primary) 6%, var(--color-base-100));
+  }
+
+  .orchid-ask-option:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
+    outline-offset: 1px;
+  }
+
+  .orchid-ask-option:active {
+    transform: scale(0.995);
+  }
+
+  .orchid-ask-option-selected {
+    border-color: color-mix(in srgb, var(--color-primary) 55%, var(--color-base-300));
+    background: color-mix(in srgb, var(--color-primary) 10%, var(--color-base-100));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary) 35%, transparent);
+  }
+
+  .orchid-ask-option-indicator {
+    @apply mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center border border-base-content/35 bg-base-100 text-primary-content;
+    transition:
+      border-color var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1)),
+      background-color var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1));
+  }
+
+  .orchid-ask-option-indicator-single {
+    border-radius: 9999px;
+  }
+
+  .orchid-ask-option-indicator-multi {
+    border-radius: 4px;
+  }
+
+  .orchid-ask-option-selected .orchid-ask-option-indicator {
+    border-color: var(--color-primary);
+  }
+
+  .orchid-ask-option-selected .orchid-ask-option-indicator-single::after {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 9999px;
+    background: var(--color-primary);
+    animation: orchid-pop 160ms ease-out;
+  }
+
+  .orchid-ask-option-selected .orchid-ask-option-indicator-multi {
+    background: var(--color-primary);
+  }
+
+  .orchid-ask-option-text {
+    @apply flex min-w-0 flex-col;
+  }
+
+  .orchid-ask-option-label {
+    @apply text-sm font-medium text-base-content;
+  }
+
+  .orchid-ask-option-hint {
+    @apply text-xs text-base-content/60;
+  }
+
+  .orchid-ask-note {
+    @apply flex flex-col gap-1;
+  }
+
+  .orchid-ask-note-label {
+    @apply text-xs font-medium text-base-content/70;
+  }
+
+  .orchid-ask-note-input {
+    @apply w-full resize-none rounded-md border border-base-300 bg-base-100 px-2.5 py-2 text-sm text-base-content outline-none;
+    transition:
+      border-color var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1)),
+      box-shadow var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1));
+  }
+
+  .orchid-ask-note-input:focus {
+    border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-base-300));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 10%, transparent);
+  }
+
+  .orchid-ask-nav {
+    @apply flex items-center justify-between gap-2 border-t border-base-content/10 px-3 py-2;
+  }
+
+  .orchid-ask-nav-start {
+    @apply flex items-center gap-1;
+  }
+
+  /* ── Ask-question terminal summary (chat history) ───────────────────────── */
+
+  .orchid-ask-result {
+    @apply flex min-w-0 flex-col gap-2 text-sm;
+  }
+
+  .orchid-ask-result-cancelled {
+    @apply flex items-center gap-2 text-xs text-base-content/70;
+  }
+
+  .orchid-ask-result-item {
+    @apply flex min-w-0 flex-col gap-1.5 rounded-md border border-base-300/70 bg-base-200/60 px-2.5 py-2;
+  }
+
+  .orchid-ask-result-item-header {
+    @apply flex items-center gap-2;
+  }
+
+  .orchid-ask-result-item-title {
+    @apply text-xs font-semibold uppercase tracking-wide text-base-content/70;
+  }
+
+  .orchid-ask-result-chips {
+    @apply flex flex-wrap gap-1.5;
+  }
+
+  .orchid-ask-result-chip {
+    @apply inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium;
+    background: color-mix(in srgb, var(--color-primary) 14%, transparent);
+    color: color-mix(in srgb, var(--color-primary) 80%, var(--color-base-content));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 30%, transparent);
+  }
+
+  .orchid-ask-result-text {
+    @apply m-0 border-l-2 border-base-content/20 pl-2 text-xs text-base-content/80;
+    white-space: pre-wrap;
+  }
+
+  .orchid-ask-result-empty {
+    @apply text-xs text-base-content/50;
+  }
+
   .orchid-chat-footer {
     @apply flex shrink-0 items-center justify-between gap-2.5 bg-base-100 text-xs text-base-content/70;
     min-height: 34px;

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -670,6 +670,42 @@ export interface ToolExecuteMessage {
 
 export type ToolExecuteResult = ToolExecutionResult;
 
+// ── Ask Question API ─────────────────────────────────────────────────────────
+
+/** Event payload when the agent asks the user interactive questions. */
+export interface AskQuestionAskedEvent {
+  sessionId: string;
+  toolCallId: string;
+  questions: Array<{
+    type: 'single' | 'multi';
+    title: string;
+    description?: string;
+    options: Array<{
+      label: string;
+      description?: string;
+    }>;
+  }>;
+}
+
+/** Renderer → main: submit answers for a pending ask_question tool call. */
+export interface AskQuestionAnswerMessage {
+  toolCallId: string;
+  answers: Array<{
+    selected: string[];
+    text: string | null;
+    skipped: boolean;
+  }>;
+}
+
+/** Renderer → main: cancel a pending ask_question tool call. */
+export interface AskQuestionCancelMessage {
+  toolCallId: string;
+}
+
+export interface AskQuestionResult {
+  ok: boolean;
+}
+
 // ── RAG API ──────────────────────────────────────────────────────────────────
 
 export interface RAGIndexMessage {
@@ -860,6 +896,12 @@ export interface OrchidAPI {
   bgCmd: {
     snapshot: (request: BgCommandSnapshotRequest) => Promise<BgCommandSnapshotResult>;
   };
+
+  askQuestion: {
+    answer: (payload: AskQuestionAnswerMessage) => Promise<AskQuestionResult>;
+    cancel: (payload: AskQuestionCancelMessage) => Promise<AskQuestionResult>;
+    onAsked: (callback: (event: AskQuestionAskedEvent) => void) => () => void;
+  };
 }
 
 // ── IPC Channel names ────────────────────────────────────────────────────────
@@ -981,6 +1023,11 @@ export const IPC_CHANNELS = {
   // Background Commands
   BG_CMD_SNAPSHOT: 'bgcmd:snapshot',
 
+  // Ask Question
+  ASK_QUESTION_ASKED: 'ask_question:asked',
+  ASK_QUESTION_ANSWER: 'ask_question:answer',
+  ASK_QUESTION_CANCEL: 'ask_question:cancel',
+
   // Updater
   UPDATER_STATUS_UPDATE: 'updater:status_update',
   UPDATER_PROGRESS: 'updater:progress',
@@ -1051,6 +1098,8 @@ export const ALLOWED_INVOKE_CHANNELS = [
   IPC_CHANNELS.AST_INDEX,
   IPC_CHANNELS.AST_INDEX_STATE,
   IPC_CHANNELS.BG_CMD_SNAPSHOT,
+  IPC_CHANNELS.ASK_QUESTION_ANSWER,
+  IPC_CHANNELS.ASK_QUESTION_CANCEL,
 ] as const satisfies readonly IPCChannel[];
 
 // ── Allowed event channels (preload security gate) ───────────────────────────
@@ -1076,6 +1125,7 @@ export const ALLOWED_EVENT_CHANNELS = [
   IPC_CHANNELS.SESSION_WORKING_SET_CHANGED,
   IPC_CHANNELS.RAG_PROGRESS,
   IPC_CHANNELS.AST_PROGRESS,
+  IPC_CHANNELS.ASK_QUESTION_ASKED,
 ] as const satisfies readonly IPCChannel[];
 
 // ── Window type augmentation (renderer-side) ─────────────────────────────────

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -687,6 +687,13 @@ export interface AskQuestionAskedEvent {
   }>;
 }
 
+/** Event payload when a pending interactive question leaves the main store. */
+export interface AskQuestionSettledEvent {
+  sessionId: string;
+  toolCallId: string;
+  result: 'answered' | 'cancelled';
+}
+
 /** Renderer → main: submit answers for a pending ask_question tool call. */
 export interface AskQuestionAnswerMessage {
   toolCallId: string;
@@ -704,6 +711,11 @@ export interface AskQuestionCancelMessage {
 
 export interface AskQuestionResult {
   ok: boolean;
+}
+
+/** Replayable pending questions for the session selected by the invoking window. */
+export interface AskQuestionSnapshot {
+  questions: AskQuestionAskedEvent[];
 }
 
 // ── RAG API ──────────────────────────────────────────────────────────────────
@@ -898,9 +910,11 @@ export interface OrchidAPI {
   };
 
   askQuestion: {
+    snapshot: () => Promise<AskQuestionSnapshot>;
     answer: (payload: AskQuestionAnswerMessage) => Promise<AskQuestionResult>;
     cancel: (payload: AskQuestionCancelMessage) => Promise<AskQuestionResult>;
     onAsked: (callback: (event: AskQuestionAskedEvent) => void) => () => void;
+    onSettled: (callback: (event: AskQuestionSettledEvent) => void) => () => void;
   };
 }
 
@@ -1025,6 +1039,8 @@ export const IPC_CHANNELS = {
 
   // Ask Question
   ASK_QUESTION_ASKED: 'ask_question:asked',
+  ASK_QUESTION_SETTLED: 'ask_question:settled',
+  ASK_QUESTION_SNAPSHOT: 'ask_question:snapshot',
   ASK_QUESTION_ANSWER: 'ask_question:answer',
   ASK_QUESTION_CANCEL: 'ask_question:cancel',
 
@@ -1098,6 +1114,7 @@ export const ALLOWED_INVOKE_CHANNELS = [
   IPC_CHANNELS.AST_INDEX,
   IPC_CHANNELS.AST_INDEX_STATE,
   IPC_CHANNELS.BG_CMD_SNAPSHOT,
+  IPC_CHANNELS.ASK_QUESTION_SNAPSHOT,
   IPC_CHANNELS.ASK_QUESTION_ANSWER,
   IPC_CHANNELS.ASK_QUESTION_CANCEL,
 ] as const satisfies readonly IPCChannel[];
@@ -1126,6 +1143,7 @@ export const ALLOWED_EVENT_CHANNELS = [
   IPC_CHANNELS.RAG_PROGRESS,
   IPC_CHANNELS.AST_PROGRESS,
   IPC_CHANNELS.ASK_QUESTION_ASKED,
+  IPC_CHANNELS.ASK_QUESTION_SETTLED,
 ] as const satisfies readonly IPCChannel[];
 
 // ── Window type augmentation (renderer-side) ─────────────────────────────────

--- a/electron/src/shared/types/message.ts
+++ b/electron/src/shared/types/message.ts
@@ -87,6 +87,8 @@ export interface Message {
   readonly timestamp: string;
   readonly usage: Usage | null;
   readonly hidden: boolean;
+  /** Persisted display message that must not be replayed to the model. */
+  readonly excludeFromModel?: boolean;
   /** Canonical terminal facts for TOOL_RESULT messages; null for other messages. */
   readonly tool_result: CanonicalToolResult | null;
 }
@@ -110,6 +112,8 @@ export interface MessageStorageDict {
     context?: ContextSnapshot;
   };
   hidden?: boolean;
+  /** Keep the message visible in history while excluding it from model context. */
+  exclude_from_model?: boolean;
   /** Explicit tool failure; only meaningful for tool_result messages. */
   is_error?: boolean;
   /** Canonical terminal facts for TOOL_RESULT records. */
@@ -200,6 +204,9 @@ export function messageToStorageDict(msg: Message): MessageStorageDict {
   if (msg.hidden) {
     d.hidden = true;
   }
+  if (msg.excludeFromModel) {
+    d.exclude_from_model = true;
+  }
   if (msg.tool_result?.status === 'error') {
     d.is_error = true;
   }
@@ -276,6 +283,7 @@ export function messageFromStorageDict(data: unknown): Message {
     timestamp: typeof raw.timestamp === 'string' ? raw.timestamp : new Date().toISOString(),
     usage,
     hidden: raw.hidden === true,
+    excludeFromModel: raw.exclude_from_model === true,
     tool_result: toolResult,
   };
 }

--- a/electron/tests/integration/app-shell.test.ts
+++ b/electron/tests/integration/app-shell.test.ts
@@ -31,8 +31,8 @@ import {
 
 describe('IPC Channel Names', () => {
   it('all channels follow the namespace:action format', () => {
-    for (const [key, channel] of Object.entries(IPC_CHANNELS)) {
-      expect(channel).toMatch(/^[a-z]+:[a-z_]+$/);
+    for (const channel of Object.values(IPC_CHANNELS)) {
+      expect(channel).toMatch(/^[a-z_]+:[a-z_]+$/);
     }
   });
 

--- a/electron/tests/parity/tools.test.ts
+++ b/electron/tests/parity/tools.test.ts
@@ -465,7 +465,7 @@ describe('Tool Completeness', () => {
       buildWaitTool({} as any).definition.name,
       buildInterruptTool({} as any).definition.name,
       buildAnswerSubagentTool({} as any).definition.name,
-      buildAskQuestionTool().definition.name,
+      buildAskQuestionTool({} as any).definition.name,
     ];
     expect(allNames).toHaveLength(32);
     expect(new Set(allNames).size).toBe(32);

--- a/electron/tests/parity/tools.test.ts
+++ b/electron/tests/parity/tools.test.ts
@@ -65,9 +65,11 @@ import { buildListMcpResourcesTool } from '../../src/main/tools/mcp/list-resourc
 import { buildDelegateTool } from '../../src/main/tools/subagent/delegate';
 import { buildWaitTool } from '../../src/main/tools/subagent/wait';
 import { buildInterruptTool } from '../../src/main/tools/subagent/interrupt';
+import { buildAnswerSubagentTool } from '../../src/main/tools/subagent/answer';
+import { buildAskQuestionTool } from '../../src/main/tools/ask-question';
 import { registerBuiltinTools, toolRegistry } from '../../src/main/tools';
 
-// ── Expected tool names (30 total) ─────────────────────────────────────────
+// ── Expected tool names (32 total) ─────────────────────────────────────────
 
 const EXPECTED_TOOL_NAMES = [
   // Filesystem (6)
@@ -94,10 +96,13 @@ const EXPECTED_TOOL_NAMES = [
   'terminate_command',
   // Web (1)
   'web_fetch',
-  // Subagent (3)
+  // Subagent (4)
   'delegate_to_subagent',
   'wait_for_subagent',
   'interrupt_subagents',
+  'answer_subagent',
+  // Ask question (1)
+  'ask_question',
   // Skill (1)
   'skill',
   // MCP (2)
@@ -391,10 +396,10 @@ describe('Dynamic Tool Builders', () => {
 // ── Completeness Check ─────────────────────────────────────────────────────
 
 describe('Tool Completeness', () => {
-  it('all 30 expected tool names are defined in this test file', () => {
+  it('all 32 expected tool names are defined in this test file', () => {
     // This test ensures we haven't accidentally removed a tool from our list.
     // If a new tool is added to the codebase, this list must be updated.
-    expect(EXPECTED_TOOL_NAMES).toHaveLength(30);
+    expect(EXPECTED_TOOL_NAMES).toHaveLength(32);
   });
 
   it('static tool count matches expected', () => {
@@ -459,9 +464,11 @@ describe('Tool Completeness', () => {
       buildDelegateTool(new Map(), {} as any).definition.name,
       buildWaitTool({} as any).definition.name,
       buildInterruptTool({} as any).definition.name,
+      buildAnswerSubagentTool({} as any).definition.name,
+      buildAskQuestionTool().definition.name,
     ];
-    expect(allNames).toHaveLength(30);
-    expect(new Set(allNames).size).toBe(30);
+    expect(allNames).toHaveLength(32);
+    expect(new Set(allNames).size).toBe(32);
   });
 
   it('registerBuiltinTools populates the singleton registry with all tools', () => {

--- a/electron/tests/unit/agent-scope-isolation.test.ts
+++ b/electron/tests/unit/agent-scope-isolation.test.ts
@@ -21,6 +21,7 @@ import { buildListTool } from '../../src/main/tools/todo/list';
 import { buildUpdateTool } from '../../src/main/tools/todo/update';
 import { buildDeleteTool } from '../../src/main/tools/todo/delete';
 import { TodoStore } from '../../src/main/tools/todo/store';
+import { getSubagentManager } from '../../src/main/tools';
 import {
   buildSystemPromptContext,
   __resetDirectoryTreeCacheForTests,
@@ -164,5 +165,59 @@ describe('prompt context agent isolation', () => {
     });
     expect(subACtx.todos?.map((t) => t.title)).toEqual(['SubA work']);
     expect(subACtx.subagents).toEqual([]);
+  });
+
+  it('surfaces pending subagent questions only to the owning session main scope', async () => {
+    const config = defaults();
+    const manager = getSubagentManager();
+    const sessionId = `scope-question-${Date.now()}`;
+    const record = manager.spawn('question owner', 'ask parent', {
+      name: 'question-worker',
+      type: 'subagent',
+      tier: 'bloom',
+      description: 'Asks a parent-scoped question',
+      allowed_tools: ['ask_question'],
+      allowed_skills: [],
+    }, { sessionId });
+    manager.markRunning(record.id);
+    const questionPromise = manager.markQuestionPending(record.id, 'tc-scope', [
+      {
+        type: 'single',
+        title: 'Parent only?',
+        options: [{ label: 'Yes' }],
+      },
+    ]);
+
+    try {
+      const mainCtx = await buildSystemPromptContext({
+        cwd: tmpDir,
+        config,
+        sessionId,
+        agentScopeId: 'main',
+        getTodos: () => [],
+      });
+      const childCtx = await buildSystemPromptContext({
+        cwd: tmpDir,
+        config,
+        sessionId,
+        agentScopeId: 'subagent-peer',
+        getTodos: () => [],
+      });
+      const otherSessionCtx = await buildSystemPromptContext({
+        cwd: tmpDir,
+        config,
+        sessionId: `${sessionId}-other`,
+        agentScopeId: 'main',
+        getTodos: () => [],
+      });
+
+      expect(mainCtx.pendingSubagentQuestions).toHaveLength(1);
+      expect(childCtx.pendingSubagentQuestions).toEqual([]);
+      expect(otherSessionCtx.pendingSubagentQuestions).toEqual([]);
+    } finally {
+      manager.answerSubagentQuestion(record.id, 'tc-scope', { type: 'declined' });
+      await questionPromise;
+      manager.cancelOne(record.id);
+    }
   });
 });

--- a/electron/tests/unit/ask-question-ipc.test.ts
+++ b/electron/tests/unit/ask-question-ipc.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IPC_CHANNELS } from '../../src/shared/types/ipc';
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const selectedByWebContents = new Map<number, string>();
+  const activeTurnOwnerBySession = new Map<string, string>();
+  const webContentsById = new Map<string, {
+    id: number;
+    isDestroyed: () => boolean;
+    send: ReturnType<typeof vi.fn>;
+  }>();
+
+  return {
+    handlers,
+    selectedByWebContents,
+    activeTurnOwnerBySession,
+    webContentsById,
+    forceAbortMainTurn: vi.fn(),
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+      removeHandler: vi.fn((channel: string) => {
+        handlers.delete(channel);
+      }),
+    },
+    sessionManager: {
+      getActive: vi.fn((ownerId: string) => {
+        const id = selectedByWebContents.get(Number(ownerId));
+        return id ? { id } : null;
+      }),
+    },
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: mocks.ipcMain,
+}));
+
+vi.mock('../../src/main/ipc/chat', () => ({
+  forceAbortMainTurn: mocks.forceAbortMainTurn,
+  getActiveMainTurnWindowId: (sessionId: string) =>
+    mocks.activeTurnOwnerBySession.get(sessionId) ?? null,
+  webContentsForWindowId: (windowId: string) => {
+    const webContents = mocks.webContentsById.get(windowId);
+    return webContents && !webContents.isDestroyed() ? webContents : null;
+  },
+}));
+
+vi.mock('../../src/main/ipc/session', () => ({
+  getSessionManager: () => mocks.sessionManager,
+}));
+
+import {
+  registerAskQuestionIPC,
+  unregisterAskQuestionIPC,
+} from '../../src/main/ipc/ask-question';
+import { questionStore } from '../../src/main/tools/ask-question/store';
+
+const SESSION_A = '11111111-1111-4111-8111-111111111111';
+const SESSION_B = '22222222-2222-4222-8222-222222222222';
+const TOOL_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const TOOL_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const QUESTIONS = [{ type: 'single', title: 'Choose', options: [{ label: 'A' }] }];
+
+function addWindow(id: number, destroyed = false) {
+  const webContents = {
+    id,
+    isDestroyed: () => destroyed,
+    send: vi.fn(),
+  };
+  mocks.webContentsById.set(String(id), webContents);
+  return { webContents };
+}
+
+function eventFrom(id: number) {
+  return { sender: { id } };
+}
+
+describe('ask_question IPC', () => {
+  beforeEach(() => {
+    mocks.handlers.clear();
+    mocks.selectedByWebContents.clear();
+    mocks.activeTurnOwnerBySession.clear();
+    mocks.webContentsById.clear();
+    mocks.forceAbortMainTurn.mockClear();
+    questionStore.cleanupAll();
+    registerAskQuestionIPC();
+  });
+
+  afterEach(() => {
+    unregisterAskQuestionIPC();
+  });
+
+  it('sends and replays questions only to windows viewing the owning session', () => {
+    const owner = addWindow(10);
+    const other = addWindow(20);
+    mocks.selectedByWebContents.set(10, SESSION_A);
+    mocks.selectedByWebContents.set(20, SESSION_B);
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+
+    void questionStore.create(TOOL_A, SESSION_A, QUESTIONS);
+
+    expect(owner.webContents.send).toHaveBeenCalledWith(
+      IPC_CHANNELS.ASK_QUESTION_ASKED,
+      { sessionId: SESSION_A, toolCallId: TOOL_A, questions: QUESTIONS },
+    );
+    expect(other.webContents.send).not.toHaveBeenCalled();
+
+    const snapshot = mocks.handlers.get(IPC_CHANNELS.ASK_QUESTION_SNAPSHOT)!;
+    expect(snapshot(eventFrom(10))).toEqual({
+      questions: [{ sessionId: SESSION_A, toolCallId: TOOL_A, questions: QUESTIONS }],
+    });
+    expect(snapshot(eventFrom(20))).toEqual({ questions: [] });
+  });
+
+  it('forwards settlement only to the exact owning window', async () => {
+    const owner = addWindow(10);
+    const other = addWindow(20);
+    mocks.selectedByWebContents.set(10, SESSION_A);
+    mocks.selectedByWebContents.set(20, SESSION_A);
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+    const pending = questionStore.create(TOOL_A, SESSION_A, QUESTIONS);
+
+    expect(questionStore.answer(TOOL_A, [])).toBe(true);
+    await expect(pending).resolves.toMatchObject({ type: 'answered' });
+
+    expect(owner.webContents.send).toHaveBeenCalledWith(
+      IPC_CHANNELS.ASK_QUESTION_SETTLED,
+      { sessionId: SESSION_A, toolCallId: TOOL_A, result: 'answered' },
+    );
+    expect(other.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('settles and aborts when the owning WebContents is unavailable', async () => {
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+
+    const pending = questionStore.create(TOOL_A, SESSION_A, QUESTIONS);
+
+    await expect(pending).resolves.toEqual({ type: 'cancelled' });
+    expect(questionStore.get(TOOL_A)).toBeUndefined();
+    expect(mocks.forceAbortMainTurn).toHaveBeenCalledWith(SESSION_A);
+  });
+
+  it('settles and aborts when the owning WebContents is destroyed', async () => {
+    addWindow(10, true);
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+
+    const pending = questionStore.create(TOOL_A, SESSION_A, QUESTIONS);
+
+    await expect(pending).resolves.toEqual({ type: 'cancelled' });
+    expect(questionStore.get(TOOL_A)).toBeUndefined();
+    expect(mocks.forceAbortMainTurn).toHaveBeenCalledWith(SESSION_A);
+  });
+
+  it('settles and aborts when synchronous question delivery throws', async () => {
+    const owner = addWindow(10);
+    owner.webContents.send.mockImplementation(() => {
+      throw new Error('renderer closed during send');
+    });
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+
+    const pending = questionStore.create(TOOL_A, SESSION_A, QUESTIONS);
+
+    await expect(pending).resolves.toEqual({ type: 'cancelled' });
+    expect(questionStore.get(TOOL_A)).toBeUndefined();
+    expect(mocks.forceAbortMainTurn).toHaveBeenCalledWith(SESSION_A);
+  });
+
+  it('does not expose or settle a question from another window on the same session', async () => {
+    const owner = addWindow(10);
+    const sameSessionOtherWindow = addWindow(20);
+    mocks.selectedByWebContents.set(10, SESSION_A);
+    mocks.selectedByWebContents.set(20, SESSION_A);
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+    const pending = questionStore.create(TOOL_A, SESSION_A, QUESTIONS);
+
+    expect(owner.webContents.send).toHaveBeenCalledOnce();
+    expect(sameSessionOtherWindow.webContents.send).not.toHaveBeenCalled();
+
+    const snapshot = mocks.handlers.get(IPC_CHANNELS.ASK_QUESTION_SNAPSHOT)!;
+    expect(snapshot(eventFrom(20))).toEqual({ questions: [] });
+
+    const answer = mocks.handlers.get(IPC_CHANNELS.ASK_QUESTION_ANSWER)!;
+    expect(answer(eventFrom(20), { toolCallId: TOOL_A, answers: [] })).toEqual({ ok: false });
+    expect(questionStore.get(TOOL_A)).toBeDefined();
+
+    expect(answer(eventFrom(10), { toolCallId: TOOL_A, answers: [] })).toEqual({ ok: true });
+    await expect(pending).resolves.toEqual({ type: 'answered', answers: [] });
+  });
+
+  it('rejects a different window and runtime-validates answer payloads', async () => {
+    addWindow(10);
+    addWindow(20);
+    mocks.selectedByWebContents.set(10, SESSION_A);
+    mocks.selectedByWebContents.set(20, SESSION_B);
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+    const pending = questionStore.create(TOOL_A, SESSION_A, QUESTIONS);
+    const answer = mocks.handlers.get(IPC_CHANNELS.ASK_QUESTION_ANSWER)!;
+
+    expect(answer(eventFrom(20), { toolCallId: TOOL_A, answers: [] })).toEqual({ ok: false });
+    expect(() => answer(eventFrom(10), {
+      toolCallId: TOOL_A,
+      answers: [{ selected: 'A', text: null, skipped: false }],
+    })).toThrow();
+    expect(answer(eventFrom(10), {
+      toolCallId: TOOL_A,
+      answers: [{ selected: ['A'], text: null, skipped: false }],
+    })).toEqual({ ok: true });
+    await expect(pending).resolves.toMatchObject({ type: 'answered' });
+  });
+
+  it('cancels only the owning main turn and validates cancel payloads', async () => {
+    addWindow(10);
+    mocks.selectedByWebContents.set(10, SESSION_A);
+    mocks.activeTurnOwnerBySession.set(SESSION_A, '10');
+    const pending = questionStore.create(TOOL_B, SESSION_A, QUESTIONS);
+    const cancel = mocks.handlers.get(IPC_CHANNELS.ASK_QUESTION_CANCEL)!;
+
+    expect(() => cancel(eventFrom(10), { toolCallId: 'not-a-uuid' })).toThrow();
+    expect(cancel(eventFrom(10), { toolCallId: TOOL_B })).toEqual({ ok: true });
+    await expect(pending).resolves.toEqual({ type: 'cancelled' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(mocks.forceAbortMainTurn).toHaveBeenCalledWith(
+      SESSION_A,
+      { emitTerminalEvents: true },
+    );
+  });
+});

--- a/electron/tests/unit/chat-ipc.test.ts
+++ b/electron/tests/unit/chat-ipc.test.ts
@@ -21,6 +21,23 @@ function successfulToolResult(toolCallId: string, content: string): Record<strin
   };
 }
 
+function cancelledToolResult(toolCallId: string): Record<string, unknown> {
+  const canonical = createCanonicalToolResult('generic', {
+    status: 'cancelled',
+    data: { questions: [], answers: [], cancelled: true },
+  });
+  return {
+    type: 'tool_result',
+    toolCallId,
+    content: 'Question cancelled',
+    isError: false,
+    execution: {
+      canonical,
+      agentProjection: { content: 'Question cancelled', completeness: 'complete' },
+    },
+  };
+}
+
 const mocks = vi.hoisted(() => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
   const streamResponses: string[] = [];
@@ -745,6 +762,108 @@ describe('chat IPC driver streaming', () => {
     mocks.streamResponses.length = 0;
     mocks.streamEventSequences.length = 0;
     mocks.sessionManager._reset();
+  });
+
+  it('main-turn-only abort leaves subagents and background commands running', () => {
+    chatIpc.forceAbortMainTurn('11111111-1111-4111-8111-111111111111');
+
+    expect(mocks.subagentManager.cancelRunning).not.toHaveBeenCalled();
+    expect(mocks.backgroundStore.terminateSession).not.toHaveBeenCalled();
+  });
+
+  it('visible main-turn abort persists interruption and resets the renderer', async () => {
+    const sessionId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+    const selection = {
+      connectionId: '11111111-1111-4111-8111-111111111111',
+      modelId: 'vendor/path/model',
+    };
+    mocks.sessionManager._setActive({
+      ...makeSession(sessionId),
+      model: selection.modelId,
+      selection,
+      modelLabel: selection.modelId,
+    });
+    let releaseStream: (() => void) | undefined;
+    const streamGate = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    mocks.streamChat.mockImplementationOnce(async function* () {
+      yield { type: 'content', text: 'Waiting for your choice' };
+      await streamGate;
+      yield { type: 'finish', finishReason: 'stop' };
+    });
+
+    const send = vi.fn();
+    const webContents = { id: 603, send };
+    mocks.electronWebContents.fromId.mockReturnValue(webContents);
+    const chatSend = mocks.handlers.get(IPC_CHANNELS.CHAT_SEND)!;
+    await chatSend(
+      { sender: webContents },
+      { message: 'Ask before continuing' },
+    );
+    await waitForChannelCount(send, IPC_CHANNELS.CHAT_CHUNK, 1);
+
+    chatIpc.forceAbortMainTurn(sessionId, { emitTerminalEvents: true });
+
+    expect(doneEvents(send).at(-1)?.[1]).toMatchObject({
+      type: 'done',
+      response: 'Waiting for your choice',
+      interrupted: true,
+    });
+    expect(channelEvents(send, IPC_CHANNELS.CHAT_STATE).at(-1)?.[1]).toMatchObject({
+      state: 'idle',
+      response: 'Waiting for your choice',
+      interruptState: 'idle',
+    });
+    expect(mocks.sessionManager.persistTurn.mock.calls.at(-1)?.[0]).toMatchObject({
+      status: 'interrupted',
+    });
+    expect(mocks.subagentManager.cancelRunning).not.toHaveBeenCalled();
+    expect(mocks.backgroundStore.terminateSession).not.toHaveBeenCalled();
+    releaseStream?.();
+  });
+
+  it('persists cancelled tool results as visible but excluded from model context', async () => {
+    const selection = {
+      connectionId: '11111111-1111-4111-8111-111111111111',
+      modelId: 'vendor/path/model',
+    };
+    mocks.sessionManager._setActive({
+      ...makeSession('dddddddd-dddd-4ddd-8ddd-dddddddddddd'),
+      model: selection.modelId,
+      selection,
+      modelLabel: selection.modelId,
+    });
+    mocks.streamChat.mockImplementationOnce(async function* () {
+      yield {
+        type: 'tool_call',
+        toolCallId: 'tc-question-cancelled',
+        toolName: 'ask_question',
+        args: '{"questions":[]}',
+      };
+      yield cancelledToolResult('tc-question-cancelled');
+      yield { type: 'finish', finishReason: 'stop' };
+    });
+
+    const send = vi.fn();
+    const chatSend = mocks.handlers.get(IPC_CHANNELS.CHAT_SEND)!;
+    await chatSend(
+      { sender: { id: 602, send } },
+      { message: 'Ask before continuing' },
+    );
+    await waitForDoneCount(send, 1);
+
+    const persisted = mocks.sessionManager.persistTurn.mock.calls.at(-1)?.[0] as {
+      messages: Array<Record<string, unknown>>;
+    };
+    expect(persisted.messages.find((message) => (
+      message.type === MessageType.TOOL_RESULT &&
+      message.tool_call_id === 'tc-question-cancelled'
+    )))
+      .toMatchObject({
+        hidden: false,
+        excludeFromModel: true,
+      });
   });
 
   it('emits tool_update IPC payloads with the expected shape through the typed provider path', async () => {

--- a/electron/tests/unit/domain.test.ts
+++ b/electron/tests/unit/domain.test.ts
@@ -64,6 +64,7 @@ function makeMessage(overrides: Partial<Message> & { role: MessageRole }): Messa
     timestamp: overrides.timestamp ?? new Date().toISOString(),
     usage: overrides.usage ?? null,
     hidden: overrides.hidden ?? false,
+    excludeFromModel: overrides.excludeFromModel ?? false,
     tool_result: overrides.tool_result ?? null,
   };
 }
@@ -667,6 +668,23 @@ describe('Domain Models: Per-chain error isolation', () => {
 // ── Additional tests ────────────────────────────────────────────────────────
 
 describe('Domain Models: Message edge cases', () => {
+  it('round-trips visible messages excluded from model context', () => {
+    const message = makeMessage({
+      role: MessageRole.TOOL,
+      type: MessageType.TOOL_RESULT,
+      content: 'Question cancelled',
+      tool_call_id: 'tool-cancelled',
+      excludeFromModel: true,
+    });
+
+    const stored = messageToStorageDict(message);
+    const restored = messageFromStorageDict(stored);
+
+    expect(stored.exclude_from_model).toBe(true);
+    expect(restored.excludeFromModel).toBe(true);
+    expect(restored.hidden).toBe(false);
+  });
+
   it('handles missing fields gracefully on restore', () => {
     const restored = messageFromStorageDict({
       role: 'assistant',

--- a/electron/tests/unit/history.test.ts
+++ b/electron/tests/unit/history.test.ts
@@ -72,3 +72,70 @@ describe('toApiMessages match-set', () => {
     expect(result[3].content).toBe('Done with partial tools');
   });
 });
+
+describe('toApiMessages hidden filtering', () => {
+  it('excludes hidden messages from API output', () => {
+    const messages: Message[] = [
+      makeMessage({
+        role: MessageRole.USER,
+        content: 'Hello',
+        type: MessageType.TEXT,
+      }),
+      makeMessage({
+        role: MessageRole.ASSISTANT,
+        content: 'Visible reply',
+        type: MessageType.TEXT,
+      }),
+      makeMessage({
+        role: MessageRole.ASSISTANT,
+        content: 'Hidden note',
+        type: MessageType.TEXT,
+        hidden: true,
+      }),
+    ];
+
+    const result = toApiMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe('Hello');
+    expect(result[1].content).toBe('Visible reply');
+  });
+
+  it('drops tool_call whose only result is hidden (cancelled tool)', () => {
+    const tc = makeToolCall('tc-cancelled', 'ask_question');
+    const messages: Message[] = [
+      makeMessage({
+        role: MessageRole.USER,
+        content: 'Do something',
+        type: MessageType.TEXT,
+      }),
+      makeMessage({
+        role: MessageRole.ASSISTANT,
+        content: '',
+        type: MessageType.TOOL_CALL,
+        tool_calls: [tc],
+        tool_call_id: 'tc-cancelled',
+      }),
+      makeMessage({
+        role: MessageRole.TOOL,
+        content: 'cancelled',
+        type: MessageType.TOOL_RESULT,
+        tool_call_id: 'tc-cancelled',
+        hidden: true,
+      }),
+      makeMessage({
+        role: MessageRole.ASSISTANT,
+        content: 'Turn interrupted',
+        type: MessageType.TEXT,
+      }),
+    ];
+
+    const result = toApiMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe('Do something');
+    expect(result[1].content).toBe('Turn interrupted');
+    expect(result.some((m) => m.tool_call_id === 'tc-cancelled')).toBe(false);
+    expect(result.some((m) => m.tool_calls?.some((t) => t.id === 'tc-cancelled'))).toBe(false);
+  });
+});

--- a/electron/tests/unit/history.test.ts
+++ b/electron/tests/unit/history.test.ts
@@ -138,4 +138,32 @@ describe('toApiMessages hidden filtering', () => {
     expect(result.some((m) => m.tool_call_id === 'tc-cancelled')).toBe(false);
     expect(result.some((m) => m.tool_calls?.some((t) => t.id === 'tc-cancelled'))).toBe(false);
   });
+
+  it('drops a visible tool result explicitly excluded from model context', () => {
+    const tc = makeToolCall('tc-cancelled-visible', 'ask_question');
+    const messages: Message[] = [
+      makeMessage({
+        role: MessageRole.USER,
+        content: 'Do something',
+        type: MessageType.TEXT,
+      }),
+      makeMessage({
+        role: MessageRole.ASSISTANT,
+        type: MessageType.TOOL_CALL,
+        tool_calls: [tc],
+      }),
+      makeMessage({
+        role: MessageRole.TOOL,
+        content: 'cancelled',
+        type: MessageType.TOOL_RESULT,
+        tool_call_id: tc.id,
+        excludeFromModel: true,
+      }),
+    ];
+
+    const result = toApiMessages(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('Do something');
+  });
 });

--- a/electron/tests/unit/question-store.test.ts
+++ b/electron/tests/unit/question-store.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { QuestionStore } from '../../src/main/tools/ask-question/store';
+
+const QUESTIONS = [{ type: 'single', title: 'Choose', options: [{ label: 'A' }] }];
+
+describe('QuestionStore', () => {
+  it('settles and removes a pending wait when its turn aborts', async () => {
+    const store = new QuestionStore();
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+    const settled = vi.fn();
+    store.on('question-settled', settled);
+    const pending = store.create('tool-1', 'session-1', QUESTIONS, controller.signal);
+    store.bindOwnerWindow('tool-1', 'window-1');
+
+    controller.abort();
+
+    await expect(pending).resolves.toEqual({ type: 'cancelled' });
+    expect(store.get('tool-1')).toBeUndefined();
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(settled).toHaveBeenCalledWith({
+      toolCallId: 'tool-1',
+      sessionId: 'session-1',
+      ownerWindowId: 'window-1',
+      result: 'cancelled',
+    });
+  });
+
+  it('cleanup settles the waiter instead of silently deleting it', async () => {
+    const store = new QuestionStore();
+    const settled = vi.fn();
+    store.on('question-settled', settled);
+    const pending = store.create('tool-2', 'session-1', QUESTIONS);
+
+    expect(store.cleanup('tool-2')).toBe(true);
+
+    await expect(pending).resolves.toEqual({ type: 'cancelled' });
+    expect(store.cleanup('tool-2')).toBe(false);
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits one owner-affine settlement for answer and explicit cancel', async () => {
+    const store = new QuestionStore();
+    const settled = vi.fn();
+    store.on('question-settled', settled);
+    const answered = store.create('tool-3', 'session-1', QUESTIONS);
+    const cancelled = store.create('tool-4', 'session-1', QUESTIONS);
+    store.bindOwnerWindow('tool-3', 'window-1');
+    store.bindOwnerWindow('tool-4', 'window-1');
+
+    expect(store.answer('tool-3', [{ selected: ['A'], text: null, skipped: false }]))
+      .toBe(true);
+    expect(store.cancel('tool-4')).toBe(true);
+
+    await expect(answered).resolves.toMatchObject({ type: 'answered' });
+    await expect(cancelled).resolves.toEqual({ type: 'cancelled' });
+    expect(settled.mock.calls.map(([event]) => event)).toEqual([
+      expect.objectContaining({ toolCallId: 'tool-3', result: 'answered' }),
+      expect.objectContaining({ toolCallId: 'tool-4', result: 'cancelled' }),
+    ]);
+    expect(store.cancel('tool-4')).toBe(false);
+    expect(settled).toHaveBeenCalledTimes(2);
+  });
+});

--- a/electron/tests/unit/renderer-ask-question.test.ts
+++ b/electron/tests/unit/renderer-ask-question.test.ts
@@ -1,0 +1,299 @@
+/**
+ * ask_question renderer — stepper hook helpers, overlay, and terminal summary.
+ *
+ * Uses ReactDOMServer static markup so Vitest stays on Node (no jsdom),
+ * matching the renderer-ui-primitives convention. Hook IPC wiring is asserted
+ * at the source level (composer-contract style); state transitions are covered
+ * through the exported pure helpers the hook calls.
+ */
+import { createElement, type ReactElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  applyOptionSelection,
+  applyText,
+  buildSubmissions,
+  createActiveQuestion,
+  markAnswerSkipped,
+  type ActiveQuestion,
+  type Question,
+  type UseAskQuestionReturn,
+} from '../../src/renderer/hooks/useAskQuestion';
+import { AskQuestionOverlay } from '../../src/renderer/components/AskQuestionOverlay';
+import { AskQuestionToolResult } from '../../src/renderer/components/ToolResults/AskQuestionToolResult';
+import {
+  resolveToolResultRenderer,
+  rendererRegistrySnapshot,
+} from '../../src/renderer/components/ToolResults/registry';
+import type { CanonicalToolResult } from '../../src/shared/types/tool-result';
+
+const RENDERER = path.resolve(__dirname, '../../src/renderer');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(RENDERER, rel), 'utf8');
+}
+
+const QUESTIONS: Question[] = [
+  {
+    type: 'single',
+    title: 'Which database?',
+    description: 'Pick one storage engine.',
+    options: [
+      { label: 'PostgreSQL', description: 'Relational, battle-tested' },
+      { label: 'SQLite', description: 'Embedded, zero-config' },
+    ],
+  },
+  {
+    type: 'multi',
+    title: 'Which extras?',
+    options: [
+      { label: 'Migrations' },
+      { label: 'Seeds' },
+      { label: 'Backups' },
+    ],
+  },
+];
+
+function makeState(questions: Question[] = QUESTIONS): ActiveQuestion {
+  return createActiveQuestion('tool-call-1', questions);
+}
+
+function makeController(active: ActiveQuestion | null): UseAskQuestionReturn {
+  return {
+    active,
+    selectOption: () => {},
+    setText: () => {},
+    next: () => {},
+    back: () => {},
+    skip: () => {},
+    submit: async () => {},
+    cancelAll: async () => {},
+  };
+}
+
+function renderOverlay(active: ActiveQuestion | null): string {
+  const node: ReactElement = createElement(AskQuestionOverlay, {
+    question: makeController(active),
+  });
+  return renderToStaticMarkup(node);
+}
+
+function canonical(value: unknown, status: 'complete' | 'cancelled' = 'complete'): CanonicalToolResult {
+  return {
+    schemaVersion: 1,
+    family: 'generic',
+    status,
+    completeness: 'complete',
+    data: { value, origin: { kind: 'built-in', name: 'ask_question' } },
+  } as CanonicalToolResult;
+}
+
+function renderResult(canonicalResult: CanonicalToolResult): string {
+  return renderToStaticMarkup(createElement(AskQuestionToolResult, { canonical: canonicalResult }));
+}
+
+// ── Pure state transitions ───────────────────────────────────────────────────
+
+describe('createActiveQuestion', () => {
+  it('starts on the first question with one empty answer per question', () => {
+    const state = makeState();
+    expect(state.toolCallId).toBe('tool-call-1');
+    expect(state.currentIndex).toBe(0);
+    expect(state.answers).toEqual([
+      { selected: [], text: '', skipped: false },
+      { selected: [], text: '', skipped: false },
+    ]);
+  });
+});
+
+describe('applyOptionSelection', () => {
+  it('single-choice replaces the previous selection', () => {
+    let state = applyOptionSelection(makeState(), 0, 'PostgreSQL');
+    state = applyOptionSelection(state, 0, 'SQLite');
+    expect(state.answers[0]!.selected).toEqual(['SQLite']);
+  });
+
+  it('multi-choice toggles options on and off', () => {
+    let state = applyOptionSelection(makeState(), 1, 'Migrations');
+    state = applyOptionSelection(state, 1, 'Backups');
+    expect(state.answers[1]!.selected).toEqual(['Migrations', 'Backups']);
+    state = applyOptionSelection(state, 1, 'Migrations');
+    expect(state.answers[1]!.selected).toEqual(['Backups']);
+  });
+
+  it('selecting an option clears a prior skip mark', () => {
+    let state = markAnswerSkipped(makeState(), 0);
+    expect(state.answers[0]!.skipped).toBe(true);
+    state = applyOptionSelection(state, 0, 'PostgreSQL');
+    expect(state.answers[0]!.skipped).toBe(false);
+  });
+
+  it('ignores out-of-range question indexes', () => {
+    const state = makeState();
+    expect(applyOptionSelection(state, 9, 'PostgreSQL')).toBe(state);
+  });
+});
+
+describe('applyText', () => {
+  it('sets free text independently of selections and clears skip', () => {
+    let state = applyOptionSelection(makeState(), 0, 'PostgreSQL');
+    state = markAnswerSkipped(state, 0);
+    state = applyText(state, 0, '  prefer managed hosting ');
+    expect(state.answers[0]!.text).toBe('  prefer managed hosting ');
+    expect(state.answers[0]!.selected).toEqual(['PostgreSQL']);
+    expect(state.answers[0]!.skipped).toBe(false);
+  });
+});
+
+describe('markAnswerSkipped', () => {
+  it('marks skipped without touching selections or text', () => {
+    let state = applyOptionSelection(makeState(), 0, 'SQLite');
+    state = applyText(state, 0, 'note');
+    state = markAnswerSkipped(state, 0);
+    expect(state.answers[0]).toEqual({ selected: ['SQLite'], text: 'note', skipped: true });
+  });
+});
+
+describe('buildSubmissions', () => {
+  it('trims text and sends null when empty', () => {
+    let state = applyText(makeState(), 0, '  hello  ');
+    state = applyOptionSelection(state, 1, 'Seeds');
+    state = markAnswerSkipped(state, 1);
+    expect(buildSubmissions(state)).toEqual([
+      { selected: [], text: 'hello', skipped: false },
+      { selected: ['Seeds'], text: null, skipped: true },
+    ]);
+  });
+});
+
+// ── Overlay markup ───────────────────────────────────────────────────────────
+
+describe('AskQuestionOverlay', () => {
+  it('renders nothing without an active question', () => {
+    expect(renderOverlay(null)).toBe('');
+  });
+
+  it('renders the first question with progress, options, and navigation', () => {
+    const html = renderOverlay(makeState());
+    expect(html).toContain('Agent question');
+    expect(html).toContain('Question 1 of 2');
+    expect(html).toContain('Which database?');
+    expect(html).toContain('Pick one storage engine.');
+    expect(html).toContain('PostgreSQL');
+    expect(html).toContain('Relational, battle-tested');
+    expect(html).toContain('SQLite');
+    expect(html).toContain('Additional thoughts (optional)');
+    expect(html).toContain('Back');
+    expect(html).toContain('Skip');
+    expect(html).toContain('Next');
+    expect(html).not.toContain('Submit');
+  });
+
+  it('disables Back on the first question', () => {
+    const html = renderOverlay(makeState());
+    const backTag = html.slice(html.lastIndexOf('<button', html.indexOf('Back')), html.indexOf('Back'));
+    expect(backTag).toContain('disabled');
+  });
+
+  it('uses radio semantics for single-choice questions', () => {
+    const html = renderOverlay(makeState());
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('role="radio"');
+    expect(html).toContain('aria-checked="false"');
+  });
+
+  it('uses checkbox semantics for multi-choice questions', () => {
+    const state = { ...makeState(), currentIndex: 1 };
+    const html = renderOverlay(state);
+    expect(html).toContain('role="group"');
+    expect(html).toContain('role="checkbox"');
+    expect(html).toContain('Question 2 of 2');
+  });
+
+  it('marks the selected option and shows Submit on the last question', () => {
+    let state = applyOptionSelection(makeState(), 1, 'Seeds');
+    state = { ...state, currentIndex: 1 };
+    const html = renderOverlay(state);
+    expect(html).toContain('orchid-ask-option-selected');
+    expect(html).toContain('aria-checked="true"');
+    expect(html).toContain('Submit');
+    expect(html).not.toContain('Next');
+  });
+
+  it('shows a Skipped badge when returning to a skipped question', () => {
+    const state = markAnswerSkipped(makeState(), 0);
+    expect(renderOverlay(state)).toContain('Skipped');
+  });
+
+  it('renders free text into the note textarea', () => {
+    const state = applyText(makeState(), 0, 'thinking out loud');
+    expect(renderOverlay(state)).toContain('thinking out loud');
+  });
+});
+
+// ── Terminal summary markup ──────────────────────────────────────────────────
+
+describe('AskQuestionToolResult', () => {
+  it('summarizes answered questions with selections and free text', () => {
+    const html = renderResult(canonical({
+      answers: [
+        { selected: ['PostgreSQL'], text: 'hosted please', skipped: false },
+        { selected: ['Seeds', 'Backups'], text: null, skipped: false },
+      ],
+    }));
+    expect(html).toContain('Question 1');
+    expect(html).toContain('Question 2');
+    expect(html).toContain('PostgreSQL');
+    expect(html).toContain('Seeds');
+    expect(html).toContain('Backups');
+    expect(html).toContain('hosted please');
+    expect(html).not.toContain('Skipped');
+  });
+
+  it('flags skipped questions', () => {
+    const html = renderResult(canonical({
+      answers: [{ selected: [], text: null, skipped: true }],
+    }));
+    expect(html).toContain('Skipped');
+    expect(html).toContain('No answer provided');
+  });
+
+  it('reports cancelled tool calls', () => {
+    const html = renderResult(canonical({ answers: [], cancelled: true }, 'cancelled'));
+    expect(html).toContain('Cancelled');
+    expect(html).toContain('cancelled before it was answered');
+  });
+
+  it('falls back to the generic renderer on unexpected payloads', () => {
+    const html = renderResult(canonical({ unrelated: 42 }));
+    expect(html).toContain('unrelated');
+    expect(html).not.toContain('orchid-ask-result-item');
+  });
+});
+
+// ── Registry + wiring ────────────────────────────────────────────────────────
+
+describe('ask_question registry and wiring', () => {
+  it('registers the terminal renderer for ask_question', () => {
+    expect(resolveToolResultRenderer('ask_question', 'generic')).toBe(AskQuestionToolResult);
+    expect(rendererRegistrySnapshot().tools).toContain('ask_question');
+  });
+
+  it('useAskQuestion subscribes via the askQuestion bridge and cleans up', () => {
+    const src = read('hooks/useAskQuestion.ts');
+    expect(src).toMatch(/window\.orchid\?\.askQuestion/);
+    expect(src).toMatch(/bridge\.onAsked\(/);
+    expect(src).toMatch(/return bridge\.onAsked/);
+    expect(src).toMatch(/bridge\.answer\(\{/);
+    expect(src).toMatch(/bridge\.cancel\(\{/);
+  });
+
+  it('InputArea swaps the composer for the overlay while a question is active', () => {
+    const src = read('components/InputArea.tsx');
+    expect(src).toMatch(/useAskQuestion\(\)/);
+    expect(src).toMatch(/if \(askQuestion\.active\) \{/);
+    expect(src).toMatch(/<AskQuestionOverlay question=\{askQuestion\} \/>/);
+  });
+});

--- a/electron/tests/unit/renderer-ask-question.test.ts
+++ b/electron/tests/unit/renderer-ask-question.test.ts
@@ -12,15 +12,21 @@ import { describe, expect, it } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+  applyQuestionResult,
   applyOptionSelection,
   applyText,
   buildSubmissions,
   createActiveQuestion,
+  enqueueQuestion,
   markAnswerSkipped,
+  reconcileQuestionSnapshot,
+  removeSettledQuestion,
+  updateActiveQuestion,
   type ActiveQuestion,
   type Question,
   type UseAskQuestionReturn,
 } from '../../src/renderer/hooks/useAskQuestion';
+import { resolveInputEscapeAction } from '../../src/renderer/components/InputArea';
 import { AskQuestionOverlay } from '../../src/renderer/components/AskQuestionOverlay';
 import { AskQuestionToolResult } from '../../src/renderer/components/ToolResults/AskQuestionToolResult';
 import {
@@ -28,6 +34,7 @@ import {
   rendererRegistrySnapshot,
 } from '../../src/renderer/components/ToolResults/registry';
 import type { CanonicalToolResult } from '../../src/shared/types/tool-result';
+import type { AskQuestionAskedEvent } from '../../src/shared/types/ipc';
 
 const RENDERER = path.resolve(__dirname, '../../src/renderer');
 
@@ -57,7 +64,11 @@ const QUESTIONS: Question[] = [
 ];
 
 function makeState(questions: Question[] = QUESTIONS): ActiveQuestion {
-  return createActiveQuestion('tool-call-1', questions);
+  return createActiveQuestion('tool-call-1', questions, 'session-1');
+}
+
+function asked(toolCallId: string, sessionId = 'session-1'): AskQuestionAskedEvent {
+  return { sessionId, toolCallId, questions: QUESTIONS };
 }
 
 function makeController(active: ActiveQuestion | null): UseAskQuestionReturn {
@@ -165,6 +176,136 @@ describe('buildSubmissions', () => {
       { selected: [], text: 'hello', skipped: false },
       { selected: ['Seeds'], text: null, skipped: true },
     ]);
+  });
+});
+
+// ── Session-affine pending queue ─────────────────────────────────────────────
+
+describe('ask_question pending queue', () => {
+  it('keeps overlapping events in FIFO order and deduplicates by session + tool call', () => {
+    let queue: ActiveQuestion[] = [];
+    queue = enqueueQuestion(queue, asked('tool-call-1'), 'session-1');
+    queue = enqueueQuestion(queue, asked('tool-call-2'), 'session-1');
+    queue = enqueueQuestion(queue, asked('tool-call-1'), 'session-1');
+
+    expect(queue.map((item) => item.toolCallId)).toEqual(['tool-call-1', 'tool-call-2']);
+  });
+
+  it('retains controls when an invoke rejects or returns ok:false', () => {
+    const queue = [
+      createActiveQuestion('tool-call-1', QUESTIONS, 'session-1'),
+      createActiveQuestion('tool-call-2', QUESTIONS, 'session-1'),
+    ];
+
+    expect(applyQuestionResult(queue, queue[0]!)).toBe(queue);
+    expect(applyQuestionResult(queue, queue[0]!, { ok: false })).toBe(queue);
+  });
+
+  it('promotes only the next item after an acknowledged settlement', () => {
+    const queue = [
+      createActiveQuestion('tool-call-1', QUESTIONS, 'session-1'),
+      createActiveQuestion('tool-call-2', QUESTIONS, 'session-1'),
+    ];
+
+    expect(applyQuestionResult(queue, queue[0]!, { ok: true }).map((item) => item.toolCallId))
+      .toEqual(['tool-call-2']);
+  });
+
+  it('updates only the active FIFO entry and preserves identity for stale or no-op edits', () => {
+    const first = createActiveQuestion('tool-call-1', QUESTIONS, 'session-1');
+    const second = createActiveQuestion('tool-call-2', QUESTIONS, 'session-1');
+    const queue = [first, second];
+
+    expect(updateActiveQuestion(queue, first, (state) => state)).toBe(queue);
+    expect(updateActiveQuestion(
+      queue,
+      createActiveQuestion('stale', QUESTIONS, 'session-1'),
+      (state) => ({ ...state, currentIndex: 1 }),
+    )).toBe(queue);
+
+    const updated = updateActiveQuestion(queue, first, (state) => ({
+      ...state,
+      currentIndex: 1,
+    }));
+    expect(updated[0]?.currentIndex).toBe(1);
+    expect(updated[1]).toBe(second);
+  });
+
+  it('hydrates a changed session from its snapshot and replays buffered events', () => {
+    const queue = reconcileQuestionSnapshot(
+      'session-2',
+      [asked('snapshot-question', 'session-2')],
+      [
+        asked('snapshot-question', 'session-2'),
+        asked('live-question', 'session-2'),
+        asked('wrong-session', 'session-1'),
+      ],
+    );
+
+    expect(queue.map((item) => [item.sessionId, item.toolCallId])).toEqual([
+      ['session-2', 'snapshot-question'],
+      ['session-2', 'live-question'],
+    ]);
+  });
+
+  it('does not resurrect a snapshot entry settled while hydration was in flight', () => {
+    const settledKeys = new Set(['session-1\u0000snapshot-question']);
+
+    const queue = reconcileQuestionSnapshot(
+      'session-1',
+      [asked('snapshot-question')],
+      [asked('live-question')],
+      settledKeys,
+    );
+
+    expect(queue.map((item) => item.toolCallId)).toEqual(['live-question']);
+  });
+
+  it('removes a settled queue entry idempotently and promotes the next question', () => {
+    const queue = [
+      createActiveQuestion('tool-call-1', QUESTIONS, 'session-1'),
+      createActiveQuestion('tool-call-2', QUESTIONS, 'session-1'),
+    ];
+    const settled = {
+      sessionId: 'session-1',
+      toolCallId: 'tool-call-1',
+      result: 'cancelled' as const,
+    };
+
+    const promoted = removeSettledQuestion(queue, settled);
+    expect(promoted.map((item) => item.toolCallId)).toEqual(['tool-call-2']);
+    expect(removeSettledQuestion(promoted, settled)).toBe(promoted);
+  });
+
+  it('defensively ignores live and snapshot questions for another session', () => {
+    expect(enqueueQuestion([], asked('wrong', 'session-2'), 'session-1')).toEqual([]);
+    expect(reconcileQuestionSnapshot('session-1', [asked('wrong', 'session-2')], []))
+      .toEqual([]);
+  });
+});
+
+describe('InputArea Escape ownership', () => {
+  it('prioritizes the active question over chat interruption', () => {
+    expect(resolveInputEscapeAction({
+      hasActiveQuestion: true,
+      canInterrupt: true,
+      isSlashMode: false,
+      isViewActive: false,
+      settingsOpen: false,
+    })).toBe('cancel-question');
+  });
+
+  it('leaves Escape to settings, inactive views, and slash menus', () => {
+    const base = {
+      hasActiveQuestion: false,
+      canInterrupt: true,
+      isSlashMode: false,
+      isViewActive: false,
+      settingsOpen: false,
+    };
+    expect(resolveInputEscapeAction({ ...base, settingsOpen: true })).toBe('none');
+    expect(resolveInputEscapeAction({ ...base, isViewActive: true })).toBe('none');
+    expect(resolveInputEscapeAction({ ...base, isSlashMode: true })).toBe('none');
   });
 });
 
@@ -285,14 +426,16 @@ describe('ask_question registry and wiring', () => {
     const src = read('hooks/useAskQuestion.ts');
     expect(src).toMatch(/window\.orchid\?\.askQuestion/);
     expect(src).toMatch(/bridge\.onAsked\(/);
-    expect(src).toMatch(/return bridge\.onAsked/);
+    expect(src).toMatch(/bridge\.onSettled\(/);
+    expect(src).toMatch(/unsubscribeAsked\(\)/);
+    expect(src).toMatch(/unsubscribeSettled\(\)/);
     expect(src).toMatch(/bridge\.answer\(\{/);
     expect(src).toMatch(/bridge\.cancel\(\{/);
   });
 
   it('InputArea swaps the composer for the overlay while a question is active', () => {
     const src = read('components/InputArea.tsx');
-    expect(src).toMatch(/useAskQuestion\(\)/);
+    expect(src).toMatch(/useAskQuestion\(sessionId\)/);
     expect(src).toMatch(/if \(askQuestion\.active\) \{/);
     expect(src).toMatch(/<AskQuestionOverlay question=\{askQuestion\} \/>/);
   });

--- a/electron/tests/unit/subagent-question-routing.test.ts
+++ b/electron/tests/unit/subagent-question-routing.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AgentTier, AgentType, type Agent } from '../../src/shared/types/agent';
+import { SubagentManager } from '../../src/main/agents/manager';
+import { createBuiltinToolRegistry } from '../../src/main/tools';
+import { questionStore } from '../../src/main/tools/ask-question';
+
+const worker: Agent = {
+  name: 'question-worker',
+  type: AgentType.SUBAGENT,
+  tier: AgentTier.BLOOM,
+  description: 'Asks the parent for clarification',
+  allowed_tools: ['ask_question'],
+  allowed_skills: [],
+};
+
+const questions = [
+  {
+    type: 'single' as const,
+    title: 'Which path?',
+    options: [{ label: 'A' }, { label: 'B' }],
+  },
+];
+
+describe('subagent ask_question production registry routing', () => {
+  it('keeps main-agent questions on the renderer-backed question store', async () => {
+    const registry = createBuiltinToolRegistry({ subagentManager: new SubagentManager() });
+    const askQuestion = registry.get('ask_question')!;
+    const rendererEvent = vi.fn((payload: { toolCallId: string }) => {
+      questionStore.cancel(payload.toolCallId);
+    });
+    questionStore.on('question-asked', rendererEvent);
+
+    try {
+      const result = await askQuestion.handler(
+        { questions },
+        {
+          cwd: '/tmp/project',
+          sessionId: 'session-main',
+          agentScopeId: 'main',
+        },
+      );
+
+      expect(rendererEvent).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'session-main',
+        questions,
+      }));
+      expect(result.status).toBe('cancelled');
+    } finally {
+      questionStore.off('question-asked', rendererEvent);
+    }
+  });
+
+  it.each([
+    {
+      name: 'answered',
+      answerInput: {
+        answers: [{ selected: ['A'], text: null, skipped: false }],
+      },
+      expectedAskValue: {
+        questions,
+        answers: [{ selected: ['A'], text: null, skipped: false }],
+      },
+    },
+    {
+      name: 'declined',
+      answerInput: { decline: true },
+      expectedAskValue: { status: 'declined' },
+    },
+  ])('routes a $name child question through the shared manager without a renderer event', async ({
+    answerInput,
+    expectedAskValue,
+  }) => {
+    const manager = new SubagentManager();
+    const registry = createBuiltinToolRegistry({ subagentManager: manager });
+    const record = manager.spawn('question worker', 'ask the parent', worker, {
+      sessionId: 'session-owner',
+    });
+    manager.markRunning(record.id);
+
+    const askQuestion = registry.get('ask_question')!;
+    const waitForSubagent = registry.get('wait_for_subagent')!;
+    const answerSubagent = registry.get('answer_subagent')!;
+    const rendererEvent = vi.fn((payload: { toolCallId: string }) => {
+      questionStore.cancel(payload.toolCallId);
+    });
+    questionStore.on('question-asked', rendererEvent);
+
+    const originalWait = manager.wait.bind(manager);
+    vi.spyOn(manager, 'wait').mockImplementation((ids, options) =>
+      originalWait(ids, { ...options, timeoutMs: 30 }),
+    );
+
+    try {
+      const askPromise = askQuestion.handler(
+        { questions },
+        {
+          cwd: '/tmp/project',
+          sessionId: 'session-owner',
+          agentScopeId: record.id,
+        },
+      );
+      const waitResult = await waitForSubagent.handler(
+        { subagent_ids: [record.id] },
+        {
+          cwd: '/tmp/project',
+          sessionId: 'session-owner',
+          agentScopeId: 'main',
+        },
+      );
+      const pending = manager.getRecord(record.id)?.pendingQuestion;
+      expect(pending).not.toBeNull();
+      const answerResult = await answerSubagent.handler(
+        {
+          subagent_id: record.id,
+          tool_call_id: pending!.toolCallId,
+          ...answerInput,
+        },
+        {
+          cwd: '/tmp/project',
+          sessionId: 'session-owner',
+          agentScopeId: 'main',
+        },
+      );
+      const askResult = await askPromise;
+
+      expect(rendererEvent).not.toHaveBeenCalled();
+      expect(waitResult.status).toBe('complete');
+      expect(String(waitResult.data.value)).toContain('question_pending');
+      expect(String(waitResult.data.value)).toContain(
+        `tool_call_id="${pending!.toolCallId}"`,
+      );
+      expect(answerResult.status).toBe('complete');
+      expect(askResult.status).toBe('complete');
+      expect(askResult.data.value).toEqual(expectedAskValue);
+    } finally {
+      questionStore.off('question-asked', rendererEvent);
+      manager.cancelOne(record.id);
+    }
+  });
+});

--- a/electron/tests/unit/subagent-runner.test.ts
+++ b/electron/tests/unit/subagent-runner.test.ts
@@ -54,6 +54,7 @@ const mocks = vi.hoisted(() => ({
         { definition: { name: 'delegate_to_subagent' } },
         { definition: { name: 'wait_for_subagent' } },
         { definition: { name: 'interrupt_subagents' } },
+        { definition: { name: 'answer_subagent' } },
       ];
     }),
   },
@@ -276,6 +277,24 @@ describe('createSubagentStreamRunner', () => {
     expect(mocks.toolRegistry.filter).toHaveBeenCalledWith([]);
     expect(mocks.streamChat).toHaveBeenCalledWith(expect.objectContaining({
       agent: expect.objectContaining({ allowed_tools: [] }),
+    }));
+  });
+
+  it('removes main-only subagent controls from wildcard child registries', async () => {
+    await collect(createSubagentStreamRunner()({
+      task: 'Inspect the project',
+      agent,
+      selection,
+      abortSignal: new AbortController().signal,
+      agentScopeId: 'scope-main-only-tools',
+      sessionId: 'session-main-only-tools',
+      cwd: '/tmp/project',
+      projectRuntime: runtime(),
+    }));
+
+    expect(mocks.toolRegistry.filter).toHaveBeenCalledWith(['*']);
+    expect(mocks.streamChat).toHaveBeenCalledWith(expect.objectContaining({
+      agent: expect.objectContaining({ allowed_tools: ['read_file'] }),
     }));
   });
 });

--- a/electron/tests/unit/subagent-tools.test.ts
+++ b/electron/tests/unit/subagent-tools.test.ts
@@ -467,7 +467,7 @@ describe('wait_for_subagent', () => {
     const waitPromise = handler({ subagent_ids: [record.id] });
 
     // The subagent pauses to ask a question, which unblocks the wait early.
-    const questionPromise = manager.markQuestionPending(record.id, 'tc-123', [
+    const questionPromise = manager.markQuestionPending(record.id, 'tc-123<&"', [
       {
         type: 'single',
         title: 'Which framework?',
@@ -483,7 +483,9 @@ describe('wait_for_subagent', () => {
 
     expect(result.canonical.status).toBe('complete');
     expect(result.agentProjection.content).toContain('status="question_pending"');
-    expect(result.agentProjection.content).toContain('<pending_question tool_call_id="tc-123">');
+    expect(result.agentProjection.content).toContain(
+      '<pending_question tool_call_id="tc-123&lt;&amp;&quot;">',
+    );
     expect(result.agentProjection.content).toContain(
       '<question type="single" title="Which framework?" description="Pick one">',
     );
@@ -493,7 +495,7 @@ describe('wait_for_subagent', () => {
     expect(record.state).toBe(SubagentState.RUNNING);
 
     // Resolve the pending question so the promise does not dangle.
-    manager.answerSubagentQuestion(record.id, { type: 'declined' });
+    manager.answerSubagentQuestion(record.id, 'tc-123<&"', { type: 'declined' });
     await questionPromise;
   });
 });
@@ -699,8 +701,8 @@ describe('answer_subagent', () => {
     manager = new SubagentManager();
   });
 
-  function spawnWithPendingQuestion() {
-    const record = manager.spawn('test', 'task', codeReviewerAgent);
+  function spawnWithPendingQuestion(sessionId?: string) {
+    const record = manager.spawn('test', 'task', codeReviewerAgent, { sessionId });
     manager.markRunning(record.id);
     const questionPromise = manager.markQuestionPending(record.id, 'tc-1', sampleQuestions);
     return { id: record.id, questionPromise };
@@ -711,7 +713,7 @@ describe('answer_subagent', () => {
     const { id, questionPromise } = spawnWithPendingQuestion();
 
     const answers = [{ selected: ['React'], text: null, skipped: false }];
-    const result = (await handler({ subagent_id: id, answers })) as ToolExecutionResult;
+    const result = (await handler({ subagent_id: id, tool_call_id: 'tc-1', answers })) as ToolExecutionResult;
 
     expect(result.canonical.status).toBe('complete');
     expect(result.agentProjection.content).toContain('answered');
@@ -723,11 +725,49 @@ describe('answer_subagent', () => {
     const { handler } = buildAnswerSubagentTool(manager);
     const { id, questionPromise } = spawnWithPendingQuestion();
 
-    const result = (await handler({ subagent_id: id, decline: true })) as ToolExecutionResult;
+    const result = (await handler({ subagent_id: id, tool_call_id: 'tc-1', decline: true })) as ToolExecutionResult;
 
     expect(result.canonical.status).toBe('complete');
     expect(result.agentProjection.content).toContain('declined');
     await expect(questionPromise).resolves.toEqual({ type: 'declined' });
+  });
+
+  it('rejects attempts from a subagent scope and leaves the question pending', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const { id, questionPromise } = spawnWithPendingQuestion('sess-a');
+
+    try {
+      const result = (await handler(
+        { subagent_id: id, tool_call_id: 'tc-1', decline: true },
+        { cwd: '/tmp/project', sessionId: 'sess-a', agentScopeId: 'subagent-peer' },
+      )) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('error');
+      expect(result.agentProjection.content).toMatch(/main agent/i);
+      expect(manager.getRecord(id)?.pendingQuestion).not.toBeNull();
+    } finally {
+      manager.answerSubagentQuestion(id, 'tc-1', { type: 'declined' });
+      await questionPromise;
+    }
+  });
+
+  it('rejects attempts from another session and leaves the question pending', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const { id, questionPromise } = spawnWithPendingQuestion('sess-owner');
+
+    try {
+      const result = (await handler(
+        { subagent_id: id, tool_call_id: 'tc-1', decline: true },
+        { cwd: '/tmp/project', sessionId: 'sess-other', agentScopeId: 'main' },
+      )) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('error');
+      expect(result.agentProjection.content).toContain('no pending question');
+      expect(manager.getRecord(id)?.pendingQuestion).not.toBeNull();
+    } finally {
+      manager.answerSubagentQuestion(id, 'tc-1', { type: 'declined' });
+      await questionPromise;
+    }
   });
 
   it('errors when both answers and decline are provided', async () => {
@@ -736,6 +776,7 @@ describe('answer_subagent', () => {
 
     const result = (await handler({
       subagent_id: id,
+      tool_call_id: 'tc-1',
       answers: [{ selected: ['React'], text: null, skipped: false }],
       decline: true,
     })) as ToolExecutionResult;
@@ -743,7 +784,7 @@ describe('answer_subagent', () => {
     expect(result.canonical.status).toBe('error');
     expect(result.agentProjection.content).toContain('exactly one');
     // The pending question is left untouched; clean it up.
-    manager.answerSubagentQuestion(id, { type: 'declined' });
+    manager.answerSubagentQuestion(id, 'tc-1', { type: 'declined' });
     await questionPromise;
   });
 
@@ -751,11 +792,11 @@ describe('answer_subagent', () => {
     const { handler } = buildAnswerSubagentTool(manager);
     const { id, questionPromise } = spawnWithPendingQuestion();
 
-    const result = (await handler({ subagent_id: id })) as ToolExecutionResult;
+    const result = (await handler({ subagent_id: id, tool_call_id: 'tc-1' })) as ToolExecutionResult;
 
     expect(result.canonical.status).toBe('error');
     expect(result.agentProjection.content).toContain('exactly one');
-    manager.answerSubagentQuestion(id, { type: 'declined' });
+    manager.answerSubagentQuestion(id, 'tc-1', { type: 'declined' });
     await questionPromise;
   });
 
@@ -763,7 +804,11 @@ describe('answer_subagent', () => {
     const { handler } = buildAnswerSubagentTool(manager);
     const record = manager.spawn('test', 'task', codeReviewerAgent);
 
-    const result = (await handler({ subagent_id: record.id, decline: true })) as ToolExecutionResult;
+    const result = (await handler({
+      subagent_id: record.id,
+      tool_call_id: 'tc-missing',
+      decline: true,
+    })) as ToolExecutionResult;
 
     expect(result.canonical.status).toBe('error');
     expect(result.agentProjection.content).toContain('no pending question');
@@ -774,5 +819,32 @@ describe('answer_subagent', () => {
     expect(definition.name).toBe('answer_subagent');
     expect(definition.actionLabel).toBe('Answering subagent...');
     expect(definition.category).toBe('subagent');
+    expect(definition.description).toContain('tool_call_id');
+    expect(definition.inputSchema.safeParse({
+      subagent_id: 'subagent-1',
+      decline: true,
+    }).success).toBe(false);
+    expect(definition.inputSchema.safeParse({
+      subagent_id: 'subagent-1',
+      tool_call_id: 'tc-1',
+      decline: true,
+    }).success).toBe(true);
+  });
+
+  it('rejects the wrong question identity without settling the pending question', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const { id, questionPromise } = spawnWithPendingQuestion();
+
+    const result = (await handler({
+      subagent_id: id,
+      tool_call_id: 'tc-stale',
+      decline: true,
+    })) as ToolExecutionResult;
+
+    expect(result.canonical.status).toBe('error');
+    expect(result.agentProjection.content).toContain('tc-stale');
+    expect(manager.getRecord(id)?.pendingQuestion?.toolCallId).toBe('tc-1');
+    manager.answerSubagentQuestion(id, 'tc-1', { type: 'declined' });
+    await questionPromise;
   });
 });

--- a/electron/tests/unit/subagent-tools.test.ts
+++ b/electron/tests/unit/subagent-tools.test.ts
@@ -17,6 +17,7 @@ import { SubagentManager, SubagentState } from '../../src/main/agents/manager';
 import { buildDelegateTool as buildDelegateToolRaw } from '../../src/main/tools/subagent/delegate';
 import { buildWaitTool as buildWaitToolRaw } from '../../src/main/tools/subagent/wait';
 import { buildInterruptTool as buildInterruptToolRaw } from '../../src/main/tools/subagent/interrupt';
+import { buildAnswerSubagentTool as buildAnswerSubagentToolRaw } from '../../src/main/tools/subagent/answer';
 import type { ToolDefinition, ToolExecutionContext, ToolHandler } from '../../src/main/tools/types';
 import { finalizeToolExecutionResult } from '../../src/main/tools/result';
 import {
@@ -110,6 +111,8 @@ const buildWaitTool = (...args: Parameters<typeof buildWaitToolRaw>) =>
   canonicalizeTool(buildWaitToolRaw(...args));
 const buildInterruptTool = (...args: Parameters<typeof buildInterruptToolRaw>) =>
   canonicalizeTool(buildInterruptToolRaw(...args));
+const buildAnswerSubagentTool = (...args: Parameters<typeof buildAnswerSubagentToolRaw>) =>
+  canonicalizeTool(buildAnswerSubagentToolRaw(...args));
 
 // ── delegate_to_subagent ─────────────────────────────────────────────────────
 
@@ -455,6 +458,44 @@ describe('wait_for_subagent', () => {
     expect(record.state).toBe(SubagentState.RUNNING);
     waitSpy.mockRestore();
   });
+
+  it('returns early with a pending_question block when a subagent asks a question', async () => {
+    const { handler } = buildWaitTool(manager);
+    const record = manager.spawn('test', 'Review the auth module', codeReviewerAgent);
+    manager.markRunning(record.id);
+
+    const waitPromise = handler({ subagent_ids: [record.id] });
+
+    // The subagent pauses to ask a question, which unblocks the wait early.
+    const questionPromise = manager.markQuestionPending(record.id, 'tc-123', [
+      {
+        type: 'single',
+        title: 'Which framework?',
+        description: 'Pick one',
+        options: [
+          { label: 'React', description: 'A UI library' },
+          { label: 'Vue' },
+        ],
+      },
+    ]);
+
+    const result = (await waitPromise) as ToolExecutionResult;
+
+    expect(result.canonical.status).toBe('complete');
+    expect(result.agentProjection.content).toContain('status="question_pending"');
+    expect(result.agentProjection.content).toContain('<pending_question tool_call_id="tc-123">');
+    expect(result.agentProjection.content).toContain(
+      '<question type="single" title="Which framework?" description="Pick one">',
+    );
+    expect(result.agentProjection.content).toContain('<option label="React" description="A UI library"/>');
+    expect(result.agentProjection.content).toContain('<option label="Vue"/>');
+    // The record is still running — only the wait returned early.
+    expect(record.state).toBe(SubagentState.RUNNING);
+
+    // Resolve the pending question so the promise does not dangle.
+    manager.answerSubagentQuestion(record.id, { type: 'declined' });
+    await questionPromise;
+  });
 });
 
 // ── interrupt_subagents ──────────────────────────────────────────────────────
@@ -637,6 +678,101 @@ describe('interrupt_subagents', () => {
     const { definition } = buildInterruptTool(manager);
     expect(definition.name).toBe('interrupt_subagents');
     expect(definition.actionLabel).toBe('Interrupting...');
+    expect(definition.category).toBe('subagent');
+  });
+});
+
+// ── answer_subagent ──────────────────────────────────────────────────────────
+
+describe('answer_subagent', () => {
+  let manager: SubagentManager;
+
+  const sampleQuestions = [
+    {
+      type: 'single' as const,
+      title: 'Which framework?',
+      options: [{ label: 'React' }, { label: 'Vue' }],
+    },
+  ];
+
+  beforeEach(() => {
+    manager = new SubagentManager();
+  });
+
+  function spawnWithPendingQuestion() {
+    const record = manager.spawn('test', 'task', codeReviewerAgent);
+    manager.markRunning(record.id);
+    const questionPromise = manager.markQuestionPending(record.id, 'tc-1', sampleQuestions);
+    return { id: record.id, questionPromise };
+  }
+
+  it('answers a pending question and resolves the subagent with the answers', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const { id, questionPromise } = spawnWithPendingQuestion();
+
+    const answers = [{ selected: ['React'], text: null, skipped: false }];
+    const result = (await handler({ subagent_id: id, answers })) as ToolExecutionResult;
+
+    expect(result.canonical.status).toBe('complete');
+    expect(result.agentProjection.content).toContain('answered');
+    expect(result.agentProjection.content).toContain(id);
+    await expect(questionPromise).resolves.toEqual({ type: 'answered', answers });
+  });
+
+  it('declines a pending question', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const { id, questionPromise } = spawnWithPendingQuestion();
+
+    const result = (await handler({ subagent_id: id, decline: true })) as ToolExecutionResult;
+
+    expect(result.canonical.status).toBe('complete');
+    expect(result.agentProjection.content).toContain('declined');
+    await expect(questionPromise).resolves.toEqual({ type: 'declined' });
+  });
+
+  it('errors when both answers and decline are provided', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const { id, questionPromise } = spawnWithPendingQuestion();
+
+    const result = (await handler({
+      subagent_id: id,
+      answers: [{ selected: ['React'], text: null, skipped: false }],
+      decline: true,
+    })) as ToolExecutionResult;
+
+    expect(result.canonical.status).toBe('error');
+    expect(result.agentProjection.content).toContain('exactly one');
+    // The pending question is left untouched; clean it up.
+    manager.answerSubagentQuestion(id, { type: 'declined' });
+    await questionPromise;
+  });
+
+  it('errors when neither answers nor decline is provided', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const { id, questionPromise } = spawnWithPendingQuestion();
+
+    const result = (await handler({ subagent_id: id })) as ToolExecutionResult;
+
+    expect(result.canonical.status).toBe('error');
+    expect(result.agentProjection.content).toContain('exactly one');
+    manager.answerSubagentQuestion(id, { type: 'declined' });
+    await questionPromise;
+  });
+
+  it('errors when the subagent has no pending question', async () => {
+    const { handler } = buildAnswerSubagentTool(manager);
+    const record = manager.spawn('test', 'task', codeReviewerAgent);
+
+    const result = (await handler({ subagent_id: record.id, decline: true })) as ToolExecutionResult;
+
+    expect(result.canonical.status).toBe('error');
+    expect(result.agentProjection.content).toContain('no pending question');
+  });
+
+  it('should have correct tool definition', () => {
+    const { definition } = buildAnswerSubagentTool(manager);
+    expect(definition.name).toBe('answer_subagent');
+    expect(definition.actionLabel).toBe('Answering subagent...');
     expect(definition.category).toBe('subagent');
   });
 });

--- a/electron/tests/unit/system-prompt.test.ts
+++ b/electron/tests/unit/system-prompt.test.ts
@@ -13,7 +13,7 @@ describe('buildDynamicSystemPrompt — pendingSubagentQuestions', () => {
           subagentId: 'sa-1',
           name: 'review auth',
           type: 'code-reviewer',
-          toolCallId: 'tc-1',
+          toolCallId: 'tc-&"1',
           questions: [
             {
               type: 'single',
@@ -31,7 +31,7 @@ describe('buildDynamicSystemPrompt — pendingSubagentQuestions', () => {
 
     expect(prompt).toContain('<pending_subagent_questions>');
     expect(prompt).toContain(
-      '<pending_question subagent_id="sa-1" name="review auth" type="code-reviewer">',
+      '<pending_question subagent_id="sa-1" tool_call_id="tc-&amp;&quot;1" name="review auth" type="code-reviewer">',
     );
     expect(prompt).toContain(
       '<question type="single" title="Which framework?" description="Pick one">',
@@ -54,7 +54,7 @@ describe('buildDynamicSystemPrompt — pendingSubagentQuestions', () => {
           subagentId: 'sa-1',
           name: 'a & b <c>',
           type: 'code-reviewer',
-          toolCallId: 'tc-1',
+          toolCallId: 'tc-1 & "quoted"',
           questions: [
             {
               type: 'single',
@@ -67,6 +67,7 @@ describe('buildDynamicSystemPrompt — pendingSubagentQuestions', () => {
     });
 
     expect(prompt).toContain('name="a &amp; b &lt;c&gt;"');
+    expect(prompt).toContain('tool_call_id="tc-1 &amp; &quot;quoted&quot;"');
     expect(prompt).toContain('title="Say &quot;hi&quot; &amp; &lt;bye&gt;"');
     expect(prompt).toContain('label="A &quot;quoted&quot; &amp; &lt;tagged&gt;"');
   });

--- a/electron/tests/unit/system-prompt.test.ts
+++ b/electron/tests/unit/system-prompt.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Dynamic system prompt rendering — pending subagent questions (U8).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildDynamicSystemPrompt } from '../../src/main/llm/system-prompt';
+
+describe('buildDynamicSystemPrompt — pendingSubagentQuestions', () => {
+  it('renders a pending_subagent_questions section when questions exist', () => {
+    const prompt = buildDynamicSystemPrompt({
+      cwd: '/tmp',
+      pendingSubagentQuestions: [
+        {
+          subagentId: 'sa-1',
+          name: 'review auth',
+          type: 'code-reviewer',
+          toolCallId: 'tc-1',
+          questions: [
+            {
+              type: 'single',
+              title: 'Which framework?',
+              description: 'Pick one',
+              options: [
+                { label: 'React', description: 'A UI library' },
+                { label: 'Vue' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(prompt).toContain('<pending_subagent_questions>');
+    expect(prompt).toContain(
+      '<pending_question subagent_id="sa-1" name="review auth" type="code-reviewer">',
+    );
+    expect(prompt).toContain(
+      '<question type="single" title="Which framework?" description="Pick one">',
+    );
+    expect(prompt).toContain('<option label="React" description="A UI library"/>');
+    expect(prompt).toContain('<option label="Vue"/>');
+    expect(prompt).toContain('</pending_subagent_questions>');
+  });
+
+  it('omits the section when there are no pending questions', () => {
+    const prompt = buildDynamicSystemPrompt({ cwd: '/tmp', pendingSubagentQuestions: [] });
+    expect(prompt).not.toContain('<pending_subagent_questions>');
+  });
+
+  it('escapes XML special characters in attribute values', () => {
+    const prompt = buildDynamicSystemPrompt({
+      cwd: '/tmp',
+      pendingSubagentQuestions: [
+        {
+          subagentId: 'sa-1',
+          name: 'a & b <c>',
+          type: 'code-reviewer',
+          toolCallId: 'tc-1',
+          questions: [
+            {
+              type: 'single',
+              title: 'Say "hi" & <bye>',
+              options: [{ label: 'A "quoted" & <tagged>' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(prompt).toContain('name="a &amp; b &lt;c&gt;"');
+    expect(prompt).toContain('title="Say &quot;hi&quot; &amp; &lt;bye&gt;"');
+    expect(prompt).toContain('label="A &quot;quoted&quot; &amp; &lt;tagged&gt;"');
+  });
+});

--- a/electron/tests/unit/xstate-agents.test.ts
+++ b/electron/tests/unit/xstate-agents.test.ts
@@ -607,6 +607,66 @@ describe('SubagentManager', () => {
     expect(results.get(record.id)?.state).toBe(SubagentState.COMPLETED);
   });
 
+  it('wait resolves immediately when a requested subagent already has a pending question', async () => {
+    const record = manager.spawn('test', 'task', mockAgent);
+    manager.markRunning(record.id);
+    const questionPromise = manager.markQuestionPending(record.id, 'tc-before-wait', [
+      {
+        type: 'single',
+        title: 'Choose a direction',
+        options: [{ label: 'Continue' }],
+      },
+    ]);
+
+    try {
+      const results = await manager.wait([record.id], { timeoutMs: 30 });
+      expect(results.get(record.id)?.pendingQuestion?.toolCallId).toBe('tc-before-wait');
+    } finally {
+      manager.answerSubagentQuestion(record.id, 'tc-before-wait', { type: 'declined' });
+      await questionPromise;
+    }
+  });
+
+  it('declines a second concurrent question without replacing the first', async () => {
+    const record = manager.spawn('test', 'task', mockAgent);
+    manager.markRunning(record.id);
+
+    const first = manager.markQuestionPending(record.id, 'tc-first', [
+      {
+        type: 'single',
+        title: 'First question',
+        options: [{ label: 'Continue' }],
+      },
+    ]);
+    const second = manager.markQuestionPending(record.id, 'tc-second', [
+      {
+        type: 'single',
+        title: 'Second question',
+        options: [{ label: 'Continue' }],
+      },
+    ]);
+
+    await expect(second).resolves.toEqual({ type: 'declined' });
+    expect(record.pendingQuestion?.toolCallId).toBe('tc-first');
+    expect(manager.answerSubagentQuestion(record.id, 'tc-first', { type: 'declined' })).toBe(true);
+    await expect(first).resolves.toEqual({ type: 'declined' });
+  });
+
+  it('rejects a delayed answer after the next question is installed', async () => {
+    const record = manager.spawn('test', 'task', mockAgent);
+    manager.markRunning(record.id);
+
+    const first = manager.markQuestionPending(record.id, 'tc-first', []);
+    expect(manager.answerSubagentQuestion(record.id, 'tc-first', { type: 'declined' })).toBe(true);
+    await expect(first).resolves.toEqual({ type: 'declined' });
+
+    const second = manager.markQuestionPending(record.id, 'tc-second', []);
+    expect(manager.answerSubagentQuestion(record.id, 'tc-first', { type: 'declined' })).toBe(false);
+    expect(record.pendingQuestion?.toolCallId).toBe('tc-second');
+    expect(manager.answerSubagentQuestion(record.id, 'tc-second', { type: 'declined' })).toBe(true);
+    await expect(second).resolves.toEqual({ type: 'declined' });
+  });
+
   it('getRecord returns a single record by ID', () => {
     const record = manager.spawn('test', 'task', mockAgent);
 
@@ -630,6 +690,32 @@ describe('SubagentManager', () => {
     expect(results.size).toBe(2);
     expect(results.get(a.id)?.result).toBe('result a');
     expect(results.get(b.id)?.result).toBe('result b');
+  });
+
+  it('wait resolves on the first pending question in a multi-target wait and cleans peer waiters', async () => {
+    const a = manager.spawn('a', 'task 1', mockAgent);
+    const b = manager.spawn('b', 'task 2', mockAgent);
+    manager.markRunning(a.id);
+    manager.markRunning(b.id);
+
+    const waitPromise = manager.wait([a.id, b.id], { timeoutMs: 30 });
+    const questionPromise = manager.markQuestionPending(a.id, 'tc-first-question', [
+      {
+        type: 'single',
+        title: 'Need parent input',
+        options: [{ label: 'Proceed' }],
+      },
+    ]);
+
+    try {
+      const results = await waitPromise;
+      expect(results.get(a.id)?.pendingQuestion?.toolCallId).toBe('tc-first-question');
+      expect(results.get(b.id)?.state).toBe(SubagentState.RUNNING);
+      expect(b._resolveWait).toBeNull();
+    } finally {
+      manager.answerSubagentQuestion(a.id, 'tc-first-question', { type: 'declined' });
+      await questionPromise;
+    }
   });
 
   it('wait timeout errors without cancelling running subagents', async () => {


### PR DESCRIPTION
Agents can now ask the user multiple-choice questions mid-conversation via the ask_question tool. Supports single/multi-select with optional free-text, rendered as an overlay in the UI.

Subagents can also use ask_question — their questions route to the main agent (surfaced in the dynamic system prompt and returned early from wait_for_subagent), which can answer via answer_subagent or decline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive agent questions with single-choice, multi-choice, free-text, skip, and cancel support.
  * Added a step-by-step question overlay in the composer.
  * Added summarized question responses and cancellation results to chat history.
  * Added subagent question handling, including pending questions, responses, and declines.
* **Bug Fixes**
  * Cancelled tool results are now hidden from conversation history and API context.
* **Tests**
  * Added coverage for question flows, subagent responses, prompt formatting, and hidden results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->