### PR TITLE
fix(session): synchronize activity status surfaces

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - Subagent finished results should only send the last message, not full subagent history, the task is already defined on the dynamic context so I think it isnt necessary to resend
 - Interface may prevent some changes while streaming (Such as model and reasoning level) but the command pallete still allows to execute
 - Cannot execute commands while streaming (Only queue messages is possible)
-- Status icons and the status (Working, done, etc.) itself is not syncronized (Tabs, activity, session listing)
 
 ## Agent quality
 

--- a/electron/src/main/ipc/session-activity.ts
+++ b/electron/src/main/ipc/session-activity.ts
@@ -46,23 +46,19 @@ export function completeSessionActivity(
   sessionId: string,
   unread: boolean,
 ): SessionActivity {
-  const activity = sessionActivityStore.complete(sessionId, unread);
+  sessionActivityStore.complete(sessionId, unread);
   const enriched = sessionActivityStore.update(sessionId, {
     backgroundProcessCount: backgroundProcessCount(sessionId),
   });
   broadcast(enriched);
-  return activity.backgroundProcessCount === enriched.backgroundProcessCount
-    ? activity
-    : enriched;
+  return enriched;
 }
 
 export function removeSessionActivity(sessionId: string): void {
   const previous = sessionActivityStore.get(sessionId);
-  sessionActivityStore.remove(sessionId);
   if (!previous) return;
   // Tombstone: idle + seen + no bg so list filters out and renderers prune.
-  broadcast({
-    ...previous,
+  const tombstone = sessionActivityStore.update(sessionId, {
     state: 'idle',
     phase: null,
     detail: null,
@@ -70,8 +66,9 @@ export function removeSessionActivity(sessionId: string): void {
     canCancel: false,
     backgroundProcessCount: 0,
     completedAt: Date.now(),
-    updatedAt: Date.now(),
   });
+  sessionActivityStore.remove(sessionId);
+  broadcast(tombstone);
 }
 
 export function registerSessionActivityIPC(): void {

--- a/electron/src/main/session/activity.ts
+++ b/electron/src/main/session/activity.ts
@@ -47,12 +47,13 @@ export class SessionActivityStore {
     patch: SessionActivityUpdate,
     now: number = Date.now(),
   ): SessionActivity {
-    const previous = this.activities.get(sessionId) ?? emptyActivity(sessionId, now);
+    const existing = this.activities.get(sessionId);
+    const previous = existing ?? emptyActivity(sessionId, now);
     const next: SessionActivity = Object.freeze({
       ...previous,
       ...patch,
       sessionId,
-      updatedAt: now,
+      updatedAt: existing ? Math.max(now, existing.updatedAt + 1) : now,
     });
     this.activities.set(sessionId, next);
     return next;

--- a/electron/src/renderer/components/LeftSidebar.tsx
+++ b/electron/src/renderer/components/LeftSidebar.tsx
@@ -16,6 +16,10 @@ import type { WorkspaceInfo } from '../../shared/types/ipc';
 import type { SessionListState } from '../hooks/useSession';
 import { formatShortcut, useRovingListIndex } from '../keyboard';
 import {
+  sessionActivityPresentation,
+  sessionActivitySummaryPresentation,
+} from '../utils/session-activity-presentation';
+import {
   countProjectActivity,
   filterSessionsByQuery,
   groupSessionsByProject,
@@ -117,6 +121,7 @@ export const LeftSidebar = memo(function LeftSidebar({
     () => groupSessionsByProject(filterSessionsByQuery(sessions, query)),
     [sessions, query],
   );
+  const activitySummary = sessionActivitySummaryPresentation(activities);
 
   if (isCollapsed) {
     return (
@@ -144,17 +149,20 @@ export const LeftSidebar = memo(function LeftSidebar({
             onClick={onPickProjectDir}
           />
         )}
-        {activities.length > 0 && (
+        {activitySummary && (
           <Button
             variant="ghost"
             size="sm"
             shape="circle"
             className="left-panel-activity-count"
             onClick={onToggle}
-            title={`${activities.length} session${activities.length === 1 ? '' : 's'} need attention or are running`}
-            aria-label={`${activities.length} session${activities.length === 1 ? '' : 's'} need attention or are running`}
+            title={activitySummary.label}
+            aria-label={activitySummary.label}
           >
-            <span className="status status-xs status-warning" aria-hidden />
+            <span
+              className={`status status-xs ${activitySummary.statusClass}`}
+              aria-hidden
+            />
           </Button>
         )}
         <div className="left-panel-collapsed-spacer" />
@@ -699,6 +707,9 @@ const SessionRow = memo(function SessionRow({
   const pathHint = session.cwd
     ? truncatePathDisplay(session.cwd, 24)
     : 'Unknown path';
+  const activityStatus = activity
+    ? sessionActivityPresentation(activity)
+    : null;
 
   const handleSelect = useCallback(() => {
     onActivate(sessionIndex);
@@ -721,30 +732,10 @@ const SessionRow = memo(function SessionRow({
         title={session.cwd ?? session.name}
         onClick={handleSelect}
       >
-        {activity && (
+        {activityStatus?.visible && (
           <span
-            className={`status status-xs ${
-              activity.state === 'needs_attention'
-                ? 'status-error'
-                : activity.state === 'working'
-                  ? 'status-warning'
-                  : activity.state === 'waiting'
-                    ? 'status-info'
-                    : activity.unread
-                      ? 'status-success'
-                      : 'status-neutral'
-            }`}
-            title={
-              activity.state === 'needs_attention'
-                ? 'Needs attention'
-                : activity.state === 'working'
-                  ? 'Working'
-                  : activity.state === 'waiting'
-                    ? 'Waiting'
-                    : activity.unread
-                      ? 'Completed unread'
-                      : 'Idle'
-            }
+            className={`status status-xs ${activityStatus.statusClass}`}
+            title={activityStatus.label}
           />
         )}
         <span className="session-item-main min-w-0">

--- a/electron/src/renderer/components/SessionTabBar.tsx
+++ b/electron/src/renderer/components/SessionTabBar.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useMemo, useRef } from 'react';
 import type { SessionActivity, SessionSummary } from '../../shared/types/ipc-boundary';
+import { sessionActivityPresentation } from '../utils/session-activity-presentation';
 import { Icon } from './Icon';
 import { Button } from './ui/Button';
 import { SessionNameEditor } from './SessionNameEditor';
@@ -18,13 +19,6 @@ export interface SessionTabBarProps {
   onCloseDraft: () => void;
   onRename?: (sessionId: string, name: string) => void | Promise<void>;
 }
-
-const statusClass: Record<SessionActivity['state'], string> = {
-  idle: '',
-  working: 'status-warning',
-  waiting: 'status-info',
-  needs_attention: 'status-error',
-};
 
 function projectBasename(cwd: string | null | undefined): string | null {
   if (!cwd) return null;
@@ -99,14 +93,9 @@ export const SessionTabBar = memo(function SessionTabBar({
           const active = !showDraft && focusedSessionId === id;
           const project = projectBasename(session?.cwd);
           const title = session?.name ?? id.slice(0, 8);
-          const showDot =
-            activity &&
-            (activity.state !== 'idle' ||
-              activity.unread ||
-              activity.backgroundProcessCount > 0);
-          const dotClass = activity
-            ? statusClass[activity.state] || (activity.unread ? 'status-warning' : 'status-neutral')
-            : '';
+          const activityStatus = activity
+            ? sessionActivityPresentation(activity)
+            : null;
 
           return (
             <div
@@ -134,8 +123,12 @@ export const SessionTabBar = memo(function SessionTabBar({
                     : title
                 }
               >
-                {showDot ? (
-                  <span className={`status status-xs ${dotClass}`} aria-hidden />
+                {activityStatus?.visible ? (
+                  <span
+                    className={`status status-xs ${activityStatus.statusClass}`}
+                    title={activityStatus.label}
+                    aria-hidden
+                  />
                 ) : null}
                 {multiProject && project ? (
                   <span className="session-tab-project truncate" aria-hidden>

--- a/electron/src/renderer/components/session-activity-section.tsx
+++ b/electron/src/renderer/components/session-activity-section.tsx
@@ -3,6 +3,10 @@ import type {
   SessionActivity,
   SessionSummary,
 } from '../../shared/types/ipc-boundary';
+import {
+  sessionActivityPresentation,
+  sessionActivitySummaryPresentation,
+} from '../utils/session-activity-presentation';
 import { truncatePathDisplay } from '../utils/session-workspace';
 import { IconButton } from './ui/IconButton';
 import { StatusBadge } from './ui/StatusBadge';
@@ -12,26 +16,6 @@ interface SessionActivitySectionProps {
   sessions: readonly SessionSummary[];
   onSelect: (sessionId: string) => void;
   onStop: (sessionId: string) => void;
-}
-
-const statusClass: Record<SessionActivity['state'], string> = {
-  idle: 'status-neutral',
-  working: 'status-warning',
-  waiting: 'status-info',
-  needs_attention: 'status-error',
-};
-
-function activityLabel(activity: SessionActivity): string {
-  if (activity.state === 'needs_attention') return 'Needs attention';
-  if (activity.state === 'working') return 'Working';
-  if (activity.state === 'waiting') return 'Waiting';
-  if (activity.unread) return 'Completed · unread';
-  if (activity.backgroundProcessCount > 0) {
-    return `Idle · ${activity.backgroundProcessCount} process${
-      activity.backgroundProcessCount === 1 ? '' : 'es'
-    }`;
-  }
-  return 'Idle';
 }
 
 function elapsedLabel(startedAt: number | null, now: number): string | null {
@@ -66,6 +50,7 @@ export const SessionActivitySection = memo(function SessionActivitySection({
     () => new Map(sessions.map((session) => [session.id, session])),
     [sessions],
   );
+  const summary = sessionActivitySummaryPresentation(activities);
 
   if (activities.length === 0) return null;
 
@@ -73,13 +58,16 @@ export const SessionActivitySection = memo(function SessionActivitySection({
     <section className="session-activity border-b border-base-300" aria-label="Session activity">
       <div className="session-activity-heading">
         <span>Activity</span>
-        <StatusBadge tone="warning" size="xs">{activities.length}</StatusBadge>
+        <StatusBadge tone={summary?.tone ?? 'neutral'} size="xs">
+          {activities.length}
+        </StatusBadge>
       </div>
       <div className="session-activity-list" role="list">
         {activities.map((activity) => {
           const session = sessionsById.get(activity.sessionId);
           const projectPath = session?.cwd ?? activity.cwd;
           const elapsed = elapsedLabel(activity.startedAt, now);
+          const activityStatus = sessionActivityPresentation(activity);
           return (
             <div key={activity.sessionId} className="session-activity-row orchid-list-item-enter" role="listitem">
               <button
@@ -88,7 +76,10 @@ export const SessionActivitySection = memo(function SessionActivitySection({
                 onClick={() => onSelect(activity.sessionId)}
                 title={projectPath ?? session?.name ?? 'Session activity'}
               >
-                <span className={`status status-xs ${statusClass[activity.state]}`} aria-hidden />
+                <span
+                  className={`status status-xs ${activityStatus.statusClass}`}
+                  aria-hidden
+                />
                 <span className="session-activity-copy min-w-0">
                   <span className="session-activity-name truncate">
                     {session?.name ?? 'New session'}
@@ -100,7 +91,7 @@ export const SessionActivitySection = memo(function SessionActivitySection({
                 </span>
                 <span className="session-activity-status">
                   {elapsed && <span>{elapsed}</span>}
-                  <span>{activityLabel(activity)}</span>
+                  <span>{activityStatus.label}</span>
                 </span>
               </button>
               {activity.canCancel && (

--- a/electron/src/renderer/hooks/useSessionActivity.ts
+++ b/electron/src/renderer/hooks/useSessionActivity.ts
@@ -1,5 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SessionActivity } from '../../shared/types/ipc-boundary';
+import {
+  captureSessionActivityBaseline,
+  mergeSessionActivity,
+  orderedSessionActivities,
+  reconcileSessionActivitySnapshot,
+  type SessionActivityMap,
+} from '../utils/session-activity-state';
 
 export type SessionActivityState =
   | { status: 'loading' }
@@ -13,48 +20,6 @@ export interface UseSessionActivityReturn {
   markSeen: (sessionId: string) => Promise<void>;
 }
 
-function isVisibleActivity(activity: SessionActivity): boolean {
-  return (
-    activity.state !== 'idle' ||
-    activity.unread ||
-    activity.backgroundProcessCount > 0
-  );
-}
-
-function mergeActivity(
-  current: ReadonlyMap<string, SessionActivity>,
-  incoming: SessionActivity,
-): Map<string, SessionActivity> {
-  const existing = current.get(incoming.sessionId);
-  if (existing && existing.updatedAt > incoming.updatedAt) {
-    return new Map(current);
-  }
-  const next = new Map(current);
-  if (!isVisibleActivity(incoming)) {
-    next.delete(incoming.sessionId);
-    return next;
-  }
-  next.set(incoming.sessionId, incoming);
-  return next;
-}
-
-function orderedActivities(map: ReadonlyMap<string, SessionActivity>): SessionActivity[] {
-  const priority: Record<SessionActivity['state'], number> = {
-    needs_attention: 0,
-    working: 1,
-    waiting: 2,
-    idle: 3,
-  };
-  return [...map.values()]
-    .filter(isVisibleActivity)
-    .sort((a, b) => {
-      const statePriority = priority[a.state] - priority[b.state];
-      if (statePriority !== 0) return statePriority;
-      if (a.unread !== b.unread) return a.unread ? -1 : 1;
-      return b.updatedAt - a.updatedAt;
-    });
-}
-
 /**
  * Process-wide session activity. Push updates are merged by timestamp so a
  * slow initial snapshot can never overwrite a newer broadcast.
@@ -63,26 +28,34 @@ export function useSessionActivity(): UseSessionActivityReturn {
   const [activityBySession, setActivityBySession] = useState<
     ReadonlyMap<string, SessionActivity>
   >(() => new Map());
+  const activityBySessionRef = useRef<SessionActivityMap>(activityBySession);
   const [state, setState] = useState<SessionActivityState>({ status: 'loading' });
 
+  const updateActivities = useCallback(
+    (update: (current: SessionActivityMap) => SessionActivityMap) => {
+      setActivityBySession((current) => {
+        const next = update(current);
+        activityBySessionRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
   const apply = useCallback((activity: SessionActivity) => {
-    setActivityBySession((current) => mergeActivity(current, activity));
-  }, []);
+    updateActivities((current) => mergeSessionActivity(current, activity));
+  }, [updateActivities]);
 
   const refresh = useCallback(async () => {
     if (!window.orchid?.session?.listActivity) {
       setState({ status: 'ready' });
       return;
     }
+    const baseline = captureSessionActivityBaseline(activityBySessionRef.current);
     try {
       const activities = await window.orchid.session.listActivity();
-      setActivityBySession((current) => {
-        let next: ReadonlyMap<string, SessionActivity> = current;
-        for (const activity of activities) {
-          next = mergeActivity(next, activity);
-        }
-        return next;
-      });
+      updateActivities((current) =>
+        reconcileSessionActivitySnapshot(current, activities, baseline));
       setState({ status: 'ready' });
     } catch (err) {
       setState({
@@ -90,7 +63,7 @@ export function useSessionActivity(): UseSessionActivityReturn {
         error: err instanceof Error ? err.message : String(err),
       });
     }
-  }, []);
+  }, [updateActivities]);
 
   useEffect(() => {
     const unsubscribe = window.orchid?.session?.onActivityChanged?.((event) => {
@@ -111,7 +84,7 @@ export function useSessionActivity(): UseSessionActivityReturn {
   }, [apply]);
 
   const activities = useMemo(
-    () => orderedActivities(activityBySession),
+    () => orderedSessionActivities(activityBySession),
     [activityBySession],
   );
 

--- a/electron/src/renderer/utils/session-activity-presentation.ts
+++ b/electron/src/renderer/utils/session-activity-presentation.ts
@@ -1,0 +1,102 @@
+import type { SessionActivity } from '../../shared/types/ipc-boundary';
+
+export type SessionActivityDisplayState =
+  | 'needs_attention'
+  | 'working'
+  | 'waiting'
+  | 'completed_unread'
+  | 'idle_background'
+  | 'idle';
+
+export type SessionActivityTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error';
+
+export interface SessionActivityPresentation {
+  readonly state: SessionActivityDisplayState;
+  readonly label: string;
+  readonly tone: SessionActivityTone;
+  readonly statusClass: string;
+  readonly visible: boolean;
+}
+
+const STATUS_CLASS: Record<SessionActivityTone, string> = {
+  neutral: 'status-neutral',
+  info: 'status-info',
+  success: 'status-success',
+  warning: 'status-warning',
+  error: 'status-error',
+};
+
+const SUMMARY_PRIORITY: Record<SessionActivityDisplayState, number> = {
+  needs_attention: 0,
+  working: 1,
+  waiting: 2,
+  completed_unread: 3,
+  idle_background: 4,
+  idle: 5,
+};
+
+function presentation(
+  state: SessionActivityDisplayState,
+  label: string,
+  tone: SessionActivityTone,
+  visible = true,
+): SessionActivityPresentation {
+  return {
+    state,
+    label,
+    tone,
+    statusClass: STATUS_CLASS[tone],
+    visible,
+  };
+}
+
+/** Derive one user-facing status from the activity's orthogonal runtime fields. */
+export function sessionActivityPresentation(
+  activity: SessionActivity,
+): SessionActivityPresentation {
+  if (activity.state === 'needs_attention') {
+    return presentation('needs_attention', 'Needs attention', 'error');
+  }
+  if (activity.state === 'working') {
+    return presentation('working', 'Working', 'warning');
+  }
+  if (activity.state === 'waiting') {
+    return presentation('waiting', 'Waiting', 'info');
+  }
+  if (activity.unread) {
+    return presentation('completed_unread', 'Completed · unread', 'success');
+  }
+  if (activity.backgroundProcessCount > 0) {
+    const suffix = activity.backgroundProcessCount === 1 ? 'process' : 'processes';
+    return presentation(
+      'idle_background',
+      `Idle · ${activity.backgroundProcessCount} ${suffix}`,
+      'neutral',
+    );
+  }
+  return presentation('idle', 'Idle', 'neutral', false);
+}
+
+/** Highest-priority visible status for compact aggregate activity affordances. */
+export function sessionActivitySummaryPresentation(
+  activities: readonly SessionActivity[],
+): (Pick<SessionActivityPresentation, 'tone' | 'statusClass'> & {
+  readonly label: string;
+}) | null {
+  const visible = activities
+    .map(sessionActivityPresentation)
+    .filter((item) => item.visible)
+    .sort((a, b) => SUMMARY_PRIORITY[a.state] - SUMMARY_PRIORITY[b.state]);
+  const highest = visible[0];
+  if (!highest) return null;
+  return {
+    label: `${visible.length} session${visible.length === 1 ? '' : 's'} with activity`,
+    tone: highest.tone,
+    statusClass: highest.statusClass,
+  };
+}

--- a/electron/src/renderer/utils/session-activity-state.ts
+++ b/electron/src/renderer/utils/session-activity-state.ts
@@ -1,0 +1,87 @@
+import type { SessionActivity } from '../../shared/types/ipc-boundary';
+import { sessionActivityPresentation } from './session-activity-presentation';
+
+export type SessionActivityMap = ReadonlyMap<string, SessionActivity>;
+export type SessionActivityBaseline = ReadonlyMap<string, number>;
+
+function terminalTombstone(activity: SessionActivity): SessionActivity {
+  return Object.freeze({
+    ...activity,
+    state: 'idle',
+    phase: null,
+    detail: null,
+    unread: false,
+    backgroundProcessCount: 0,
+    canCancel: false,
+  });
+}
+
+/** Merge one ordered activity event while retaining invisible terminal tombstones. */
+export function mergeSessionActivity(
+  current: SessionActivityMap,
+  incoming: SessionActivity,
+): SessionActivityMap {
+  const existing = current.get(incoming.sessionId);
+  if (existing && existing.updatedAt >= incoming.updatedAt) {
+    return current;
+  }
+  const next = new Map(current);
+  next.set(incoming.sessionId, incoming);
+  return next;
+}
+
+/** Capture the entries an authoritative refresh is allowed to remove. */
+export function captureSessionActivityBaseline(
+  current: SessionActivityMap,
+): SessionActivityBaseline {
+  return new Map(
+    [...current].map(([sessionId, activity]) => [sessionId, activity.updatedAt]),
+  );
+}
+
+/**
+ * Reconcile a snapshot without pruning broadcasts that arrived after the
+ * request began. Missing unchanged entries become ordered tombstones.
+ */
+export function reconcileSessionActivitySnapshot(
+  current: SessionActivityMap,
+  incoming: readonly SessionActivity[],
+  baseline: SessionActivityBaseline,
+): SessionActivityMap {
+  let next = current;
+  const incomingIds = new Set<string>();
+  for (const activity of incoming) {
+    incomingIds.add(activity.sessionId);
+    next = mergeSessionActivity(next, activity);
+  }
+
+  for (const [sessionId, baselineUpdatedAt] of baseline) {
+    if (incomingIds.has(sessionId)) continue;
+    const latest = next.get(sessionId);
+    if (!latest || latest.updatedAt !== baselineUpdatedAt) continue;
+    const updated = new Map(next);
+    updated.set(sessionId, terminalTombstone(latest));
+    next = updated;
+  }
+  return next;
+}
+
+/** Visible activities ordered by urgency and recency. */
+export function orderedSessionActivities(
+  current: SessionActivityMap,
+): SessionActivity[] {
+  const priority: Record<SessionActivity['state'], number> = {
+    needs_attention: 0,
+    working: 1,
+    waiting: 2,
+    idle: 3,
+  };
+  return [...current.values()]
+    .filter((activity) => sessionActivityPresentation(activity).visible)
+    .sort((a, b) => {
+      const statePriority = priority[a.state] - priority[b.state];
+      if (statePriority !== 0) return statePriority;
+      if (a.unread !== b.unread) return a.unread ? -1 : 1;
+      return b.updatedAt - a.updatedAt;
+    });
+}

--- a/electron/tests/unit/session-activity-presentation.test.tsx
+++ b/electron/tests/unit/session-activity-presentation.test.tsx
@@ -1,0 +1,188 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { LeftSidebar } from '../../src/renderer/components/LeftSidebar';
+import { SessionTabBar } from '../../src/renderer/components/SessionTabBar';
+import { SessionActivitySection } from '../../src/renderer/components/session-activity-section';
+import {
+  captureSessionActivityBaseline,
+  mergeSessionActivity,
+  orderedSessionActivities,
+  reconcileSessionActivitySnapshot,
+} from '../../src/renderer/utils/session-activity-state';
+import {
+  sessionActivityPresentation,
+  sessionActivitySummaryPresentation,
+} from '../../src/renderer/utils/session-activity-presentation';
+import type {
+  SessionActivity,
+  SessionSummary,
+} from '../../src/shared/types/ipc-boundary';
+
+const SESSION_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function activity(
+  partial: Partial<SessionActivity> = {},
+): SessionActivity {
+  return {
+    sessionId: SESSION_ID,
+    cwd: '/project/orchid',
+    state: 'idle',
+    phase: null,
+    detail: null,
+    startedAt: null,
+    updatedAt: 1,
+    completedAt: null,
+    unread: false,
+    backgroundProcessCount: 0,
+    canCancel: false,
+    ...partial,
+  };
+}
+
+const session: SessionSummary = {
+  id: SESSION_ID,
+  name: 'Status synchronization',
+  modelLabel: 'test/model',
+  cwd: '/project/orchid',
+  chainCount: 1,
+  updatedAt: 1,
+};
+
+describe('session activity presentation', () => {
+  it.each([
+    ['working', activity({ state: 'working' }), 'Working', 'status-warning'],
+    ['waiting', activity({ state: 'waiting' }), 'Waiting', 'status-info'],
+    [
+      'needs attention',
+      activity({ state: 'needs_attention' }),
+      'Needs attention',
+      'status-error',
+    ],
+    [
+      'completed unread',
+      activity({ state: 'idle', unread: true }),
+      'Completed · unread',
+      'status-success',
+    ],
+    [
+      'background process',
+      activity({ state: 'idle', backgroundProcessCount: 2 }),
+      'Idle · 2 processes',
+      'status-neutral',
+    ],
+    ['idle', activity(), 'Idle', 'status-neutral'],
+  ])('derives one canonical %s label and tone', (_name, input, label, statusClass) => {
+    expect(sessionActivityPresentation(input)).toMatchObject({
+      label,
+      statusClass,
+    });
+  });
+
+  it('uses the highest-priority visible activity for a collapsed summary', () => {
+    expect(sessionActivitySummaryPresentation([
+      activity({ state: 'waiting' }),
+      activity({ state: 'needs_attention', sessionId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb' }),
+      activity({ unread: true, sessionId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' }),
+    ])).toMatchObject({
+      label: '3 sessions with activity',
+      statusClass: 'status-error',
+    });
+  });
+
+  it('renders completed unread consistently in tabs, Activity, and session rows', () => {
+    const completed = activity({ unread: true });
+    const tabHtml = renderToStaticMarkup(createElement(SessionTabBar, {
+      openSessionIds: [SESSION_ID],
+      focusedSessionId: null,
+      sessions: [session],
+      activities: [completed],
+      showDraft: false,
+      draftLabel: 'New chat',
+      draftProjectName: null,
+      onSelect: () => {},
+      onSelectDraft: () => {},
+      onClose: () => {},
+      onCloseDraft: () => {},
+    }));
+    const activityHtml = renderToStaticMarkup(createElement(SessionActivitySection, {
+      activities: [completed],
+      sessions: [session],
+      onSelect: () => {},
+      onStop: () => {},
+    }));
+    const sidebarHtml = renderToStaticMarkup(createElement(LeftSidebar, {
+      isCollapsed: false,
+      onToggle: () => {},
+      sessionListState: { status: 'ready', sessions: [session] },
+      activeSessionId: null,
+      onSessionSelect: () => {},
+      onSessionCreate: () => {},
+      onSessionDelete: () => {},
+      onRefreshSessions: () => {},
+      onOpenSettings: () => {},
+      activities: [completed],
+    }));
+
+    expect(tabHtml).toContain('status-success');
+    expect(activityHtml).toContain('status-success');
+    expect(activityHtml).toContain('Completed · unread');
+    expect(sidebarHtml.match(/status-success/g)).toHaveLength(2);
+  });
+});
+
+describe('session activity reconciliation', () => {
+  it('keeps a terminal tombstone so an older working snapshot cannot return', () => {
+    let current = mergeSessionActivity(new Map(), activity({
+      state: 'working',
+      updatedAt: 100,
+    }));
+    current = mergeSessionActivity(current, activity({
+      state: 'idle',
+      updatedAt: 200,
+    }));
+    current = mergeSessionActivity(current, activity({
+      state: 'working',
+      updatedAt: 100,
+    }));
+
+    expect(orderedSessionActivities(current)).toEqual([]);
+  });
+
+  it('prunes snapshot omissions that were unchanged while refresh was in flight', () => {
+    const current = mergeSessionActivity(new Map(), activity({
+      state: 'working',
+      updatedAt: 100,
+    }));
+    const baseline = captureSessionActivityBaseline(current);
+    const reconciled = reconcileSessionActivitySnapshot(current, [], baseline);
+
+    expect(orderedSessionActivities(reconciled)).toEqual([]);
+    expect(orderedSessionActivities(mergeSessionActivity(
+      reconciled,
+      activity({ state: 'working', updatedAt: 100 }),
+    ))).toEqual([]);
+  });
+
+  it('preserves a newer broadcast when an older snapshot omits the session', () => {
+    const initial = mergeSessionActivity(new Map(), activity({
+      state: 'working',
+      updatedAt: 100,
+    }));
+    const baseline = captureSessionActivityBaseline(initial);
+    const withNewerBroadcast = mergeSessionActivity(initial, activity({
+      state: 'waiting',
+      updatedAt: 200,
+    }));
+    const reconciled = reconcileSessionActivitySnapshot(
+      withNewerBroadcast,
+      [],
+      baseline,
+    );
+
+    expect(orderedSessionActivities(reconciled)).toEqual([
+      expect.objectContaining({ state: 'waiting', updatedAt: 200 }),
+    ]);
+  });
+});

--- a/electron/tests/unit/session-activity.test.ts
+++ b/electron/tests/unit/session-activity.test.ts
@@ -76,4 +76,21 @@ describe('SessionActivityStore', () => {
     expect(store.get('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')?.unread).toBe(false);
     expect(store.get('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')?.unread).toBe(true);
   });
+
+  it('assigns strictly increasing timestamps to same-millisecond updates', () => {
+    const store = new SessionActivityStore();
+    const first = store.update(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      { state: 'working' },
+      100,
+    );
+    const second = store.update(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      { state: 'waiting' },
+      100,
+    );
+
+    expect(first.updatedAt).toBe(100);
+    expect(second.updatedAt).toBe(101);
+  });
 });


### PR DESCRIPTION
Centralize user-facing activity status presentation across tabs, the Activity panel, and session lists. Preserve ordered terminal tombstones and monotonic timestamps so delayed snapshots cannot restore stale working states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of session activity across tabs, refreshes, and activity views.
  * Standardized activity statuses, labels, colors, and visibility across the sidebar, session tabs, and activity panel.
  * Prevented stale updates from restoring completed or removed activity.
  * Preserved the correct ordering of rapid activity updates.
  * Added clearer aggregate activity indicators and status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->