### PR TITLE
fix(composer): allow slash commands while streaming

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - RAG onnxruntime may not be being shipped correctly
 - Subagent finished results should only send the last message, not full subagent history, the task is already defined on the dynamic context so I think it isnt necessary to resend
 - Interface may prevent some changes while streaming (Such as model and reasoning level) but the command pallete still allows to execute
-- Cannot execute commands while streaming (Only queue messages is possible)
 
 ## Agent quality
 

--- a/electron/src/renderer/components/InputArea.tsx
+++ b/electron/src/renderer/components/InputArea.tsx
@@ -144,7 +144,6 @@ export const InputArea = memo(function InputArea({
   /** Slash mode: input starts with `/` (single line) or a sub-picker is open. */
   const isSlashMode =
     Boolean(commandContext) &&
-    !isStreaming &&
     (subPicker !== null || (input.startsWith('/') && !input.includes('\n')));
 
   const availableModels = commandContext?.getAvailableModels() ?? [];
@@ -719,7 +718,7 @@ export const InputArea = memo(function InputArea({
             onKeyDown={handleKeyDown}
             placeholder={
               isStreaming
-                ? 'Type to queue a message… (Esc to interrupt)'
+                ? 'Type to queue a message or run /command… (Esc to interrupt)'
                 : interruptState === 'confirmAgent'
                   ? 'Streaming… (Esc or ■ to interrupt)'
                   : interruptState === 'confirmSubagents'
@@ -743,7 +742,7 @@ export const InputArea = memo(function InputArea({
 
           <div className="orchid-composer-controls">
             <span
-              key={showCancel ? 'cancel' : isStreaming && hasInput ? 'queue' : showMenu ? 'command' : 'send'}
+              key={showCancel ? 'cancel' : showMenu ? 'command' : isStreaming && hasInput ? 'queue' : 'send'}
               className="orchid-composer-action-swap"
             >
             {showCancel ? (
@@ -756,7 +755,7 @@ export const InputArea = memo(function InputArea({
                 onClick={() => void onCancel()}
                 iconSize={14}
               />
-            ) : isStreaming && hasInput ? (
+            ) : isStreaming && hasInput && !showMenu ? (
               <IconButton
                 label="Queue message"
                 icon="list"

--- a/electron/tests/unit/composer-send-lock.test.ts
+++ b/electron/tests/unit/composer-send-lock.test.ts
@@ -47,8 +47,8 @@ describe('evaluateComposerSend (lock + gates)', () => {
     expect(evaluateComposerSend({ ...ready, isStreaming: true }).action).toBe('queue');
   });
 
-  it('ignores slash commands during streaming (not queueable)', () => {
-    expect(evaluateComposerSend({ ...ready, isStreaming: true, trimmed: '/help' }).action).toBe(
+  it('keeps unknown slash input out of the queue fallback during streaming', () => {
+    expect(evaluateComposerSend({ ...ready, isStreaming: true, trimmed: '/unknown' }).action).toBe(
       'ignore',
     );
   });

--- a/electron/tests/unit/input-area-slash-command.test.tsx
+++ b/electron/tests/unit/input-area-slash-command.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InputArea } from '../../src/renderer/components/InputArea';
+import type { CommandContext } from '../../src/shared/types/ipc-boundary';
+
+function createCommandContext(
+  overrides: Partial<CommandContext> = {},
+): CommandContext {
+  return {
+    onCreateSession: vi.fn(async () => {}),
+    onLoadSession: vi.fn(async () => {}),
+    onDeleteSession: vi.fn(async () => {}),
+    onRenameSession: vi.fn(async () => {}),
+    getActiveSessionId: vi.fn(() => null),
+    getActiveSessionName: vi.fn(() => null),
+    onSetTheme: vi.fn(async () => {}),
+    onSetPersonality: vi.fn(async () => {}),
+    onSetModel: vi.fn(async () => {}),
+    getAvailableModels: vi.fn(() => []),
+    getCurrentModel: vi.fn(() => ''),
+    onOpenSettings: vi.fn(),
+    onPickProjectDir: vi.fn(async () => {}),
+    onIndexRAG: vi.fn(async () => {}),
+    onIndexAST: vi.fn(async () => {}),
+    onClearRAG: vi.fn(async () => {}),
+    onNotify: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('InputArea slash commands', () => {
+  it('runs a slash command instead of queueing it while streaming', async () => {
+    const onOpenSettings = vi.fn();
+    const onQueue = vi.fn();
+    const onSend = vi.fn(async () => {});
+
+    render(
+      <InputArea
+        sessionId={null}
+        status="streaming"
+        model=""
+        onSend={onSend}
+        onCancel={vi.fn(async () => {})}
+        onQueue={onQueue}
+        commandContext={createCommandContext({ onOpenSettings })}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '/settings' },
+    });
+
+    expect(screen.getByRole('listbox', { name: 'Commands' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Run command' }));
+
+    await waitFor(() => expect(onOpenSettings).toHaveBeenCalledOnce());
+    expect(onQueue).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Run supported slash commands immediately from the streaming composer while preserving the queue for plain messages and rejecting unknown slash input.