### PR TITLE
Feat/agents md context handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,11 @@ src/
 │   │       ├── agent-machine.ts      # Core agent loop (idle→streaming→toolExec→idle)
 │   │       ├── events.ts             # Agent machine event types
 │   │       └── interrupt-machine.ts  # Two-phase Esc cancellation
+│   ├── agents-md/           # AGENTS.md discovery, injection, and write enforcement
+│   │   ├── resolver.ts      # Governing-chain resolver (walk up to workspace root)
+│   │   ├── config.ts        # Defaults + alias normalization
+│   │   ├── inject.ts        # Read-path injection builder
+│   │   └── enforce.ts       # Write-path enforcement evaluator
 │   ├── llm/                 # LLM integration
 │   │   ├── orchestrator.ts  # streamChat() — async generator yielding StreamEvents
 │   │   ├── system-prompt.ts # buildSystemPrompt() — dynamic context injection
@@ -116,11 +121,13 @@ src/
 │   │   ├── manager.ts       # SessionManager — CRUD, auto-naming
 │   │   ├── storage.ts       # JSON file storage in ~/.orchid/sessions/
 │   │   ├── activity.ts      # Session activity tracking
+│   │   ├── agents-md-context.ts # Per-session AGENTS.md context tracker (in-memory)
 │   │   └── working-set.ts   # Session working-set tracking
 │   ├── project/             # Workspace binding (session cwd / sticky default)
 │   │   ├── path.ts          # inspect/canonicalize absolute project directories
 │   │   ├── workspace.ts     # draft cwd, sticky default_project_dir, resolveWorkspace*
 │   │   ├── runtime.ts       # ProjectRuntime — config + agents/skills/personalities overlays
+│   │   ├── agents-md.ts     # Root AGENTS.md injection + subagent root seeding
 │   │   └── personality.ts   # project personality helpers
 │   ├── mcp/                 # Model Context Protocol client
 │   │   ├── index.ts         # MCPManager export
@@ -293,6 +300,14 @@ idle → [USER_INPUT] → streaming → [TOOL_CALL] → toolExecuting → [TOOL_
 - **`ToolExecutionContext`**: frozen `{ cwd, sessionId? }` captured at turn start; every tool handler receives it (never re-reads live session/process.cwd mid-turn)
 - **`tool:execute` IPC**: allowlisted read-only tools only; args validated via `toolRegistry.validate` before the handler
 
+### AGENTS.md Context Handling
+Instruction files (`AGENTS.md` and the configured `agents_md.filenames` aliases) are discovered and surfaced automatically — the agent never loads them manually.
+- **Discovery** (`agents-md/resolver.ts`): for any touched path, walk up from its directory to the workspace root, taking the first matching alias per directory. Symlinks that escape the workspace are ignored and filenames match case-insensitively. The workspace-root file is the `root` tier; the rest are `nested`.
+- **Root injection** (`project/agents-md.ts`, wired in `ipc/chat.ts` and `agents/subagent-runner.ts`): the root file is appended once to the static system instructions (after personality) and seeded into the per-session tracker, so it is never re-injected. Subagents get the root the same way.
+- **Read-path injection** (`agents-md/inject.ts`, in `llm/tool-dispatch.ts`): single-path read tools (`read`, `read_directory`, `get_file_skeleton`, `get_function`, `find_symbol_references`) append the byte-capped content of every not-yet-seen governing file to their result as an `<agents_md>` block, then mark it seen. `grep`/`glob`/`rag_search` fan-out is deliberately skipped.
+- **Write-path enforcement** (`agents-md/enforce.ts`, in `llm/tool-dispatch.ts`): the five file mutators (`edit`, `write`, `apply_patch`, `rename_symbol`, `replace_symbol`) are gated by `agents_md.enforce_on_write` — `block` denies the mutation until the governing files are read, `warn` appends a warning, `inject` appends the content and marks it seen, `off` disables. `apply_patch` reports every unseen file at once; editing an instruction file is exempt and refreshes its tracker entry.
+- **Tracker** (`session/agents-md-context.ts`): an ephemeral, in-memory, per-session set of seen canonical paths, keyed by `sessionId::agentScope` so each subagent starts fresh (root only) rather than inheriting the parent's seen-set. With no session there is no injection/enforcement and never a block; the renderer `tool:execute` path opts out via `agentsMdDisabled`.
+
 ### Workspace / Session Cwd
 - Each `Session` has `cwd: string | null` (absolute project dir; null = unbound / legacy)
 - Resolution order: draft cwd → active `session.cwd` → sticky `default_project_dir` → unbound
@@ -353,6 +368,13 @@ Defined in `src/main/config/schema.ts` — single source of truth:
 | `rag.embedding_threads` | 2 | ONNX embedding worker threads (1–64) |
 | `rag.embedding_batch_size` | 16 | ONNX embedding batch size (1–256) |
 | `rag.embedding_api_model` | `null` | Optional API embedder, bound to chat connection/model |
+| `agents_md.enabled` | `true` | Master switch for AGENTS.md discovery, injection, and write enforcement |
+| `agents_md.filenames` | `AGENTS.md, CLAUDE.md` | Ordered instruction-file aliases; first present per directory wins |
+| `agents_md.max_file_bytes` | 32768 | Byte cap for injected instruction-file content (head + read pointer) |
+| `agents_md.max_chain_depth` | 8 | Max directories walked upward when resolving the governing chain |
+| `agents_md.enforce_on_write` | `warn` | Mutation policy for unseen governing files: `block` \| `inject` \| `warn` \| `off` |
+| `agents_md.inject_on_read` | `true` | Inject unseen governing files into single-path read-tool results |
+| `agents_md.include_local` | `false` | Also consider `AGENTS.local.md` (appended as the lowest-precedence alias) |
 | `ast_max_file_size` | 1MB | Max file for AST indexing |
 | `mcp_startup_timeout` | 60s | MCP server startup timeout |
 | `mcp_per_server_timeout` | 10s | Per-MCP-server timeout |
@@ -463,6 +485,7 @@ Motion is a shared interaction contract, not local decoration. Use it to explain
 | Add IPC channel | `src/shared/types/ipc.ts` (channels + types), `src/main/ipc/<module>.ts`, `src/preload/index.ts` |
 | Modify chat flow | `src/main/ipc/chat.ts`, `src/main/agents/xstate/agent-machine.ts`, `src/renderer/hooks/useChat.ts` |
 | Change config | `src/main/config/schema.ts`, `src/main/config/loader.ts`, `src/shared/types/ipc-boundary.ts` |
+| AGENTS.md context handling | `src/main/agents-md/` (resolver/inject/enforce/config), `src/main/session/agents-md-context.ts`, `src/main/project/agents-md.ts` |
 | Workspace / session cwd | `src/main/project/*`, `src/main/ipc/session.ts`, `src/shared/types/session.ts` |
 | Add React component | `src/renderer/components/`, import in parent |
 | Modify themes | `src/renderer/themes/`, CSS files + `index.ts` |

--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,9 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 ## Bugs
 
 - RAG onnxruntime may not be being shipped correctly
-- Subagent finished results should only send the last message, not full subagent history, the task is already defined on the dynamic context so I think it isnt necessary to resend
 - Interface may prevent some changes while streaming (Such as model and reasoning level) but the command pallete still allows to execute
+- Interrupted subagents are being marked as complete - possibly after starting a new chain it is not preserved? - but only on some places (subagent view is correct, main agent context and main chat/session UI appears to not be)
+- Failed command (red) widgets title have blue left border when expanded and waiting (yellow) have blue left border
 
 ## Agent quality
 
@@ -55,14 +56,13 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - Concurrency control for file locking
 - LSP integration
 - SSH / remote connection support
-- `AGENTS.md` handling
-  - Also an `/init` command for it
-  - When the `read` tool opens a file, rules from `AGENTS.md` in that directory (and ancestors) should be applied
 - Session compaction / compression (summarize or drop older turns so long sessions stay within context limits)
 - Analytics dashboard
 - Allow to update the status of multiple tasks in one tool call
   - Also creating in one tool call
 - Investigate if its better to not create new chains with the queued messages
+- Chain snapshoting
+- Better retry / frozen agent handling / long ttft
 
 ## Native semantic code graph / AST tool improvements
 
@@ -167,11 +167,6 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - A tool to view what the agent is currently doing / working
   - May be summarized?
   - Maybe only its TODOs are enough?
-
-## Needs improvement
-
-- Fuzzy matching in the `edit` tool
-  - e.g. OpenCode has multiple fuzzy-match strategies
 
 ## Configuration UI
 

--- a/docs/plans/2026-07-26-001-feat-agents-md-context-handling-plan.md
+++ b/docs/plans/2026-07-26-001-feat-agents-md-context-handling-plan.md
@@ -1,0 +1,313 @@
+---
+title: "feat: Add AGENTS.md context discovery, injection, and write enforcement"
+type: feat
+date: 2026-07-26
+---
+
+# feat: Add AGENTS.md context discovery, injection, and write enforcement
+
+## Summary
+
+Add first-class AGENTS.md handling: discover instruction files scattered through the workspace, inject the root file once into the static system instructions, inject nested files into read-tool results as the agent enters each directory, track which files are in context per session, and gate the five file-mutating tools on whether the governing AGENTS.md has been seen.
+
+---
+
+## Problem Frame
+
+Orchid has no runtime AGENTS.md handling today. The string `AGENTS.md` appears only as prose guidance inside default skill and agent markdown, telling the agent to "read AGENTS.md" — nothing loads it. Static instructions are assembled in `electron/src/main/ipc/chat.ts` as `appendProjectPersonality(agent.system_prompt, runtime)` (`electron/src/main/project/personality.ts`), and per-turn dynamic context is built in `electron/src/main/llm/build-prompt-context.ts`. Localized, directory-scoped instructions therefore never reach the model unless the agent happens to `read` them, and a mutation can land in a subtree whose conventions the agent never saw.
+
+This plan adds a read path (discovery + injection) and a write path (enforcement) sharing one primitive — a resolver that maps a target path to the chain of AGENTS.md files governing it — and ships both in one delivery.
+
+---
+
+## Requirements
+
+**Discovery and injection**
+
+- R1. The root instruction file (and any configured alias present at the workspace root) is injected once into the static system instructions, alongside personality.
+- R2. Nested instruction files are discovered by walking up from a touched path to the workspace root, collecting configured filenames per directory.
+- R3. Read-path tools inject each newly discovered governing file into their result projection, deduped against the session tracker.
+- R4. The root file is never re-injected by the nested mechanism.
+- R5. Injection is capped by byte size; an over-cap file injects a head plus a `read` pointer instead of full content.
+
+**Write enforcement**
+
+- R6. The five file mutators — `edit`, `write`, `apply_patch`, `rename_symbol`, `replace_symbol` — are subject to enforcement.
+- R7. When a mutation targets a file whose governing AGENTS.md is not in context, the configured policy applies; the default is `warn`.
+- R8. `apply_patch` enforcement evaluates every file in the patch and reports all missing governing files in a single result.
+- R9. Enforcement never applies to files outside the workspace, to `execute_command`, to MCP tools, or to non-file mutators.
+- R10. Editing an instruction file itself is exempt from the "must be in context" check but refreshes that tracker entry.
+
+**Configuration**
+
+- R11. The feature exposes: `enabled`, ordered `filenames` (aliases), `max_file_bytes`, `max_chain_depth`, `enforce_on_write` policy, `inject_on_read`, and `include_local`.
+- R12. These settings merge through the existing defaults → home → project → env chain like all other config.
+
+**State and scoping**
+
+- R13. The context tracker is per-session and is seeded with the root file at session start.
+- R14. Tracker identity is the canonical, symlink-resolved path so relative and symlinked variants dedupe to one entry.
+- R15. Subagents start fresh with only the root file seeded; they do not inherit the parent tracker.
+- R16. A tracker entry whose file changed on disk is detected by mtime/hash and re-injected on next encounter.
+- R17. With no session available (direct `tool:execute` IPC), enforcement degrades to non-blocking and never hard-blocks.
+
+---
+
+## Key Technical Decisions
+
+- **Reuse the permission resolver's path extraction:** `extractPathsFromArgs` and `resolveToolScope` in `electron/src/main/permissions/resolver.ts` already resolve tool paths and parse `apply_patch`'s multi-file and `Move to` destinations. The enforcement path reuses this rather than introducing a second walker, so `apply_patch` fan-out (R8) is solved for free.
+- **Inject through the result-projection seam, not the system prompt:** nested files are appended to the originating tool's agent projection using the same XML-append pattern as `appendXmlRetrieval` in `electron/src/main/tools/tool-dispatch.ts`. This keeps injection scoped to the tool that earned it, dedupes via the tracker, and avoids re-emitting content into the system prompt every turn.
+- **Tracker is a per-session store on `SessionManager`:** modeled on `getTodoStore` / `getActiveTodoStore` in `electron/src/main/session/manager.ts`. It survives the multi-step tool loop and subsequent turns, and is seeded with the root file so the root is never re-injected (R4, R13).
+- **Enforcement hooks the dispatcher after permission resolution, before the handler:** one code path in `executeToolCall` covers all five mutators and mirrors the fail-closed posture of `checkPermission` in `electron/src/main/permissions/gate.ts` (KTD posture; default policy is still non-blocking per R7).
+- **Root vs nested distinguished by canonical-path identity:** the root file's canonical path is seeded permanently; the upward walk stops at the workspace root and flags the root-level file as root tier so callers skip emission (R4).
+- **Aliases are an ordered configurable filename list:** first match per directory wins; the chain still walks up across directories. Resolution stays inside the workspace and never follows symlinks that escape it, reusing `isPathContainedIn` from the resolver (R11, R9).
+- **Default enforcement policy is `warn`:** proceed and append a warning naming the unseen files; `block`, `inject`, and `off` are configurable per project (R7).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  subgraph ReadPath[Read path]
+    RT[read / read_directory / get_file_skeleton / get_function] --> RES[governingAgentsMd resolver]
+    RES --> TRK{In session tracker?}
+    TRK -- no, not root --> INJ[Append to tool result projection]
+    INJ --> ADD[Add canonical path + mtime to tracker]
+    TRK -- yes, or root --> SKIP[Skip emission]
+  end
+
+  subgraph WritePath[Write path]
+    MUT[edit / write / apply_patch / rename_symbol / replace_symbol] --> EXT[extractPathsFromArgs]
+    EXT --> GOV[Resolve governing chain per target]
+    GOV --> MISS{Any governing file not in tracker?}
+    MISS -- no --> RUN[Run handler]
+    MISS -- yes --> POL{enforce_on_write}
+    POL -- warn --> RUNW[Run handler + append warning]
+    POL -- block --> DENY[Terminal error naming missing files]
+    POL -- inject --> AUTOREAD[Read missing files, add to tracker] --> RUN
+    POL -- off --> RUN
+  end
+
+  SEED[Session start: seed root canonical path] --> TRK
+  SEED --> MISS
+```
+
+The resolver is the shared primitive: `governingAgentsMd(targetPath, cwd, config)` returns an ordered list from the workspace root down to the target's directory, each entry tagged root-tier or nested-tier with its canonical path and mtime.
+
+---
+
+## Scope Boundaries
+
+**In scope**
+
+- Resolver, config fields, session tracker, root injection, read-path injection, write-path enforcement, subagent fresh-start, no-session degradation.
+
+**Out of scope**
+
+- `execute_command` governance — statically ungovernable; already covered by command detection in the permission gate.
+- MCP tool enforcement — opaque arguments, no reliable path extraction.
+- Non-file mutators (`todo/*`, `rag/index`, `ast/index-tool`) — not file-content edits.
+- `grep` / `glob` / `rag_search` injection — these return path sets across many trees; treated as soft discovery only (record nothing, inject nothing) to avoid noise. See Open Questions.
+- Renderer/UI surfacing of which AGENTS.md files are in context.
+- `@path` include resolution inside instruction files (shim support) — deferred.
+
+---
+
+## Implementation Units
+
+### U1. Resolver and config schema
+
+- **Goal:** A pure, testable primitive that maps a target path to its governing instruction-file chain, plus the config fields that drive it.
+- **Requirements:** R2, R5, R11, R12, R14
+- **Dependencies:** none
+- **Files:**
+  - Create `electron/src/main/agents-md/resolver.ts`
+  - Modify `electron/src/main/config/schema.ts` (new `agents_md` block)
+  - Test `electron/tests/unit/agents-md-resolver.test.ts`
+- **Approach:** Walk up from the target's directory to `cwd`, collecting the first configured filename present per directory (ordered alias list). Canonicalize each hit with `fs.realpathSync.native`. Stop at `cwd`; tag the `cwd`-level file root-tier. Cap the walk at `max_chain_depth`. Reject any candidate that escapes `cwd` via symlink using `isPathContainedIn` (import from the resolver). Read content lazily with a `max_file_bytes` cap producing a head-plus-pointer payload.
+- **Patterns to follow:** `resolveToolScope` / `canonicalizeEffectivePath` in `electron/src/main/permissions/resolver.ts`; config block shape in `electron/src/main/config/schema.ts`.
+- **Test scenarios:**
+  - Single root file resolves as root-tier.
+  - Nested chain returns root-to-leaf order.
+  - Alias precedence: first configured filename wins per directory.
+  - Symlinked file escaping `cwd` is excluded.
+  - Walk stops at `max_chain_depth`.
+  - Over-cap file yields head-plus-pointer, not full content.
+  - Case-insensitive filename match on disk preserves the on-disk name.
+  - Config defaults merge and a project `.orchid.json` override wins.
+- **Verification:** Resolver returns correct chains across nested, aliased, and symlinked fixtures; config parses and rejects unknown keys under the strict schema.
+
+### U2. Per-session context tracker
+
+- **Goal:** A session-scoped store recording which instruction files are in context, seeded with the root file and aware of staleness.
+- **Requirements:** R4, R13, R14, R16
+- **Dependencies:** U1
+- **Files:**
+  - Create `electron/src/main/session/agents-md-context.ts`
+  - Modify `electron/src/main/session/manager.ts` (`getAgentsMdContextStore`, mirroring `getTodoStore`)
+  - Test `electron/tests/unit/agents-md-context.test.ts`
+- **Approach:** Store entries keyed by canonical path with mtime/hash and a root-tier flag. Seed the root file's canonical path on store creation. `markSeen`, `isInContext`, and `isStale(entry)` (compare stored mtime/hash to disk). Provide an empty-store fallback for the no-session case, mirroring `_emptyTodoStore`.
+- **Patterns to follow:** `TodoStore` wiring and `_emptyTodoStore` fallback in `electron/src/main/session/manager.ts`; `WorkingSetStore` in `electron/src/main/session/working-set.ts`.
+- **Test scenarios:**
+  - Root file is in context immediately after seeding.
+  - `markSeen` then `isInContext` returns true for the same canonical path.
+  - Relative and symlinked variants of one file collapse to one entry.
+  - `isStale` flips true after the file's mtime changes on disk.
+  - Empty-store fallback never throws and reports nothing in context.
+- **Verification:** Tracker dedupes by canonical path, survives across calls within a session, and detects on-disk changes.
+
+### U3. Root injection into static instructions
+
+- **Goal:** The root instruction file is appended once to the static system instructions.
+- **Requirements:** R1, R4
+- **Dependencies:** U1
+- **Files:**
+  - Create `electron/src/main/project/agents-md.ts` (`appendRootAgentsMd`)
+  - Modify `electron/src/main/ipc/chat.ts` (compose after `appendProjectPersonality`)
+  - Test `electron/tests/unit/agents-md-root-injection.test.ts`
+- **Approach:** A sibling to `appendProjectPersonality`: read the root file via the resolver (root-tier only), append under a clear heading, no-op when disabled or absent. Compose at the same site where personality is appended so ordering is deterministic.
+- **Patterns to follow:** `appendProjectPersonality` in `electron/src/main/project/personality.ts`.
+- **Test scenarios:**
+  - Root content appended once when present and enabled.
+  - No-op when `enabled` is false or no root file exists.
+  - Alias at root is used when the primary filename is absent.
+  - Over-cap root file injects head-plus-pointer.
+- **Verification:** The assembled base system prompt contains the root file exactly once.
+
+### U4. Read-path injection
+
+- **Goal:** Read-path tools surface newly discovered governing files in their result projection.
+- **Requirements:** R3, R4, R5, R16
+- **Dependencies:** U1, U2
+- **Files:**
+  - Modify `electron/src/main/tools/types.ts` (thread tracker handle onto `ToolExecutionContext`)
+  - Modify `electron/src/main/tools/tool-dispatch.ts` (post-projection append for read tools)
+  - Modify `electron/src/main/ipc/chat.ts` (provide the tracker when building context)
+  - Test `electron/tests/unit/agents-md-injection.test.ts`
+- **Approach:** After a read-path tool's agent projection is produced, resolve the governing chain for the tool's target path; for each nested-tier file not in the tracker (or stale), append an `<agents_md path=... scope="new">` block using the `appendXmlRetrieval` pattern and mark it seen. Skip root-tier files entirely. Only the explicit-path read tools participate (`read`, `read_directory`, `get_file_skeleton`, `get_function`).
+- **Patterns to follow:** `appendXmlRetrieval` and the projection/offload flow in `electron/src/main/tools/tool-dispatch.ts`; `TOOLS_WITHOUT_OUTPUT_OFFLOAD` membership for read tools.
+- **Test scenarios:**
+  - First read under a nested AGENTS.md injects it; second read does not.
+  - Root-tier file is never injected on read.
+  - Stale entry re-injects after on-disk change.
+  - Over-cap file injects head-plus-pointer.
+  - No tracker (no session) degrades gracefully with no injection and no throw.
+- **Verification:** A sequence of reads injects each governing file exactly once and never re-injects the root.
+
+### U5. Write-path enforcement
+
+- **Goal:** The five file mutators are gated on whether the governing AGENTS.md is in context, per the configured policy.
+- **Requirements:** R6, R7, R8, R9, R10
+- **Dependencies:** U1, U2
+- **Files:**
+  - Create `electron/src/main/agents-md/enforce.ts`
+  - Modify `electron/src/main/tools/tool-dispatch.ts` (pre-handler enforcement step in `executeToolCall`)
+  - Test `electron/tests/unit/agents-md-enforcement.test.ts`
+- **Approach:** After permission resolution and before the handler, run enforcement for the five mutators only. Extract target paths via `extractPathsFromArgs`; resolve each target's governing chain; collect governing files not in context (excluding the target itself when it is an instruction file, per R10). Apply policy: `warn` appends a `<warning>` to the result and proceeds; `block` returns a terminal generic error naming all missing files; `inject` reads the missing files, marks them seen, appends them, and proceeds; `off` proceeds silently. Aggregate across all `apply_patch` files before acting.
+- **Patterns to follow:** `checkPermission` fail-closed posture and `genericTerminalExecution` in `electron/src/main/permissions/gate.ts`; `extractPathsFromArgs` in `electron/src/main/permissions/resolver.ts`.
+- **Test scenarios:**
+  - `warn`: edit proceeds and result carries a warning naming the unseen file.
+  - `block`: edit is rejected with a terminal error; handler never runs.
+  - `inject`: missing file is read, added to tracker, appended, and edit proceeds.
+  - `apply_patch` touching two trees reports both missing files in one denial.
+  - Editing an AGENTS.md file itself is allowed and refreshes its entry.
+  - Target outside `cwd` is not enforced.
+  - `off` proceeds with no warning.
+- **Verification:** Each policy behaves as specified and `apply_patch` fan-out reports comprehensively.
+
+### U6. Subagent fresh-start and no-session degradation
+
+- **Goal:** Subagents begin with only the root seeded; direct IPC without a session never hard-blocks.
+- **Requirements:** R15, R17
+- **Dependencies:** U2, U5
+- **Files:**
+  - Modify `electron/src/main/agents/subagent-runner.ts` (seed a fresh tracker per subagent session)
+  - Modify `electron/src/main/tools/tool-dispatch.ts` (no-session path forces non-blocking)
+  - Test `electron/tests/unit/agents-md-subagent.test.ts`
+- **Approach:** When a subagent session is created, seed its tracker with the root file only — do not copy the parent's set. In the dispatcher, when no tracker is resolvable, force the effective policy to non-blocking regardless of config.
+- **Patterns to follow:** subagent session creation and `systemPrompt` assembly in `electron/src/main/agents/subagent-runner.ts`; empty-store fallback in `electron/src/main/session/manager.ts`.
+- **Test scenarios:**
+  - Subagent tracker contains only the root file at start.
+  - Parent having seen a nested file does not mark it seen for the subagent.
+  - No-session enforcement with `block` configured still proceeds (degraded to warn/off).
+- **Verification:** Subagent isolation and no-session safety hold under the configured policies.
+
+### U7. Documentation and skill guidance
+
+- **Goal:** Align docs and default skill prose with the new automatic behavior.
+- **Requirements:** R1, R11
+- **Dependencies:** U3, U4, U5
+- **Files:**
+  - Modify `AGENTS.md`
+  - Modify default skill markdown that currently instructs "read AGENTS.md" (under `electron/src/main/skills/defaults/`)
+- **Approach:** Document the config fields and the inject/enforce behavior; soften skill prose that tells the agent to manually read AGENTS.md now that injection is automatic.
+- **Patterns to follow:** existing config documentation style in `AGENTS.md`.
+- **Test scenarios:** none (documentation).
+- **Verification:** Docs describe the shipped config keys and behavior accurately; no skill instructs redundant manual reads.
+
+---
+
+## System-Wide Impact
+
+- **Hot dispatch path:** U4 and U5 add work to every tool call in `executeToolCall`. The resolver must be cheap and cached; path canonicalization reuses the resolver's existing bounded cache pattern to avoid per-call `realpathSync` on the event loop.
+- **Prompt size:** root injection grows the static prompt by one file; nested injection grows individual tool results. Both are byte-capped (R5) to bound token impact.
+- **Session state:** a new per-session store joins the todo and working-set stores; it is in-memory and needs no schema migration.
+- **Permissions:** enforcement is adjacent to, but distinct from, the permission gate; it does not change approval resolution or risk-class floors.
+
+---
+
+## Risks and Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Per-call resolver cost on the dispatch hot path | Reuse the bounded canonical-path cache pattern from the permission resolver; cache governing-chain lookups per turn |
+| Prompt bloat from large instruction files | `max_file_bytes` cap with head-plus-pointer fallback (R5) |
+| False-positive enforcement stalls agent loops | Default policy is non-blocking `warn` (R7); `block` is opt-in per project |
+| Stale context after on-disk edits | mtime/hash staleness check re-injects on next encounter (R16) |
+| Symlink escape leaking or governing out-of-workspace files | Containment check reusing `isPathContainedIn`; walk stops at `cwd` (R9) |
+
+---
+
+## Open Questions
+
+- Should `grep` / `glob` / `rag_search` ever inject when a single directory is implicated, or remain soft-discovery only? Default: soft-discovery only; revisit if agents miss conventions in search-heavy flows.
+- Should `@path` shim includes (e.g. a `CLAUDE.md` containing `@AGENTS.md`) be resolved, and with what cycle depth cap? Deferred; the alias list covers the common case.
+- Is a renderer-side indicator of in-context instruction files worth a follow-up? Out of scope here.
+
+---
+
+## Acceptance Examples
+
+- **Nested injection, then dedupe**
+  - **Given** a session with the root file seeded and `electron/src/main/tools/AGENTS.md` present
+  - **When** the agent reads `electron/src/main/tools/filesystem/edit.ts` then reads it again
+  - **Then** the first result carries the nested AGENTS.md and the second does not (R3, R4).
+
+- **Warn on unseen governance**
+  - **Given** `enforce_on_write` is `warn` and `pkg/api/AGENTS.md` is not in context
+  - **When** the agent edits `pkg/api/client.ts`
+  - **Then** the edit succeeds and the result carries a warning naming `pkg/api/AGENTS.md` (R7).
+
+- **Block aggregates apply_patch**
+  - **Given** `enforce_on_write` is `block` and a patch touches files under two unseen AGENTS.md trees
+  - **When** the agent calls `apply_patch`
+  - **Then** the call is rejected once, naming both unseen files, and nothing is written (R8).
+
+- **Subagent isolation**
+  - **Given** the main agent has seen `pkg/api/AGENTS.md`
+  - **When** it delegates to a subagent that edits `pkg/api/client.ts`
+  - **Then** the subagent's enforcement treats that file as unseen (R15).
+
+---
+
+## Sources and Research
+
+- Static instruction assembly: `electron/src/main/ipc/chat.ts`, `electron/src/main/project/personality.ts`.
+- Per-turn dynamic context: `electron/src/main/llm/build-prompt-context.ts`, `electron/src/main/llm/system-prompt.ts`.
+- Tool execution context and dispatch: `electron/src/main/tools/types.ts`, `electron/src/main/tools/tool-dispatch.ts`.
+- Path extraction and workspace scope: `electron/src/main/permissions/resolver.ts`.
+- Permission gate posture: `electron/src/main/permissions/gate.ts`.
+- Session store patterns: `electron/src/main/session/manager.ts`, `electron/src/main/session/working-set.ts`.
+- Mutating tool definitions: `electron/src/main/tools/filesystem/edit.ts`, `write.ts`, `apply-patch.ts`; `electron/src/main/tools/ast/rename-symbol.ts`, `replace-symbol.ts`.
+- Config schema and merge: `electron/src/main/config/schema.ts`.

--- a/electron/src/main/agents-md/config.ts
+++ b/electron/src/main/agents-md/config.ts
@@ -1,0 +1,46 @@
+/**
+ * AGENTS.md config defaults and normalization helpers.
+ *
+ * The defaults mirror the `agents_md` block in the config schema; the resolver
+ * derives its effective filename alias list from these settings.
+ */
+import type { AgentsMdConfig } from '../config/schema';
+
+/** Lowest-precedence alias appended when `include_local` is enabled. */
+export const AGENTS_LOCAL_FILENAME = 'AGENTS.local.md';
+
+/** Default `agents_md` settings — must match `agentsMdConfigSchema`. */
+export const AGENTS_MD_DEFAULTS: AgentsMdConfig = {
+  enabled: true,
+  filenames: ['AGENTS.md', 'CLAUDE.md'],
+  max_file_bytes: 32768,
+  max_chain_depth: 8,
+  enforce_on_write: 'warn',
+  inject_on_read: true,
+  include_local: false,
+};
+
+/**
+ * Ordered instruction-file alias list for discovery: the configured
+ * `filenames`, with `AGENTS.local.md` appended when `include_local` is true.
+ * Entries are trimmed, empties dropped, and de-duplicated case-insensitively
+ * while preserving first-seen order.
+ */
+export function effectiveAgentsMdFilenames(config: {
+  agents_md: AgentsMdConfig;
+}): string[] {
+  const { filenames, include_local } = config.agents_md;
+  const source = include_local ? [...filenames, AGENTS_LOCAL_FILENAME] : [...filenames];
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of source) {
+    const name = raw.trim();
+    if (name === '') continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(name);
+  }
+  return result;
+}

--- a/electron/src/main/agents-md/enforce.ts
+++ b/electron/src/main/agents-md/enforce.ts
@@ -1,0 +1,149 @@
+/**
+ * Write-path AGENTS.md enforcement (U5).
+ *
+ * The five file mutators are gated on whether the governing instruction files
+ * are already in the session context. Given a tool call, resolve every target
+ * path's governing chain (R2), aggregate them across all of an `apply_patch`'s
+ * files (R8), drop targets outside the workspace (R9), and exempt any target
+ * that is itself an instruction file (R10) — recording those separately so the
+ * dispatcher can refresh their tracker entries after the mutation lands. The
+ * result carries the configured policy plus the unseen set the dispatcher acts
+ * on: `block` short-circuits before the handler; `warn`/`inject` augment the
+ * result afterwards. Pure-ish and testable: it reads metadata and computes sets
+ * but never mutates the tracker — the dispatcher marks entries seen.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AgentsMdEnforcePolicy, Config } from '../config/schema';
+import { extractPathsFromArgs } from '../permissions/resolver';
+import type { AgentsMdContextStore } from '../session/agents-md-context';
+import { escapeXmlText } from '../tools/result';
+import { resolveToolPath } from '../tools/types';
+import { effectiveAgentsMdFilenames } from './config';
+import { renderAgentsMdBlock } from './inject';
+import { resolveAgentsMdChain, type AgentsMdEntry } from './resolver';
+
+/**
+ * The five file mutators subject to write enforcement (R6). `execute_command`,
+ * MCP tools, and non-file mutators (todo/rag/ast indexers) are deliberately
+ * excluded — they are statically ungovernable or not file-content edits (R9).
+ */
+const ENFORCED_MUTATOR_TOOLS = new Set<string>([
+  'edit',
+  'write',
+  'apply_patch',
+  'rename_symbol',
+  'replace_symbol',
+]);
+
+/** The enforcement verdict for a single mutating tool call. */
+export interface AgentsMdEnforcement {
+  /** The configured policy the dispatcher should apply. */
+  policy: AgentsMdEnforcePolicy;
+  /** Governing files not yet in context (R10-exempt, de-duped, order preserved). */
+  unseen: AgentsMdEntry[];
+  /** Target files that are themselves instruction files (R10 tracker refresh). */
+  editedInstructionFiles: AgentsMdEntry[];
+}
+
+/**
+ * Canonicalize a mutation target for identity comparison against chain entries.
+ * Mirrors the resolver's canonicalization for existing files; returns null when
+ * the target does not exist yet (e.g. a `write` about to create it) — such a
+ * target cannot equal any existing chain entry, so it needs no special handling.
+ */
+function canonicalizeTarget(rawPath: string, cwd: string): string | null {
+  try {
+    return fs.realpathSync.native(resolveToolPath(cwd, rawPath));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Evaluate write enforcement for a mutating tool call, or null when enforcement
+ * does not apply (feature disabled, policy `off`, or a non-mutator tool).
+ *
+ * Aggregates the governing chains of every target path (R8), so an `apply_patch`
+ * touching several trees reports all unseen files at once. Targets outside the
+ * workspace resolve to an empty chain and are never enforced (R9). A target that
+ * is itself an instruction file is excluded from the unseen set and surfaced in
+ * `editedInstructionFiles` instead (R10).
+ */
+export function evaluateAgentsMdEnforcement(
+  toolName: string,
+  args: Record<string, unknown>,
+  cwd: string,
+  config: Config,
+  store: AgentsMdContextStore,
+): AgentsMdEnforcement | null {
+  if (!config.agents_md?.enabled) return null;
+  const policy = config.agents_md.enforce_on_write;
+  if (policy === 'off') return null;
+  if (!ENFORCED_MUTATOR_TOOLS.has(toolName)) return null;
+
+  const rawPaths = extractPathsFromArgs(toolName, args);
+
+  // Canonical paths of targets that are themselves instruction files (R10).
+  const instructionFilenames = new Set(
+    effectiveAgentsMdFilenames(config).map((name) => name.toLowerCase()),
+  );
+  const editedTargetPaths = new Set<string>();
+  for (const rawPath of rawPaths) {
+    if (!instructionFilenames.has(path.basename(rawPath).toLowerCase())) continue;
+    const canonical = canonicalizeTarget(rawPath, cwd);
+    if (canonical !== null) editedTargetPaths.add(canonical);
+  }
+
+  // Aggregate governing chains across all targets, de-duped by canonical path.
+  const governing = new Map<string, AgentsMdEntry>();
+  const edited = new Map<string, AgentsMdEntry>();
+  for (const rawPath of rawPaths) {
+    for (const entry of resolveAgentsMdChain(rawPath, cwd, config)) {
+      if (editedTargetPaths.has(entry.path)) {
+        edited.set(entry.path, entry);
+      } else if (!governing.has(entry.path)) {
+        governing.set(entry.path, entry);
+      }
+    }
+  }
+
+  return {
+    policy,
+    unseen: store.unseen([...governing.values()]),
+    editedInstructionFiles: [...edited.values()],
+  };
+}
+
+/** Plain-text terminal-denial message for a `block` policy (R8: names all). */
+export function buildAgentsMdBlockMessage(unseen: AgentsMdEntry[]): string {
+  const names = unseen.map((entry) => entry.displayPath).join(', ');
+  return (
+    `Write blocked: the files you are modifying are governed by AGENTS.md ` +
+    `instruction file(s) not yet in your context: ${names}. Read the listed ` +
+    `file(s) first, then retry the modification.`
+  );
+}
+
+/** Render the `<agents_md_warning>` block naming unseen governing files. */
+export function buildAgentsMdWarningBlock(unseen: AgentsMdEntry[]): string {
+  const names = unseen.map((entry) => entry.displayPath).join(', ');
+  return (
+    `<agents_md_warning>\n` +
+    `You modified files governed by instruction file(s) not yet in your ` +
+    `context: ${escapeXmlText(names)}. Read them to follow project conventions.\n` +
+    `</agents_md_warning>`
+  );
+}
+
+/**
+ * Render `<agents_md>` blocks for the unseen entries under the byte cap, reusing
+ * the read-path renderer (R5). The caller marks these seen after appending.
+ */
+export function buildAgentsMdInjectBlock(
+  unseen: AgentsMdEntry[],
+  config: Config,
+): string {
+  const maxBytes = config.agents_md.max_file_bytes;
+  return unseen.map((entry) => renderAgentsMdBlock(entry, maxBytes)).join('\n');
+}

--- a/electron/src/main/agents-md/enforce.ts
+++ b/electron/src/main/agents-md/enforce.ts
@@ -21,7 +21,7 @@ import { escapeXmlText } from '../tools/result';
 import { resolveToolPath } from '../tools/types';
 import { effectiveAgentsMdFilenames } from './config';
 import { renderAgentsMdBlock } from './inject';
-import { resolveAgentsMdChain, type AgentsMdEntry } from './resolver';
+import { resolveAgentsMdChain, type AgentsMdEntry, type InstructionHit } from './resolver';
 
 /**
  * The five file mutators subject to write enforcement (R6). `execute_command`,
@@ -112,9 +112,10 @@ export function evaluateAgentsMdEnforcement(
   // and is never enforced by this mechanism (R4).
   const governing = new Map<string, AgentsMdEntry>();
   const edited = new Map<string, AgentsMdEntry>();
+  const dirCache = new Map<string, InstructionHit | null>();
   for (const rawPath of rawPaths) {
     const canonicalTarget = canonicalizeTarget(rawPath, cwd);
-    for (const entry of resolveAgentsMdChain(rawPath, cwd, config)) {
+    for (const entry of resolveAgentsMdChain(rawPath, cwd, config, dirCache)) {
       if (canonicalTarget !== null && entry.path === canonicalTarget) {
         edited.set(entry.path, entry);
       } else if (entry.tier !== 'root' && !governing.has(entry.path)) {

--- a/electron/src/main/agents-md/enforce.ts
+++ b/electron/src/main/agents-md/enforce.ts
@@ -42,8 +42,15 @@ export interface AgentsMdEnforcement {
   policy: AgentsMdEnforcePolicy;
   /** Governing files not yet in context (R10-exempt, de-duped, order preserved). */
   unseen: AgentsMdEntry[];
-  /** Target files that are themselves instruction files (R10 tracker refresh). */
+  /** Target files that are themselves instruction files (R10 exemption set). */
   editedInstructionFiles: AgentsMdEntry[];
+  /**
+   * Raw arg paths that are themselves instruction files (basename matches a
+   * configured alias). Computed from the ARGS, not the disk, so it includes
+   * not-yet-created files. Phase B re-stats each post-write to refresh the
+   * tracker with the fresh mtime/size (R10).
+   */
+  instructionFileTargets: string[];
 }
 
 /**
@@ -84,25 +91,33 @@ export function evaluateAgentsMdEnforcement(
 
   const rawPaths = extractPathsFromArgs(toolName, args);
 
-  // Canonical paths of targets that are themselves instruction files (R10).
+  // Case-insensitive instruction-file basenames for R10 detection.
   const instructionFilenames = new Set(
     effectiveAgentsMdFilenames(config).map((name) => name.toLowerCase()),
   );
-  const editedTargetPaths = new Set<string>();
-  for (const rawPath of rawPaths) {
-    if (!instructionFilenames.has(path.basename(rawPath).toLowerCase())) continue;
-    const canonical = canonicalizeTarget(rawPath, cwd);
-    if (canonical !== null) editedTargetPaths.add(canonical);
-  }
+
+  // Raw arg paths that are themselves instruction files (R10). Computed from the
+  // ARGS (not the disk) so not-yet-created files are included; Phase B re-stats
+  // each post-write to refresh the tracker with the fresh mtime/size.
+  const instructionFileTargets = rawPaths.filter((rawPath) =>
+    instructionFilenames.has(path.basename(rawPath).toLowerCase()),
+  );
 
   // Aggregate governing chains across all targets, de-duped by canonical path.
+  // The R10 exemption is scoped PER TARGET: an entry is exempt (routed to
+  // `edited`) only when it IS the target currently being processed. The same
+  // file governing a co-edited sibling stays in `governing` and is enforced, so
+  // bundling a trivial instruction-file edit cannot suppress enforcement of the
+  // sibling's governing file. The root tier lives in the static system prompt
+  // and is never enforced by this mechanism (R4).
   const governing = new Map<string, AgentsMdEntry>();
   const edited = new Map<string, AgentsMdEntry>();
   for (const rawPath of rawPaths) {
+    const canonicalTarget = canonicalizeTarget(rawPath, cwd);
     for (const entry of resolveAgentsMdChain(rawPath, cwd, config)) {
-      if (editedTargetPaths.has(entry.path)) {
+      if (canonicalTarget !== null && entry.path === canonicalTarget) {
         edited.set(entry.path, entry);
-      } else if (!governing.has(entry.path)) {
+      } else if (entry.tier !== 'root' && !governing.has(entry.path)) {
         governing.set(entry.path, entry);
       }
     }
@@ -112,6 +127,7 @@ export function evaluateAgentsMdEnforcement(
     policy,
     unseen: store.unseen([...governing.values()]),
     editedInstructionFiles: [...edited.values()],
+    instructionFileTargets,
   };
 }
 

--- a/electron/src/main/agents-md/inject.ts
+++ b/electron/src/main/agents-md/inject.ts
@@ -1,0 +1,116 @@
+/**
+ * Read-path AGENTS.md injection builder (U4).
+ *
+ * When a single-path read tool touches a path, resolve the governing
+ * instruction-file chain for that path and render the byte-capped content of
+ * every entry the session has not yet seen (root already seeded → excluded,
+ * R4) as an `<agents_md>` XML block. Pure-ish and testable: it reads file
+ * content and computes the unseen set but never mutates the tracker — the
+ * dispatcher marks entries seen only after the block is appended, so a failed
+ * append cannot poison the session state.
+ */
+import path from 'node:path';
+import type { Config } from '../config/schema';
+import { escapeXmlAttribute, escapeXmlText } from '../tools/result';
+import { resolveToolPath } from '../tools/types';
+import type { AgentsMdContextStore } from '../session/agents-md-context';
+import {
+  readAgentsMdContent,
+  resolveAgentsMdChain,
+  type AgentsMdEntry,
+} from './resolver';
+
+/**
+ * Single-path read tools that trigger injection, keyed by tool name. `grep`,
+ * `glob`, and `rag_search` are deliberately excluded — they fan out across many
+ * trees with no single governing path (soft discovery only). Write/mutation
+ * tools are handled by the enforcement unit, not here.
+ */
+interface InjectableReadTool {
+  /** Argument carrying the touched path. */
+  argKey: string;
+  /**
+   * True when the arg is a directory. The resolver walks up from
+   * `dirname(target)`, so a directory target must be resolved for a synthetic
+   * child or its own instruction file would be missed (see project/agents-md.ts).
+   */
+  isDirectory: boolean;
+}
+
+const AGENTS_MD_INJECTABLE_TOOLS: Record<string, InjectableReadTool> = {
+  read: { argKey: 'file_path', isDirectory: false },
+  get_file_skeleton: { argKey: 'file_path', isDirectory: false },
+  get_function: { argKey: 'file_path', isDirectory: false },
+  find_symbol_references: { argKey: 'file_path', isDirectory: false },
+  read_directory: { argKey: 'directory_path', isDirectory: true },
+};
+
+/** The rendered injection plus the entries the caller should mark seen. */
+export interface AgentsMdInjection {
+  /** The `<agents_md>...</agents_md>` block(s) to insert, nearest-first. */
+  xml: string;
+  /** Entries whose content was rendered (caller marks these seen). */
+  injected: AgentsMdEntry[];
+}
+
+/**
+ * Render one entry as an `<agents_md>` block, reading content under the byte
+ * cap (R5). Over-cap files carry `truncated="true"` plus a short inline note
+ * pointing at `read`. Content and attributes are XML-escaped.
+ */
+function renderAgentsMdBlock(entry: AgentsMdEntry, maxBytes: number): string {
+  const { content, truncated } = readAgentsMdContent(entry, maxBytes);
+  const truncatedAttr = truncated ? ' truncated="true"' : '';
+  const note = truncated
+    ? `\n[truncated to ${maxBytes} bytes — use read with file_path=${escapeXmlText(entry.displayPath)} for the full file]`
+    : '';
+  return (
+    `<agents_md path="${escapeXmlAttribute(entry.displayPath)}" tier="${escapeXmlAttribute(entry.tier)}"${truncatedAttr}>\n` +
+    `${escapeXmlText(content)}${note}\n` +
+    `</agents_md>`
+  );
+}
+
+/**
+ * Build the AGENTS.md injection for a read-tool call, or null when nothing new
+ * should be injected.
+ *
+ * Returns null when the feature or read-injection is disabled, the tool is not
+ * an injectable read tool, the path arg is missing/empty/non-string, or every
+ * governing entry is already in context (the dedupe guarantee). Otherwise
+ * returns the concatenated blocks and the unseen entries that were rendered.
+ * Does not touch the tracker — the caller marks `injected` seen after appending.
+ */
+export function buildAgentsMdInjection(
+  toolName: string,
+  args: Record<string, unknown>,
+  cwd: string,
+  config: Config,
+  store: AgentsMdContextStore,
+): AgentsMdInjection | null {
+  // A missing `agents_md` block (e.g. a partial config) degrades to disabled.
+  if (!config.agents_md?.enabled || !config.agents_md?.inject_on_read) return null;
+
+  const spec = AGENTS_MD_INJECTABLE_TOOLS[toolName];
+  if (spec === undefined) return null;
+
+  const rawPath = args[spec.argKey];
+  if (typeof rawPath !== 'string' || rawPath.trim() === '') return null;
+
+  // Directory targets resolve for a synthetic child so the walk starts at the
+  // directory itself rather than its parent (mirrors project/agents-md.ts).
+  const resolvedPath = resolveToolPath(cwd, rawPath);
+  const resolvedTarget = spec.isDirectory
+    ? path.join(resolvedPath, 'AGENTS.md')
+    : resolvedPath;
+
+  const chain = resolveAgentsMdChain(resolvedTarget, cwd, config);
+  const fresh = store.unseen(chain);
+  if (fresh.length === 0) return null;
+
+  const maxBytes = config.agents_md.max_file_bytes;
+  return {
+    xml: fresh.map((entry) => renderAgentsMdBlock(entry, maxBytes)).join('\n'),
+    injected: fresh,
+  };
+}

--- a/electron/src/main/agents-md/inject.ts
+++ b/electron/src/main/agents-md/inject.ts
@@ -58,7 +58,7 @@ export interface AgentsMdInjection {
  * cap (R5). Over-cap files carry `truncated="true"` plus a short inline note
  * pointing at `read`. Content and attributes are XML-escaped.
  */
-function renderAgentsMdBlock(entry: AgentsMdEntry, maxBytes: number): string {
+export function renderAgentsMdBlock(entry: AgentsMdEntry, maxBytes: number): string {
   const { content, truncated } = readAgentsMdContent(entry, maxBytes);
   const truncatedAttr = truncated ? ' truncated="true"' : '';
   const note = truncated

--- a/electron/src/main/agents-md/inject.ts
+++ b/electron/src/main/agents-md/inject.ts
@@ -105,7 +105,10 @@ export function buildAgentsMdInjection(
     : resolvedPath;
 
   const chain = resolveAgentsMdChain(resolvedTarget, cwd, config);
-  const fresh = store.unseen(chain);
+  // The root tier lives in the static system prompt and is never re-injected by
+  // the nested mechanism (R4), even if it changes on disk mid-turn; only nested
+  // files re-inject on change (R16).
+  const fresh = store.unseen(chain.filter((entry) => entry.tier !== 'root'));
   if (fresh.length === 0) return null;
 
   const maxBytes = config.agents_md.max_file_bytes;

--- a/electron/src/main/agents-md/resolver.ts
+++ b/electron/src/main/agents-md/resolver.ts
@@ -109,7 +109,7 @@ function canonicalizeExistingPathCached(candidate: string): string | null {
 // Per-directory instruction-file lookup
 // ---------------------------------------------------------------------------
 
-interface InstructionHit {
+export interface InstructionHit {
   canonical: string;
   stat: fs.Stats;
 }
@@ -179,6 +179,7 @@ export function resolveAgentsMdChain(
   targetPath: string,
   cwd: string,
   config: Config,
+  dirCache?: Map<string, InstructionHit | null>,
 ): AgentsMdEntry[] {
   const canonicalCwd = canonicalizeExistingPathCached(cwd);
   if (canonicalCwd === null) return [];
@@ -196,7 +197,14 @@ export function resolveAgentsMdChain(
 
   let dir = path.dirname(canonicalTarget);
   for (let walked = 0; isPathContainedIn(dir, canonicalCwd) && walked < maxDepth; walked++) {
-    const hit = findInstructionFile(dir, filenames);
+    let hit: InstructionHit | null;
+    if (dirCache) {
+      hit = dirCache.has(dir)
+        ? dirCache.get(dir)!
+        : (hit = findInstructionFile(dir, filenames), dirCache.set(dir, hit), hit);
+    } else {
+      hit = findInstructionFile(dir, filenames);
+    }
     if (hit !== null && isPathContainedIn(hit.canonical, canonicalCwd)) {
       entries.push({
         path: hit.canonical,
@@ -262,8 +270,9 @@ export function readAgentsMdContent(
 ): AgentsMdContent {
   const fd = fs.openSync(entry.path, 'r');
   try {
-    const buffer = Buffer.alloc(maxBytes);
-    const bytesRead = fs.readSync(fd, buffer, 0, maxBytes, 0);
+    const readSize = Math.min(entry.sizeBytes, maxBytes);
+    const buffer = Buffer.alloc(readSize);
+    const bytesRead = fs.readSync(fd, buffer, 0, readSize, 0);
     return {
       content: buffer.toString('utf8', 0, bytesRead),
       truncated: entry.sizeBytes > maxBytes,

--- a/electron/src/main/agents-md/resolver.ts
+++ b/electron/src/main/agents-md/resolver.ts
@@ -1,0 +1,215 @@
+/**
+ * AGENTS.md governing-chain resolver.
+ *
+ * Maps a target path to the ordered chain of instruction files that govern it,
+ * walking up from the target's directory to the workspace root (`cwd`). Pure
+ * and side-effect-light: it reports file metadata only and never reads content
+ * (content reading + the byte cap live with the injection units). Canonical,
+ * symlink-resolved paths are the identity used for dedupe across the feature.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Config } from '../config/schema';
+import { effectiveAgentsMdFilenames } from './config';
+
+/** A single governing instruction file discovered during the upward walk. */
+export interface AgentsMdEntry {
+  /** Canonical absolute path (symlink-resolved) — the dedupe identity. */
+  path: string;
+  /** Workspace-relative form for human-facing messages. */
+  displayPath: string;
+  /** `root` for the file at `cwd` level, `nested` otherwise. */
+  tier: 'root' | 'nested';
+  /** File size in bytes (callers apply the `max_file_bytes` cap). */
+  sizeBytes: number;
+  /** Modification time in ms (callers use this for staleness). */
+  mtimeMs: number;
+}
+
+/** Result of reading an instruction file under the byte cap. */
+export interface AgentsMdContent {
+  content: string;
+  truncated: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Path canonicalization + containment (mirrors permissions/resolver.ts)
+// ---------------------------------------------------------------------------
+
+function isPathContainedIn(resolved: string, cwd: string): boolean {
+  return resolved === cwd || resolved.startsWith(cwd + path.sep);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+/**
+ * Canonicalize a path that may not fully exist yet (e.g. a file about to be
+ * created): resolve the nearest existing ancestor with `realpathSync.native`
+ * and re-append the missing components. Returns null if nothing resolves.
+ */
+function canonicalizeEffectivePath(candidate: string): string | null {
+  let current = path.resolve(candidate);
+  const missingParts: string[] = [];
+
+  while (true) {
+    try {
+      const existingParent = fs.realpathSync.native(current);
+      return path.resolve(existingParent, ...missingParts);
+    } catch (error) {
+      if (!isMissingPathError(error)) return null;
+
+      try {
+        fs.lstatSync(current);
+        return null;
+      } catch (lstatError) {
+        if (!isMissingPathError(lstatError)) return null;
+      }
+
+      const parent = path.dirname(current);
+      if (parent === current) return null;
+      missingParts.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+function canonicalizeExistingPath(candidate: string): string | null {
+  try {
+    return fs.realpathSync.native(path.resolve(candidate));
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-directory instruction-file lookup
+// ---------------------------------------------------------------------------
+
+interface InstructionHit {
+  canonical: string;
+  stat: fs.Stats;
+}
+
+/**
+ * Find the governing instruction file in `dir`, testing each configured
+ * filename in order; the first existing match wins (alias precedence).
+ * Filenames match case-insensitively but the on-disk name is preserved.
+ * Returns the canonical (symlink-resolved) path and stat of the match.
+ */
+function findInstructionFile(
+  dir: string,
+  filenames: string[],
+): InstructionHit | null {
+  let dirEntries: string[];
+  try {
+    dirEntries = fs.readdirSync(dir);
+  } catch {
+    return null;
+  }
+
+  for (const filename of filenames) {
+    const lower = filename.toLowerCase();
+    const onDisk = dirEntries.find((entry) => entry.toLowerCase() === lower);
+    if (onDisk === undefined) continue;
+
+    let canonical: string;
+    try {
+      canonical = fs.realpathSync.native(path.join(dir, onDisk));
+    } catch {
+      continue;
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(canonical);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+
+    return { canonical, stat };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the ordered chain of AGENTS.md files governing `targetPath`.
+ *
+ * Walks up from `dirname(canonicalTarget)` to `cwd` inclusive, collecting at
+ * most one instruction file per directory (first configured alias present).
+ * The result is ordered from the target's directory upward; the `cwd`-level
+ * file, if any, is tagged `tier: "root"` and is the last entry. The walk never
+ * rises above `cwd`, is capped at `agents_md.max_chain_depth` directories, and
+ * excludes any file whose canonical path escapes `cwd` (symlink containment).
+ * Returns an empty chain when the target lies outside `cwd` or cannot resolve.
+ */
+export function resolveAgentsMdChain(
+  targetPath: string,
+  cwd: string,
+  config: Config,
+): AgentsMdEntry[] {
+  const canonicalCwd = canonicalizeExistingPath(cwd);
+  if (canonicalCwd === null) return [];
+
+  const canonicalTarget = canonicalizeEffectivePath(path.resolve(cwd, targetPath));
+  if (canonicalTarget === null || !isPathContainedIn(canonicalTarget, canonicalCwd)) {
+    return [];
+  }
+
+  const filenames = effectiveAgentsMdFilenames(config);
+  if (filenames.length === 0) return [];
+
+  const maxDepth = config.agents_md.max_chain_depth;
+  const entries: AgentsMdEntry[] = [];
+
+  let dir = path.dirname(canonicalTarget);
+  for (let walked = 0; isPathContainedIn(dir, canonicalCwd) && walked < maxDepth; walked++) {
+    const hit = findInstructionFile(dir, filenames);
+    if (hit !== null && isPathContainedIn(hit.canonical, canonicalCwd)) {
+      entries.push({
+        path: hit.canonical,
+        displayPath: path.relative(canonicalCwd, hit.canonical),
+        tier: dir === canonicalCwd ? 'root' : 'nested',
+        sizeBytes: hit.stat.size,
+        mtimeMs: hit.stat.mtimeMs,
+      });
+    }
+
+    if (dir === canonicalCwd) break;
+    dir = path.dirname(dir);
+  }
+
+  return entries;
+}
+
+/**
+ * Read an instruction file's content under a byte cap (R5). Reads at most
+ * `maxBytes` from the head; `truncated` is true when the file exceeds the cap.
+ * Pure helper shared by the injection units — does not touch the tracker.
+ */
+export function readAgentsMdContent(
+  entry: AgentsMdEntry,
+  maxBytes: number,
+): AgentsMdContent {
+  const fd = fs.openSync(entry.path, 'r');
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const bytesRead = fs.readSync(fd, buffer, 0, maxBytes, 0);
+    return {
+      content: buffer.toString('utf8', 0, bytesRead),
+      truncated: entry.sizeBytes > maxBytes,
+    };
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/electron/src/main/agents-md/resolver.ts
+++ b/electron/src/main/agents-md/resolver.ts
@@ -10,6 +10,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { Config } from '../config/schema';
+import { resolveToolPath } from '../tools/types';
 import { effectiveAgentsMdFilenames } from './config';
 
 /** A single governing instruction file discovered during the upward walk. */
@@ -87,6 +88,23 @@ function canonicalizeExistingPath(candidate: string): string | null {
   }
 }
 
+// The cwd is frozen per turn, so canonicalizing it on every file-tool call
+// repeats a blocking fs.realpathSync.native on the main-process event loop
+// (amplified N× across an apply_patch's files). Memoize the result in a small
+// bounded cache keyed by the resolved cwd, mirroring permissions/resolver.ts.
+// Per-target symlink resolution (canonicalizeEffectivePath) stays live.
+const canonicalPathCache = new Map<string, string | null>();
+const CANONICAL_CACHE_MAX = 256;
+
+function canonicalizeExistingPathCached(candidate: string): string | null {
+  const key = path.resolve(candidate);
+  if (canonicalPathCache.has(key)) return canonicalPathCache.get(key) ?? null;
+  const result = canonicalizeExistingPath(key);
+  if (canonicalPathCache.size >= CANONICAL_CACHE_MAX) canonicalPathCache.clear();
+  canonicalPathCache.set(key, result);
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Per-directory instruction-file lookup
 // ---------------------------------------------------------------------------
@@ -115,7 +133,11 @@ function findInstructionFile(
 
   for (const filename of filenames) {
     const lower = filename.toLowerCase();
-    const onDisk = dirEntries.find((entry) => entry.toLowerCase() === lower);
+    // Prefer an exact-case match for determinism when both `AGENTS.md` and
+    // `agents.md` coexist on a case-sensitive FS; fall back to case-insensitive.
+    const onDisk =
+      dirEntries.find((entry) => entry === filename) ??
+      dirEntries.find((entry) => entry.toLowerCase() === lower);
     if (onDisk === undefined) continue;
 
     let canonical: string;
@@ -158,7 +180,7 @@ export function resolveAgentsMdChain(
   cwd: string,
   config: Config,
 ): AgentsMdEntry[] {
-  const canonicalCwd = canonicalizeExistingPath(cwd);
+  const canonicalCwd = canonicalizeExistingPathCached(cwd);
   if (canonicalCwd === null) return [];
 
   const canonicalTarget = canonicalizeEffectivePath(path.resolve(cwd, targetPath));
@@ -190,6 +212,43 @@ export function resolveAgentsMdChain(
   }
 
   return entries;
+}
+
+/**
+ * Stat an existing instruction file and build a fresh `AgentsMdEntry` for it
+ * (current mtime/size, tier from whether its containing directory is the
+ * workspace root, displayPath relative to cwd). Returns null when the path does
+ * not exist, is not a file, or escapes cwd. The dispatcher uses this to refresh
+ * the tracker with the POST-write state of an edited/created instruction file
+ * (R10), so the recorded mtime matches what the handler just wrote to disk.
+ */
+export function statAgentsMdEntry(
+  rawPath: string,
+  cwd: string,
+  config: Config,
+): AgentsMdEntry | null {
+  void config;
+  const canonicalCwd = canonicalizeExistingPathCached(cwd);
+  if (canonicalCwd === null) return null;
+
+  let canonical: string;
+  let stat: fs.Stats;
+  try {
+    canonical = fs.realpathSync.native(resolveToolPath(cwd, rawPath));
+    stat = fs.statSync(canonical);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile()) return null;
+  if (!isPathContainedIn(canonical, canonicalCwd)) return null;
+
+  return {
+    path: canonical,
+    displayPath: path.relative(canonicalCwd, canonical),
+    tier: path.dirname(canonical) === canonicalCwd ? 'root' : 'nested',
+    sizeBytes: stat.size,
+    mtimeMs: stat.mtimeMs,
+  };
 }
 
 /**

--- a/electron/src/main/agents/manager.ts
+++ b/electron/src/main/agents/manager.ts
@@ -730,6 +730,13 @@ export class SubagentManager {
     const messages: Message[] = [...(record.chain?.messages ?? [])];
     let responseText = '';
     let resultText = '';
+    // Per-step text tracking so the returned result is the subagent's last
+    // message rather than the concatenation of every step's narration.
+    // `stepText` accumulates the current step; `lastStepResult` remembers the
+    // most recent step that produced text (so a trailing tool-only step does
+    // not blank out the answer).
+    let stepText = '';
+    let lastStepResult = '';
     let accumulatedUsage: Usage | null = null;
     // Track open tool calls for result pairing in the chain
     const toolNames = new Map<string, string>();
@@ -761,6 +768,7 @@ export class SubagentManager {
           case 'content': {
             responseText += event.text;
             resultText += event.text;
+            stepText += event.text;
             this._appendLiveText(record, 'text', event.text);
             break;
           }
@@ -853,8 +861,12 @@ export class SubagentManager {
           case 'error': {
             throw new Error(event.detail || event.title || 'Subagent stream error');
           }
+          case 'step_finish': {
+            if (stepText.trim()) lastStepResult = stepText;
+            stepText = '';
+            break;
+          }
           case 'finish':
-          case 'step_finish':
           default:
             break;
         }
@@ -875,7 +887,11 @@ export class SubagentManager {
       // IDs become message IDs so a durable handoff cannot duplicate bubbles.
       this._commitLiveSegments(record, messages, record.live.segments.length, accumulatedUsage);
 
-      record.result = resultText || record.result;
+      // Prefer the last step's text (the subagent's final message). Fall back
+      // to the full accumulation when no step boundary was observed (e.g. the
+      // textStream fallback path, which does not emit step_finish).
+      const finalStepText = stepText.trim() ? stepText : lastStepResult;
+      record.result = finalStepText || resultText || record.result;
       record.usage = accumulatedUsage;
       this._setChainMessages(record, messages);
       this._markLiveCommitted(record);

--- a/electron/src/main/agents/subagent-runner.ts
+++ b/electron/src/main/agents/subagent-runner.ts
@@ -184,10 +184,20 @@ export function createSubagentStreamRunner(): SubagentStreamRunner {
         .map((tool) => tool.definition.name)
         .filter((name) => !SUBAGENT_FORBIDDEN_TOOLS.has(name));
       const agentForRun: Agent = { ...params.agent, allowed_tools: allowedTools };
+      // Root AGENTS.md injection is non-fatal: an fs/config failure falls back
+      // to the un-augmented prompt rather than failing the delegation (the
+      // adjacent tracker seeding is already non-fatal).
+      const basePrompt = params.agent.system_prompt || 'You are a helpful assistant.';
+      let fullPrompt = basePrompt;
+      try {
+        fullPrompt = appendRootAgentsMd(basePrompt, runtime);
+      } catch (err) {
+        console.debug('root AGENTS.md injection failed (non-fatal):', err);
+      }
       yield* streamChat({
         messages: [makeUserMessage(params.task)],
         agent: agentForRun,
-        systemPrompt: appendRootAgentsMd(params.agent.system_prompt || 'You are a helpful assistant.', runtime),
+        systemPrompt: fullPrompt,
         context,
         config,
         registry,

--- a/electron/src/main/agents/subagent-runner.ts
+++ b/electron/src/main/agents/subagent-runner.ts
@@ -15,6 +15,7 @@ import {
   getProjectRuntimeRegistry,
   type ProjectRuntime,
 } from '../project/runtime';
+import { appendRootAgentsMd, seedSubagentRootAgentsMd } from '../project/agents-md';
 import type { SubagentStreamRunner } from './manager';
 import { makeUserMessage } from '../llm/message-factories';
 import { buildSystemPromptContext } from '../llm/build-prompt-context';
@@ -158,6 +159,11 @@ export function createSubagentStreamRunner(): SubagentStreamRunner {
       sessionId,
       agentScopeId: params.agentScopeId,
     });
+    // Seed the subagent's scope-keyed tracker with the root instruction file
+    // (R13/R15) so the nested read-path mechanism never re-injects it (R4). The
+    // subagent starts fresh with only the root — it does not inherit the
+    // parent's seen nested files. Non-fatal (never breaks subagent startup).
+    seedSubagentRootAgentsMd(sessionId, params.agentScopeId, runtime);
     const accounting: ProviderAttemptAccountingContext = {
       store: accountingStore,
       sessionId,
@@ -181,7 +187,7 @@ export function createSubagentStreamRunner(): SubagentStreamRunner {
       yield* streamChat({
         messages: [makeUserMessage(params.task)],
         agent: agentForRun,
-        systemPrompt: params.agent.system_prompt || 'You are a helpful assistant.',
+        systemPrompt: appendRootAgentsMd(params.agent.system_prompt || 'You are a helpful assistant.', runtime),
         context,
         config,
         registry,

--- a/electron/src/main/config/schema.ts
+++ b/electron/src/main/config/schema.ts
@@ -10,7 +10,12 @@ import type { Config } from '../../shared/types/ipc-boundary';
 import { PERMISSION_MODE_VALUES } from '../../shared/types/permission';
 import { modelSelectionSchema } from '../../shared/types/provider';
 
-export type { Config, RAGConfig } from '../../shared/types/ipc-boundary';
+export type {
+  Config,
+  RAGConfig,
+  AgentsMdConfig,
+  AgentsMdEnforcePolicy,
+} from '../../shared/types/ipc-boundary';
 export { modelSelectionSchema, type ModelSelection } from '../../shared/types/provider';
 
 // ---------------------------------------------------------------------------
@@ -56,6 +61,24 @@ export const permissionRuleSchema = z.union([
 ]);
 
 export const permissionsConfigSchema = z.record(z.string(), permissionRuleSchema);
+
+/** Write-enforcement policies for unseen governing AGENTS.md files. */
+export const AGENTS_MD_ENFORCE_POLICIES = ['block', 'inject', 'warn', 'off'] as const;
+
+/**
+ * AGENTS.md discovery, injection, and write-enforcement settings. Mirrors the
+ * `rag` nested object: per-field defaults, referenced as `agents_md` with an
+ * explicit `.default({})` so partial project overrides deep-merge cleanly.
+ */
+export const agentsMdConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  filenames: z.array(z.string()).default(['AGENTS.md', 'CLAUDE.md']),
+  max_file_bytes: z.number().int().positive().default(32768),
+  max_chain_depth: z.number().int().positive().default(8),
+  enforce_on_write: z.enum(AGENTS_MD_ENFORCE_POLICIES).default('warn'),
+  inject_on_read: z.boolean().default(true),
+  include_local: z.boolean().default(false),
+});
 
 // ---------------------------------------------------------------------------
 // Main config schema
@@ -121,6 +144,7 @@ export const configSchema = z
     theme: z.string().min(1).default('default'),
     personality: z.string().min(1).default('default'),
     rag: ragConfigSchema.default({}),
+    agents_md: agentsMdConfigSchema.default({}),
     ast_max_file_size: z.number().int().positive().default(1_048_576),
     mcp_startup_timeout: z.number().positive().default(60.0),
     mcp_per_server_timeout: z.number().positive().default(10.0),

--- a/electron/src/main/config/schema.ts
+++ b/electron/src/main/config/schema.ts
@@ -72,9 +72,11 @@ export const AGENTS_MD_ENFORCE_POLICIES = ['block', 'inject', 'warn', 'off'] as 
  */
 export const agentsMdConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  filenames: z.array(z.string()).default(['AGENTS.md', 'CLAUDE.md']),
-  max_file_bytes: z.number().int().positive().default(32768),
-  max_chain_depth: z.number().int().positive().default(8),
+  filenames: z.array(z.string()).max(16).default(['AGENTS.md', 'CLAUDE.md']),
+  // Bounded so a hostile project `.orchid.json` cannot OOM the main process
+  // (`readAgentsMdContent` does `Buffer.alloc(max_file_bytes)`) or walk forever.
+  max_file_bytes: z.number().int().positive().max(2_097_152).default(32768),
+  max_chain_depth: z.number().int().positive().max(32).default(8),
   enforce_on_write: z.enum(AGENTS_MD_ENFORCE_POLICIES).default('warn'),
   inject_on_read: z.boolean().default(true),
   include_local: z.boolean().default(false),

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -65,6 +65,7 @@ import {
   publishSessionActivity,
 } from './session-activity';
 import { appendProjectPersonality } from '../project/personality';
+import { appendRootAgentsMd, findRootAgentsMdEntry } from '../project/agents-md';
 import { buildSystemPromptContext } from '../llm/build-prompt-context';
 import {
   acquireProjectMCPManager,
@@ -1239,6 +1240,19 @@ export function registerChatIPC(): void {
     // mutable global registry used by the settings surface.
     const abortController = new AbortController();
     const baseSystemPrompt = agent.system_prompt || 'You are a helpful assistant.';
+
+    // Seed the per-session tracker with the root instruction file (R13) so the
+    // nested read-path mechanism never re-injects it (R4). Main agent scope →
+    // omit agentScopeId (it normalizes to main). Non-fatal: a seeding failure
+    // must never break the turn.
+    try {
+      const rootAgentsMdEntry = findRootAgentsMdEntry(runtime.projectDir, runtime.config);
+      if (rootAgentsMdEntry) {
+        sessionManager.getAgentsMdContextStore(sessionId).seedRoot(rootAgentsMdEntry);
+      }
+    } catch (err) {
+      console.debug('seedRoot AGENTS.md context failed (non-fatal):', err);
+    }
     const accounting: ProviderAttemptAccountingContext = {
       store: accountingStore,
       sessionId,
@@ -1264,7 +1278,7 @@ export function registerChatIPC(): void {
       actor = createActor(agentMachine, {
         input: {
           agent,
-          systemPrompt: appendProjectPersonality(baseSystemPrompt, runtime),
+          systemPrompt: appendRootAgentsMd(appendProjectPersonality(baseSystemPrompt, runtime), runtime),
           streamFn: createProviderStreamFn({
             messages,
             runtime,

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -1275,10 +1275,20 @@ export function registerChatIPC(): void {
         skills: new Map(runtime.skills),
         mcpManager,
       });
+      // Root AGENTS.md injection is non-fatal: an fs/config failure falls back
+      // to the un-augmented prompt rather than failing the whole turn (the
+      // adjacent tracker seeding is already non-fatal).
+      const personalityPrompt = appendProjectPersonality(baseSystemPrompt, runtime);
+      let fullSystemPrompt = personalityPrompt;
+      try {
+        fullSystemPrompt = appendRootAgentsMd(personalityPrompt, runtime);
+      } catch (err) {
+        console.debug('root AGENTS.md injection failed (non-fatal):', err);
+      }
       actor = createActor(agentMachine, {
         input: {
           agent,
-          systemPrompt: appendRootAgentsMd(appendProjectPersonality(baseSystemPrompt, runtime), runtime),
+          systemPrompt: fullSystemPrompt,
           streamFn: createProviderStreamFn({
             messages,
             runtime,

--- a/electron/src/main/ipc/tool.ts
+++ b/electron/src/main/ipc/tool.ts
@@ -105,6 +105,9 @@ export function registerToolIPC(): void {
         agentScopeId: toolCtx.agentScopeId,
         projectRuntime: toolCtx.projectRuntime,
         windowId,
+        // Renderer tool:execute results surface in the UI, not the LLM context:
+        // keep AGENTS.md read injection / write enforcement off this path (R17).
+        agentsMdDisabled: true,
       },
     );
   });

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -549,6 +549,7 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
     const seenToolResultIds = new Set<string>();
     const pendingUsageEvents: Usage[] = [];
     let currentStepMessages: readonly ModelMessage[] = coreMessages;
+    let stepIndex = 0;
     let usedFullStream = false;
     let pendingStepEventsSignaled = false;
     let resolvePendingStepEvents: (() => void) | null = null;
@@ -683,6 +684,15 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
                   buildUsageContext,
                 ),
               };
+              yield {
+                type: 'step_finish',
+                stepIndex,
+                finishReason:
+                  typeof part.finishReason === 'string'
+                    ? part.finishReason
+                    : 'unknown',
+              };
+              stepIndex += 1;
               break;
             }
 

--- a/electron/src/main/llm/tool-dispatch.ts
+++ b/electron/src/main/llm/tool-dispatch.ts
@@ -40,6 +40,8 @@ import {
   type ToolHandlerOutcome,
 } from '../../shared/types/tool-result';
 import { materializeCanonicalResultRetrieval } from '../tools/result-retrieval';
+import { buildAgentsMdInjection } from '../agents-md/inject';
+import type { AgentsMdContextStore } from '../session/agents-md-context';
 import { withTimeout as sharedWithTimeout } from '../utils/async';
 import { checkPermission } from '../permissions/gate';
 import { recordToolCall } from '../permissions/history';
@@ -356,6 +358,12 @@ export async function executeToolCall(
     execution = finalizeHandlerResult(result, request, registry);
     execution = ensureProjectionRecovery(execution, request, options);
     execution = maybeOffloadAgentProjection(execution, request, options);
+    execution = maybeInjectAgentsMd(
+      execution,
+      request,
+      options,
+      handlerArgs as Record<string, unknown>,
+    );
     const executionSchema = registry.getToolExecutionResultSchema(name);
     if (!executionSchema) {
       throw new TypeError(`No execution schema registered for tool '${name}'`);
@@ -469,19 +477,24 @@ function ensureProjectionRecovery(
   }
 }
 
-function appendXmlRetrieval(
+/**
+ * Insert an XML fragment immediately before the final `</tool_result>` closing
+ * tag of a well-formed envelope. When the content is not a well-formed envelope
+ * (missing opening or closing tag), wrap it in a fallback envelope instead.
+ * Shared by retrieval recovery and AGENTS.md read-path injection.
+ */
+function insertXmlBeforeClosingTag(
   content: string,
-  retrieval: ToolResultRetrieval,
+  xml: string,
   toolName: string,
 ): string {
-  const retrievalXml = renderRetrieval(retrieval);
   const closingTag = '</tool_result>';
   const closingIndex = content.lastIndexOf(closingTag);
   const startsWithEnvelope = content.startsWith('<tool_result');
   const hasClosingTag = closingIndex >= 0;
   if (startsWithEnvelope && hasClosingTag) {
     return content.slice(0, closingIndex).trimEnd() + '\n' +
-      retrievalXml + '\n' + content.slice(closingIndex);
+      xml + '\n' + content.slice(closingIndex);
   }
   console.warn('[tool-dispatch] Projection content is not a well-formed tool_result envelope; wrapping in fallback envelope', {
     toolName,
@@ -490,7 +503,15 @@ function appendXmlRetrieval(
   });
   return '<tool_result name="' + escapeXmlAttribute(toolName) + '" status="partial">\n' +
     '<payload>' + escapeXmlText(content) + '</payload>\n' +
-    retrievalXml + '\n</tool_result>';
+    xml + '\n</tool_result>';
+}
+
+function appendXmlRetrieval(
+  content: string,
+  retrieval: ToolResultRetrieval,
+  toolName: string,
+): string {
+  return insertXmlBeforeClosingTag(content, renderRetrieval(retrieval), toolName);
 }
 
 function maybeOffloadAgentProjection(
@@ -522,6 +543,109 @@ function maybeOffloadAgentProjection(
       },
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// AGENTS.md read-path injection
+// ---------------------------------------------------------------------------
+
+/**
+ * Test-only store-resolver override. Under vitest the native `createRequire`
+ * used below cannot load `.ts` sources, so tests inject a real store here;
+ * production leaves this null and uses the lazy require. Mirrors the existing
+ * `_setToolOutputCacheRootForTests` convention in this file.
+ */
+type AgentsMdStoreResolver = (
+  sessionId: string,
+  agentScopeId: string | undefined,
+) => AgentsMdContextStore | null;
+
+let agentsMdStoreResolverOverride: AgentsMdStoreResolver | null = null;
+
+/** @internal Test-only store-resolver override (pass null to reset). */
+export function _setAgentsMdStoreResolverForTests(
+  resolver: AgentsMdStoreResolver | null,
+): void {
+  agentsMdStoreResolverOverride = resolver;
+}
+
+/**
+ * Lazily resolve the session's AGENTS.md context store.
+ *
+ * Deviation from the plan's "thread the tracker through ToolExecutionContext":
+ * resolving here (instead of editing orchestrator.ts's call sites, chat.ts, and
+ * tools/types.ts) keeps U4 to two source files. The lazy `createRequire` mirrors
+ * build-prompt-context.ts and avoids a circular init with session/tools. Returns
+ * null when there is no session or resolution fails (no-session degradation, R17).
+ */
+function resolveAgentsMdStore(
+  sessionId: string | undefined,
+  agentScopeId: string | undefined,
+): AgentsMdContextStore | null {
+  if (!sessionId) return null;
+  if (agentsMdStoreResolverOverride) {
+    return agentsMdStoreResolverOverride(sessionId, agentScopeId);
+  }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createRequire } = require('node:module') as typeof import('node:module');
+    const req = createRequire(__filename);
+    const session = req('../ipc/session') as typeof import('../ipc/session');
+    return session.getSessionManager().getAgentsMdContextStore(sessionId, agentScopeId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Inject any not-yet-seen governing AGENTS.md content into a read tool's agent
+ * projection. Runs after offloading so the small, important instruction block
+ * stays inline even when the main payload is offloaded. Entries are marked seen
+ * only after the block is appended so a failed append cannot poison the tracker.
+ * Any failure degrades to no injection and never breaks the tool result.
+ */
+function maybeInjectAgentsMd(
+  execution: ToolExecutionResult,
+  request: ToolDispatchRequest,
+  options: ToolDispatchOptions,
+  args: Record<string, unknown>,
+): ToolExecutionResult {
+  if (!options.sessionId || !options.cwd) return execution;
+  try {
+    const store = resolveAgentsMdStore(options.sessionId, options.agentScopeId);
+    if (store === null) return execution;
+
+    const config = options.projectRuntime?.config ?? FALLBACK_CONFIG;
+    const injection = buildAgentsMdInjection(
+      request.name,
+      args,
+      options.cwd,
+      config,
+      store,
+    );
+    if (injection === null) return execution;
+
+    const content = insertXmlBeforeClosingTag(
+      execution.agentProjection.content,
+      injection.xml,
+      request.name,
+    );
+    injection.injected.forEach((entry) => store.markSeen(entry));
+    return {
+      canonical: execution.canonical,
+      agentProjection: {
+        ...execution.agentProjection,
+        content,
+      },
+    };
+  } catch (error) {
+    console.warn('[tool-dispatch] AGENTS.md injection failed', {
+      toolCallId: request.id,
+      toolName: request.name,
+      exceptionClass: error instanceof Error ? error.constructor.name : 'Unknown',
+    });
+    return execution;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/electron/src/main/llm/tool-dispatch.ts
+++ b/electron/src/main/llm/tool-dispatch.ts
@@ -119,6 +119,8 @@ export interface ToolDispatchOptions {
   abortSignal?: AbortSignal;
   /** The user message that triggered the current turn (for decide-for-me evaluator). */
   triggeringMessage?: string;
+  /** When true, skip AGENTS.md read injection and write enforcement (renderer tool:execute UI path). */
+  agentsMdDisabled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -642,6 +644,7 @@ function maybeInjectAgentsMd(
   args: Record<string, unknown>,
 ): ToolExecutionResult {
   if (!options.sessionId || !options.cwd) return execution;
+  if (options.agentsMdDisabled) return execution;
   try {
     const store = resolveAgentsMdStore(options.sessionId, options.agentScopeId);
     if (store === null) return execution;
@@ -707,6 +710,7 @@ function evaluateAgentsMdWriteEnforcement(
   args: Record<string, unknown>,
 ): AgentsMdWriteVerdict | null {
   if (!options.sessionId || !options.cwd) return null;
+  if (options.agentsMdDisabled) return null;
   const store = resolveAgentsMdStore(options.sessionId, options.agentScopeId);
   if (store === null) return null;
 

--- a/electron/src/main/llm/tool-dispatch.ts
+++ b/electron/src/main/llm/tool-dispatch.ts
@@ -48,6 +48,7 @@ import {
   evaluateAgentsMdEnforcement,
   type AgentsMdEnforcement,
 } from '../agents-md/enforce';
+import { statAgentsMdEntry } from '../agents-md/resolver';
 import type { AgentsMdContextStore } from '../session/agents-md-context';
 import { withTimeout as sharedWithTimeout } from '../utils/async';
 import { checkPermission } from '../permissions/gate';
@@ -263,24 +264,38 @@ export async function executeToolCall(
   // AGENTS.md write enforcement — Phase A (pre-handler). Evaluates the governing
   // chain for the five file mutators and, under the `block` policy, short-circuits
   // with a terminal denial before the handler runs. Other policies carry the
-  // verdict forward to Phase B (post-handler) via `agentsMdWrite`.
-  const agentsMdWrite = evaluateAgentsMdWriteEnforcement(
-    request,
-    options,
-    args as Record<string, unknown>,
-  );
-  if (
-    agentsMdWrite !== null &&
-    agentsMdWrite.enforcement.policy === 'block' &&
-    agentsMdWrite.enforcement.unseen.length > 0
-  ) {
-    return genericTerminalExecution(
-      toolCallId,
-      name,
-      'error',
-      buildAgentsMdBlockMessage(agentsMdWrite.enforcement.unseen),
-      'agents_md_not_in_context',
+  // verdict forward to Phase B (post-handler) via `agentsMdWrite`. Wrapped so an
+  // enforcement failure (e.g. a partial config) degrades to no enforcement and
+  // never breaks the tool call.
+  let agentsMdWrite: AgentsMdWriteVerdict | null = null;
+  try {
+    agentsMdWrite = evaluateAgentsMdWriteEnforcement(
+      request,
+      options,
+      args as Record<string, unknown>,
     );
+    if (
+      agentsMdWrite !== null &&
+      agentsMdWrite.enforcement.policy === 'block' &&
+      agentsMdWrite.enforcement.unseen.length > 0
+    ) {
+      return genericTerminalExecution(
+        toolCallId,
+        name,
+        'error',
+        buildAgentsMdBlockMessage(agentsMdWrite.enforcement.unseen),
+        'agents_md_not_in_context',
+      );
+    }
+  } catch (error) {
+    // Degrade to no enforcement. `agentsMdWrite` keeps its null initializer:
+    // the only realistic throw is inside the evaluation, before assignment.
+    console.warn('[tool-dispatch] AGENTS.md write enforcement failed', {
+      toolCallId,
+      toolName: name,
+      stage: 'phase-a',
+      exceptionClass: error instanceof Error ? error.constructor.name : 'Unknown',
+    });
   }
 
   // Timeout AbortController — aborted by runWithToolTimeout so foreground
@@ -728,13 +743,16 @@ function evaluateAgentsMdWriteEnforcement(
 
 /**
  * AGENTS.md write enforcement — Phase B (post-handler). Runs after the agent
- * projection is finalized, next to the read-path injection. Refreshes tracker
- * entries for any instruction file the mutation edited (R10), then augments the
- * projection per policy: `warn` appends a warning naming the unseen files
- * (without marking them seen); `inject` appends their byte-capped content and
- * marks them seen. `block` only reaches here when nothing was unseen (the
- * non-empty case short-circuited in Phase A). Any failure degrades to the
- * unmodified result and never breaks the tool result.
+ * projection is finalized, next to the read-path injection. Skips failed or
+ * cancelled mutations (nothing was written, so neither warn nor refresh — F8).
+ * Refreshes tracker entries for any instruction file the mutation edited or
+ * created by re-statting each target POST-write so the recorded mtime matches
+ * what landed on disk (R10/F6), then augments the projection per policy: `warn`
+ * appends a warning naming the unseen files (without marking them seen);
+ * `inject` appends their byte-capped content and marks them seen. `block` only
+ * reaches here when nothing was unseen (the non-empty case short-circuited in
+ * Phase A). Any failure degrades to the unmodified result and never breaks the
+ * tool result.
  */
 function maybeEnforceAgentsMdOnWrite(
   execution: ToolExecutionResult,
@@ -743,18 +761,33 @@ function maybeEnforceAgentsMdOnWrite(
   verdict: AgentsMdWriteVerdict | null,
 ): ToolExecutionResult {
   if (verdict === null) return execution;
+  // A failed/cancelled mutation wrote nothing: the "you modified files…" warning
+  // would be factually wrong and there is no new on-disk state to record (F8).
+  if (
+    execution.canonical.status === 'error' ||
+    execution.canonical.status === 'cancelled'
+  ) {
+    return execution;
+  }
   try {
     const { enforcement, store } = verdict;
+    const config = options.projectRuntime?.config ?? FALLBACK_CONFIG;
 
-    // R10 refresh: editing an instruction file puts its new content in context.
-    enforcement.editedInstructionFiles.forEach((entry) => store.markSeen(entry));
+    // R10 refresh: re-stat each instruction-file target POST-write and record the
+    // fresh entry. Edited files now carry their bumped mtime; newly created files
+    // now exist. Phase A's pre-write entries are stale and deliberately unused.
+    if (options.cwd) {
+      for (const rawPath of enforcement.instructionFileTargets) {
+        const freshEntry = statAgentsMdEntry(rawPath, options.cwd, config);
+        if (freshEntry !== null) store.markSeen(freshEntry);
+      }
+    }
 
     let xml = '';
     if (enforcement.unseen.length > 0) {
       if (enforcement.policy === 'warn') {
         xml = buildAgentsMdWarningBlock(enforcement.unseen);
       } else if (enforcement.policy === 'inject') {
-        const config = options.projectRuntime?.config ?? FALLBACK_CONFIG;
         xml = buildAgentsMdInjectBlock(enforcement.unseen, config);
         enforcement.unseen.forEach((entry) => store.markSeen(entry));
       }

--- a/electron/src/main/llm/tool-dispatch.ts
+++ b/electron/src/main/llm/tool-dispatch.ts
@@ -41,6 +41,13 @@ import {
 } from '../../shared/types/tool-result';
 import { materializeCanonicalResultRetrieval } from '../tools/result-retrieval';
 import { buildAgentsMdInjection } from '../agents-md/inject';
+import {
+  buildAgentsMdBlockMessage,
+  buildAgentsMdInjectBlock,
+  buildAgentsMdWarningBlock,
+  evaluateAgentsMdEnforcement,
+  type AgentsMdEnforcement,
+} from '../agents-md/enforce';
 import type { AgentsMdContextStore } from '../session/agents-md-context';
 import { withTimeout as sharedWithTimeout } from '../utils/async';
 import { checkPermission } from '../permissions/gate';
@@ -251,6 +258,29 @@ export async function executeToolCall(
   if (permissionDenial) return permissionDenial;
   recordToolCall(options.sessionId, options.agentScopeId, name, args);
 
+  // AGENTS.md write enforcement — Phase A (pre-handler). Evaluates the governing
+  // chain for the five file mutators and, under the `block` policy, short-circuits
+  // with a terminal denial before the handler runs. Other policies carry the
+  // verdict forward to Phase B (post-handler) via `agentsMdWrite`.
+  const agentsMdWrite = evaluateAgentsMdWriteEnforcement(
+    request,
+    options,
+    args as Record<string, unknown>,
+  );
+  if (
+    agentsMdWrite !== null &&
+    agentsMdWrite.enforcement.policy === 'block' &&
+    agentsMdWrite.enforcement.unseen.length > 0
+  ) {
+    return genericTerminalExecution(
+      toolCallId,
+      name,
+      'error',
+      buildAgentsMdBlockMessage(agentsMdWrite.enforcement.unseen),
+      'agents_md_not_in_context',
+    );
+  }
+
   // Timeout AbortController — aborted by runWithToolTimeout so foreground
   // process tools can kill the live ChildProcess handle (not only reject).
   const timeoutAbort = new AbortController();
@@ -364,6 +394,7 @@ export async function executeToolCall(
       options,
       handlerArgs as Record<string, unknown>,
     );
+    execution = maybeEnforceAgentsMdOnWrite(execution, request, options, agentsMdWrite);
     const executionSchema = registry.getToolExecutionResultSchema(name);
     if (!executionSchema) {
       throw new TypeError(`No execution schema registered for tool '${name}'`);
@@ -640,6 +671,103 @@ function maybeInjectAgentsMd(
     };
   } catch (error) {
     console.warn('[tool-dispatch] AGENTS.md injection failed', {
+      toolCallId: request.id,
+      toolName: request.name,
+      exceptionClass: error instanceof Error ? error.constructor.name : 'Unknown',
+    });
+    return execution;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AGENTS.md write-path enforcement
+// ---------------------------------------------------------------------------
+
+/**
+ * The Phase A verdict carried forward to Phase B: the enforcement evaluation
+ * plus the store it was computed against (so Phase B can mark entries seen on
+ * the same instance). Null means enforcement does not apply and Phase B is a
+ * no-op.
+ */
+interface AgentsMdWriteVerdict {
+  enforcement: AgentsMdEnforcement;
+  store: AgentsMdContextStore;
+}
+
+/**
+ * AGENTS.md write enforcement — Phase A (pre-handler). Resolves the session
+ * store and evaluates the five file mutators. Returns null when there is no
+ * session/store (R17: never enforce, never block without a session) or when
+ * enforcement does not apply (disabled/off/non-mutator). The caller applies the
+ * `block` policy immediately and threads the verdict into Phase B.
+ */
+function evaluateAgentsMdWriteEnforcement(
+  request: ToolDispatchRequest,
+  options: ToolDispatchOptions,
+  args: Record<string, unknown>,
+): AgentsMdWriteVerdict | null {
+  if (!options.sessionId || !options.cwd) return null;
+  const store = resolveAgentsMdStore(options.sessionId, options.agentScopeId);
+  if (store === null) return null;
+
+  const config = options.projectRuntime?.config ?? FALLBACK_CONFIG;
+  const enforcement = evaluateAgentsMdEnforcement(
+    request.name,
+    args,
+    options.cwd,
+    config,
+    store,
+  );
+  if (enforcement === null) return null;
+  return { enforcement, store };
+}
+
+/**
+ * AGENTS.md write enforcement — Phase B (post-handler). Runs after the agent
+ * projection is finalized, next to the read-path injection. Refreshes tracker
+ * entries for any instruction file the mutation edited (R10), then augments the
+ * projection per policy: `warn` appends a warning naming the unseen files
+ * (without marking them seen); `inject` appends their byte-capped content and
+ * marks them seen. `block` only reaches here when nothing was unseen (the
+ * non-empty case short-circuited in Phase A). Any failure degrades to the
+ * unmodified result and never breaks the tool result.
+ */
+function maybeEnforceAgentsMdOnWrite(
+  execution: ToolExecutionResult,
+  request: ToolDispatchRequest,
+  options: ToolDispatchOptions,
+  verdict: AgentsMdWriteVerdict | null,
+): ToolExecutionResult {
+  if (verdict === null) return execution;
+  try {
+    const { enforcement, store } = verdict;
+
+    // R10 refresh: editing an instruction file puts its new content in context.
+    enforcement.editedInstructionFiles.forEach((entry) => store.markSeen(entry));
+
+    let xml = '';
+    if (enforcement.unseen.length > 0) {
+      if (enforcement.policy === 'warn') {
+        xml = buildAgentsMdWarningBlock(enforcement.unseen);
+      } else if (enforcement.policy === 'inject') {
+        const config = options.projectRuntime?.config ?? FALLBACK_CONFIG;
+        xml = buildAgentsMdInjectBlock(enforcement.unseen, config);
+        enforcement.unseen.forEach((entry) => store.markSeen(entry));
+      }
+    }
+    if (xml === '') return execution;
+
+    const content = insertXmlBeforeClosingTag(
+      execution.agentProjection.content,
+      xml,
+      request.name,
+    );
+    return {
+      canonical: execution.canonical,
+      agentProjection: { ...execution.agentProjection, content },
+    };
+  } catch (error) {
+    console.warn('[tool-dispatch] AGENTS.md write enforcement failed', {
       toolCallId: request.id,
       toolName: request.name,
       exceptionClass: error instanceof Error ? error.constructor.name : 'Unknown',

--- a/electron/src/main/llm/tool-dispatch.ts
+++ b/electron/src/main/llm/tool-dispatch.ts
@@ -789,7 +789,6 @@ function maybeEnforceAgentsMdOnWrite(
         xml = buildAgentsMdWarningBlock(enforcement.unseen);
       } else if (enforcement.policy === 'inject') {
         xml = buildAgentsMdInjectBlock(enforcement.unseen, config);
-        enforcement.unseen.forEach((entry) => store.markSeen(entry));
       }
     }
     if (xml === '') return execution;
@@ -799,6 +798,9 @@ function maybeEnforceAgentsMdOnWrite(
       xml,
       request.name,
     );
+    if (enforcement.policy === 'inject') {
+      enforcement.unseen.forEach((entry) => store.markSeen(entry));
+    }
     return {
       canonical: execution.canonical,
       agentProjection: { ...execution.agentProjection, content },

--- a/electron/src/main/permissions/resolver.ts
+++ b/electron/src/main/permissions/resolver.ts
@@ -19,7 +19,7 @@ export { RISK_CLASS_DEFAULTS, FILE_TOOLS, FILE_TOOL_DEFAULTS };
 const PATCH_FILE_PATTERN = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/gm;
 const PATCH_MOVE_TO_PATTERN = /^\*\*\* Move to: (.+)$/gm;
 
-function extractPathsFromArgs(
+export function extractPathsFromArgs(
   toolName: string,
   args: Record<string, unknown>,
 ): string[] {

--- a/electron/src/main/permissions/resolver.ts
+++ b/electron/src/main/permissions/resolver.ts
@@ -16,8 +16,14 @@ import type { Config, PermissionRule } from '../../shared/types/ipc-boundary';
 // working without duplicating the definitions here.
 export { RISK_CLASS_DEFAULTS, FILE_TOOLS, FILE_TOOL_DEFAULTS };
 
-const PATCH_FILE_PATTERN = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/gm;
-const PATCH_MOVE_TO_PATTERN = /^\*\*\* Move to: (.+)$/gm;
+// The real apply-patch parser trims lines before matching the header markers,
+// so an indented `   *** Add File: pkg/x.ts` is a valid header. Allow optional
+// leading spaces/tabs here too, otherwise such a header evades path extraction
+// (and thus write enforcement + permission scope detection). This errs toward
+// stricter: a header-looking context line only yields a false-positive path
+// (stricter scope/enforcement), never a new bypass.
+const PATCH_FILE_PATTERN = /^[ \t]*\*\*\* (?:Add|Update|Delete) File: (.+)$/gm;
+const PATCH_MOVE_TO_PATTERN = /^[ \t]*\*\*\* Move to: (.+)$/gm;
 
 export function extractPathsFromArgs(
   toolName: string,

--- a/electron/src/main/project/agents-md.ts
+++ b/electron/src/main/project/agents-md.ts
@@ -1,0 +1,63 @@
+/**
+ * Root AGENTS.md injection into the static system instructions.
+ *
+ * A sibling to `appendProjectPersonality`: locate the workspace-root instruction
+ * file (root tier only) and append its byte-capped content under a clear
+ * heading. No-op when the feature is disabled or no root file exists. Pure and
+ * side-effect-light — reads the single root file and never touches the tracker
+ * (seeding the session tracker happens at the chat.ts call site, R13).
+ */
+import path from 'node:path';
+import {
+  readAgentsMdContent,
+  resolveAgentsMdChain,
+  type AgentsMdEntry,
+} from '../agents-md/resolver';
+import type { Config } from '../config/schema';
+import type { ProjectRuntime } from './runtime';
+
+/**
+ * Find the root instruction file governing the workspace, or null when the
+ * feature is disabled or no root-tier file exists. `projectDir` is already
+ * canonical (it comes from `ProjectRuntime.projectDir`), matching how the
+ * resolver treats `cwd`.
+ */
+export function findRootAgentsMdEntry(
+  projectDir: string,
+  config: Config,
+): AgentsMdEntry | null {
+  // A missing `agents_md` block (e.g. a partial config) degrades to disabled.
+  if (!config.agents_md?.enabled) return null;
+
+  // The resolver walks up from `dirname(target)` and tags the `cwd`-level file
+  // `root`. Targeting `projectDir` itself would start the walk one level too
+  // high (its parent) and miss the root, so resolve for a synthetic path
+  // directly inside the root — only its containing directory matters.
+  const chain = resolveAgentsMdChain(
+    path.join(projectDir, 'AGENTS.md'),
+    projectDir,
+    config,
+  );
+  return chain.find((entry) => entry.tier === 'root') ?? null;
+}
+
+/**
+ * Append the root instruction file's content to the system prompt without
+ * mutating the base prompt. Returns the prompt unchanged when the feature is
+ * disabled or no root file exists. Over-cap files inject a head plus a `read`
+ * pointer instead of the full content (R5).
+ */
+export function appendRootAgentsMd(
+  agentSystemPrompt: string,
+  runtime: ProjectRuntime,
+): string {
+  const entry = findRootAgentsMdEntry(runtime.projectDir, runtime.config);
+  if (entry === null) return agentSystemPrompt;
+
+  const maxBytes = runtime.config.agents_md.max_file_bytes;
+  const { content, truncated } = readAgentsMdContent(entry, maxBytes);
+  const note = truncated
+    ? `\n[truncated to ${maxBytes} bytes — use read for the full file]\n`
+    : '';
+  return `${agentSystemPrompt}\n\n## Project instructions (${entry.displayPath})\n\n${content}\n${note}`;
+}

--- a/electron/src/main/project/agents-md.ts
+++ b/electron/src/main/project/agents-md.ts
@@ -14,6 +14,7 @@ import {
   type AgentsMdEntry,
 } from '../agents-md/resolver';
 import type { Config } from '../config/schema';
+import { getSessionManager } from '../ipc/session';
 import type { ProjectRuntime } from './runtime';
 import type { SessionManager } from '../session/manager';
 
@@ -71,9 +72,8 @@ export function appendRootAgentsMd(
  * agent scope (U2), seeding the subagent's scope does not touch the parent's
  * store. Non-fatal: a seeding failure must never break subagent startup.
  *
- * The session manager is resolved lazily via `createRequire` (mirroring
- * build-prompt-context.ts and tool-dispatch.ts) to avoid a circular init with
- * session/tools; tests may inject a constructed manager directly.
+ * The session manager defaults to the shared singleton; tests may inject a
+ * constructed manager directly.
  */
 export function seedSubagentRootAgentsMd(
   sessionId: string | undefined,
@@ -83,15 +83,7 @@ export function seedSubagentRootAgentsMd(
 ): void {
   if (!sessionId) return;
   try {
-    let resolved = manager;
-    if (!resolved) {
-      // Lazy require avoids circular init with session/tools.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { createRequire } = require('node:module') as typeof import('node:module');
-      const req = createRequire(__filename);
-      const session = req('../ipc/session') as typeof import('../ipc/session');
-      resolved = session.getSessionManager();
-    }
+    const resolved = manager ?? getSessionManager();
     const root = findRootAgentsMdEntry(runtime.projectDir, runtime.config);
     if (root) {
       resolved.getAgentsMdContextStore(sessionId, agentScopeId).seedRoot(root);

--- a/electron/src/main/project/agents-md.ts
+++ b/electron/src/main/project/agents-md.ts
@@ -15,6 +15,7 @@ import {
 } from '../agents-md/resolver';
 import type { Config } from '../config/schema';
 import type { ProjectRuntime } from './runtime';
+import type { SessionManager } from '../session/manager';
 
 /**
  * Find the root instruction file governing the workspace, or null when the
@@ -60,4 +61,42 @@ export function appendRootAgentsMd(
     ? `\n[truncated to ${maxBytes} bytes — use read for the full file]\n`
     : '';
   return `${agentSystemPrompt}\n\n## Project instructions (${entry.displayPath})\n\n${content}\n${note}`;
+}
+
+/**
+ * Seed a subagent's scope-keyed tracker with the root instruction file
+ * (R13/R15). A subagent starts fresh with only the root — it never inherits the
+ * parent's seen nested files — so the nested read-path mechanism never
+ * re-injects the root for it (R4). Because the store is keyed by session AND
+ * agent scope (U2), seeding the subagent's scope does not touch the parent's
+ * store. Non-fatal: a seeding failure must never break subagent startup.
+ *
+ * The session manager is resolved lazily via `createRequire` (mirroring
+ * build-prompt-context.ts and tool-dispatch.ts) to avoid a circular init with
+ * session/tools; tests may inject a constructed manager directly.
+ */
+export function seedSubagentRootAgentsMd(
+  sessionId: string | undefined,
+  agentScopeId: string,
+  runtime: ProjectRuntime,
+  manager?: SessionManager,
+): void {
+  if (!sessionId) return;
+  try {
+    let resolved = manager;
+    if (!resolved) {
+      // Lazy require avoids circular init with session/tools.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { createRequire } = require('node:module') as typeof import('node:module');
+      const req = createRequire(__filename);
+      const session = req('../ipc/session') as typeof import('../ipc/session');
+      resolved = session.getSessionManager();
+    }
+    const root = findRootAgentsMdEntry(runtime.projectDir, runtime.config);
+    if (root) {
+      resolved.getAgentsMdContextStore(sessionId, agentScopeId).seedRoot(root);
+    }
+  } catch (err) {
+    console.debug('seedSubagentRootAgentsMd AGENTS.md context failed (non-fatal):', err);
+  }
 }

--- a/electron/src/main/session/agents-md-context.ts
+++ b/electron/src/main/session/agents-md-context.ts
@@ -1,0 +1,81 @@
+/**
+ * AgentsMdContextStore — per-session tracker of which AGENTS.md files are
+ * already in the LLM context.
+ *
+ * Identity is the canonical (symlink-resolved) path carried by `AgentsMdEntry`,
+ * so relative and symlinked variants of one file dedupe to a single entry
+ * (R14). Each tracked path records the mtime it was seen at so a file that
+ * changes on disk is detected as stale and re-injected on next encounter
+ * (R16).
+ *
+ * The store is ephemeral — in-memory only, never persisted to the session
+ * file — because the LLM context is rebuilt on reload anyway. This is a
+ * deliberate difference from TodoStore (which has toData/fromData).
+ */
+import type { AgentsMdEntry } from '../agents-md/resolver';
+
+/** What the tracker remembers per canonical path. */
+interface SeenRecord {
+  mtimeMs: number;
+  sizeBytes: number;
+}
+
+/**
+ * In-memory, per-session, scope-aware set of AGENTS.md files in context.
+ *
+ * Callers pass `entry.path` (already canonical) — the store never
+ * re-canonicalizes. A fresh store is empty; the root file is seeded by the
+ * caller at session start (R13) so the nested mechanism never re-injects it
+ * (R4).
+ */
+export class AgentsMdContextStore {
+  private _seen = new Map<string, SeenRecord>();
+
+  /** Record an instruction file as present in context (canonical path identity). */
+  markSeen(entry: AgentsMdEntry): void {
+    this._seen.set(entry.path, {
+      mtimeMs: entry.mtimeMs,
+      sizeBytes: entry.sizeBytes,
+    });
+  }
+
+  /**
+   * Seed the root instruction file (R13). Semantically the session-start seed;
+   * delegates to markSeen. Provided for call-site clarity.
+   */
+  seedRoot(entry: AgentsMdEntry): void {
+    this.markSeen(entry);
+  }
+
+  /** Whether a canonical path has been seen at all (R14 membership). */
+  isSeen(canonicalPath: string): boolean {
+    return this._seen.has(canonicalPath);
+  }
+
+  /**
+   * Whether a seen entry is still current: seen AND the recorded mtime equals
+   * the entry's mtime (R16). A seen-but-changed file is not fresh.
+   */
+  isFresh(entry: AgentsMdEntry): boolean {
+    const record = this._seen.get(entry.path);
+    return record !== undefined && record.mtimeMs === entry.mtimeMs;
+  }
+
+  /**
+   * Entries not yet in context — unseen OR stale — preserving input order.
+   * The primitive the read-path injection and write-path enforcement use.
+   */
+  unseen(chain: AgentsMdEntry[]): AgentsMdEntry[] {
+    return chain.filter((entry) => !this.isFresh(entry));
+  }
+
+  /** Reset all tracked entries. */
+  clear(): void {
+    this._seen.clear();
+  }
+
+  /** Number of tracked canonical paths (for tests/debugging). */
+  get size(): number {
+    return this._seen.size;
+  }
+}

--- a/electron/src/main/session/agents-md-context.ts
+++ b/electron/src/main/session/agents-md-context.ts
@@ -53,12 +53,17 @@ export class AgentsMdContextStore {
   }
 
   /**
-   * Whether a seen entry is still current: seen AND the recorded mtime equals
-   * the entry's mtime (R16). A seen-but-changed file is not fresh.
+   * Whether a seen entry is still current: seen AND the recorded mtime and
+   * size both equal the entry's values (R16). A seen-but-changed file is not
+   * fresh.
    */
   isFresh(entry: AgentsMdEntry): boolean {
     const record = this._seen.get(entry.path);
-    return record !== undefined && record.mtimeMs === entry.mtimeMs;
+    return (
+      record !== undefined &&
+      record.mtimeMs === entry.mtimeMs &&
+      record.sizeBytes === entry.sizeBytes
+    );
   }
 
   /**

--- a/electron/src/main/session/manager.ts
+++ b/electron/src/main/session/manager.ts
@@ -26,11 +26,13 @@ import type { ModelSelection } from '../../shared/types/provider';
 import type { Message } from '../../shared/types/message';
 import { ChainStatus, type Chain } from '../../shared/types/chain';
 import type { PermissionMode } from '../../shared/types/permission';
+import { normalizeAgentScopeId } from '../../shared/types/agent-scope';
 import {
   canonicalizeProjectDirectory,
   inspectProjectDirectory,
 } from '../project/path';
 import { TodoStore } from '../tools/todo/store';
+import { AgentsMdContextStore } from './agents-md-context';
 import {
   appendActiveChain as storageAppendActiveChain,
   finishChain as storageFinishChain,
@@ -94,10 +96,17 @@ export class SessionManager {
   private _sessions = new Map<string, Session>();
   /** Mutable todo stores are owned by session id, never by the selected window. */
   private _todoStores = new Map<string, TodoStore>();
+  /**
+   * Ephemeral AGENTS.md context trackers keyed by `sessionId::agentScope`, so
+   * the main agent and each subagent get separate stores (R15). Never persisted.
+   */
+  private _agentsMdStores = new Map<string, AgentsMdContextStore>();
   /** Selection is view state: each window/owner may point at a different session. */
   private _selectedByOwner = new Map<string, string>();
   /** Empty compatibility store returned when the default owner has no selection. */
   private _emptyTodoStore: TodoStore = new TodoStore();
+  /** Empty compatibility AGENTS.md store returned when no session is active. */
+  private _emptyAgentsMdStore: AgentsMdContextStore = new AgentsMdContextStore();
   private _generateTitle: GenerateTitleCallback | null = null;
   private _storageOpts: StorageOptions | undefined;
 
@@ -196,6 +205,44 @@ export class SessionManager {
   }
 
   /**
+   * Live AGENTS.md context store for the active session and agent scope.
+   *
+   * Always returns a store (the shared empty fallback when no session is
+   * active) so callers resolve without null checks. The store is ephemeral —
+   * never persisted — and is keyed by session id AND agent scope so each
+   * subagent starts fresh (R15).
+   */
+  getActiveAgentsMdContextStore(
+    ownerId?: string,
+    agentScopeId?: string,
+  ): AgentsMdContextStore {
+    const sessionId = this.selectedSessionId(ownerId);
+    return sessionId
+      ? this.getAgentsMdContextStore(sessionId, agentScopeId)
+      : this._emptyAgentsMdStore;
+  }
+
+  /**
+   * Resolve the ephemeral AGENTS.md context store for an explicit session and
+   * agent scope, lazily creating and caching it. The composite key isolates the
+   * main agent from each subagent (R15); an omitted scope normalizes to main so
+   * main-agent callers need no change. Unlike getTodoStore, this does not call
+   * ensureSession — the store is in-memory only and needs no session on disk.
+   */
+  getAgentsMdContextStore(
+    sessionId: string,
+    agentScopeId?: string,
+  ): AgentsMdContextStore {
+    const key = `${sessionId}::${normalizeAgentScopeId(agentScopeId)}`;
+    let store = this._agentsMdStores.get(key);
+    if (!store) {
+      store = new AgentsMdContextStore();
+      this._agentsMdStores.set(key, store);
+    }
+    return store;
+  }
+
+  /**
    * Snapshot the live todo store into the active session and save to disk.
    * No-op when there is no active session.
    */
@@ -234,7 +281,10 @@ export class SessionManager {
    */
   clearActive(ownerId?: string): void {
     this._selectedByOwner.delete(this.ownerKey(ownerId));
-    if (ownerId === undefined) this._emptyTodoStore = new TodoStore();
+    if (ownerId === undefined) {
+      this._emptyTodoStore = new TodoStore();
+      this._emptyAgentsMdStore = new AgentsMdContextStore();
+    }
   }
 
   /**
@@ -319,6 +369,10 @@ export class SessionManager {
     const result = storageDeleteSession(id, this._storageOpts);
     this._sessions.delete(id);
     this._todoStores.delete(id);
+    // Drop every agent-scope store owned by this session (composite keys).
+    for (const key of [...this._agentsMdStores.keys()]) {
+      if (key.startsWith(`${id}::`)) this._agentsMdStores.delete(key);
+    }
     for (const [owner, selectedId] of this._selectedByOwner) {
       if (selectedId === id) this._selectedByOwner.delete(owner);
     }

--- a/electron/src/main/tools/filesystem/apply-patch.ts
+++ b/electron/src/main/tools/filesystem/apply-patch.ts
@@ -12,7 +12,6 @@ import { RiskClass } from '../../../shared/types/permission';
 import { resolveToolPath } from '../types';
 import {
   renderXmlToolResult,
-  xmlTextElement,
   escapeXmlText,
   escapeXmlAttribute,
   projectionWithCanonicalCompleteness,
@@ -83,33 +82,7 @@ const applyPatchAgentProjector: AgentProjector = (canonical, toolName = 'apply_p
       return `<file${attrString}>\n<error code="${escapeXmlAttribute(file.error.code)}">${escapeXmlText(file.error.message)}</error>\n</file>`;
     }
 
-    if (!file.fileChange) {
-      return `<file${attrString}>\n</file>`;
-    }
-
-    const oldParts: string[] = [];
-    const newParts: string[] = [];
-    for (const hunk of file.fileChange.hunks) {
-      for (const line of hunk.lines) {
-        if (line.kind === 'context') {
-          oldParts.push(line.content);
-          newParts.push(line.content);
-        } else if (line.kind === 'remove') {
-          oldParts.push(line.content);
-        } else {
-          newParts.push(line.content);
-        }
-      }
-    }
-
-    const bodyParts: string[] = [];
-    if (oldParts.length > 0) bodyParts.push(xmlTextElement('old_string', oldParts.join('\n')));
-    if (newParts.length > 0) bodyParts.push(xmlTextElement('new_string', newParts.join('\n')));
-
-    if (bodyParts.length === 0) {
-      return `<file${attrString}>\n</file>`;
-    }
-    return `<file${attrString}>\n${bodyParts.join('\n')}\n</file>`;
+    return `<file${attrString} />`;
   });
 
   const body = [summary, ...fileSections].join('\n');

--- a/electron/src/main/tools/result.ts
+++ b/electron/src/main/tools/result.ts
@@ -405,8 +405,16 @@ function renderReplaceSymbolPayload(record: Record<string, JsonValue>): string {
     for (const item of record.items) {
       if (item && typeof item === 'object' && !Array.isArray(item)) {
         const entry = item as Record<string, JsonValue>;
-        if (typeof entry.oldString === 'string') parts.push(xmlTextElement('old_string', entry.oldString));
-        if (typeof entry.newString === 'string') parts.push(xmlTextElement('new_string', entry.newString));
+        const itemAttrs: string[] = [];
+        if (typeof entry.file === 'string') itemAttrs.push('file="' + escapeXmlAttribute(entry.file) + '"');
+        if (typeof entry.symbol === 'string') itemAttrs.push('symbol="' + escapeXmlAttribute(entry.symbol) + '"');
+        if (typeof entry.status === 'string') itemAttrs.push('status="' + escapeXmlAttribute(entry.status) + '"');
+        if (typeof entry.line === 'number') itemAttrs.push('line="' + entry.line + '"');
+        if (typeof entry.error === 'string') {
+          parts.push('<item ' + itemAttrs.join(' ') + '>' + xmlTextElement('error', entry.error) + '</item>');
+        } else if (itemAttrs.length > 0) {
+          parts.push('<item ' + itemAttrs.join(' ') + ' />');
+        }
       }
     }
   }
@@ -529,56 +537,27 @@ export function genericBuiltInToolOutcome(
 
 const fileChangeAgentProjector: AgentProjector = (canonical, toolName = 'edit') => {
   const parsed = fileChangeDataSchema.parse(canonical.data);
-  const oldParts: string[] = [];
-  const newParts: string[] = [];
-  for (const hunk of parsed.hunks) {
-    for (const line of hunk.lines) {
-      if (line.kind === 'context') {
-        oldParts.push(line.content);
-        newParts.push(line.content);
-      } else if (line.kind === 'remove') {
-        oldParts.push(line.content);
-      } else {
-        newParts.push(line.content);
-      }
-    }
-  }
-  const oldString = oldParts.join('\n');
-  const newString = newParts.join('\n');
-  const body = oldString.length > 0 || newString.length > 0
-    ? [
-        oldString.length > 0 ? xmlTextElement('old_string', oldString) : '',
-        newString.length > 0 ? xmlTextElement('new_string', newString) : '',
-      ].filter((part) => part.length > 0).join('\n')
-    : xmlTextElement('data', serializeCanonicalResultForCopy(canonical));
+  const replacements = parsed.replacementCount ?? (parsed.hunks.length > 0 ? parsed.hunks.length : 1);
+  const summary = `${parsed.path}: ${replacements} replacement${replacements === 1 ? '' : 's'}`;
   return projectionWithCanonicalCompleteness(
     canonical,
-    renderXmlToolResult(toolName, canonical, body, {
+    renderXmlToolResult(toolName, canonical, summary, {
       path: parsed.path,
-      replacements: parsed.hunks.length > 0 ? parsed.hunks.length : undefined,
+      replacements,
+      ...(parsed.replaceAll ? { replace_all: true } : {}),
     }, undefined, true),
   );
 };
 
-/**
- * Full write content for the agent: path/lines/bytes live in attributes;
- * body is the complete written content.
- */
-function writeAgentPreviewBody(content: string, lineCount: number): string {
-  if (content.length === 0 || lineCount === 0) {
-    return '';
-  }
-  return xmlTextElement('preview', content);
-}
-
 const fileWriteAgentProjector: AgentProjector = (canonical, toolName = 'write') => {
   const parsed = fileWriteDataSchema.parse(canonical.data);
+  const summary = `${parsed.path}: ${parsed.lineCount} line${parsed.lineCount === 1 ? '' : 's'}, ${parsed.byteCount} bytes`;
   return projectionWithCanonicalCompleteness(
     canonical,
     renderXmlToolResult(
       toolName,
       canonical,
-      writeAgentPreviewBody(parsed.content, parsed.lineCount),
+      summary,
       {
         path: parsed.path,
         operation: parsed.operation,

--- a/electron/src/main/tools/result.ts
+++ b/electron/src/main/tools/result.ts
@@ -374,13 +374,15 @@ function renderWebFetchPayload(record: Record<string, JsonValue>): string {
 
 function renderDelegateToSubagentPayload(record: Record<string, JsonValue>): string {
   if (typeof record.error === 'string') return '';
+  // The task is intentionally omitted: it already lives in the delegate
+  // tool-call args (message history) and is re-injected every turn via the
+  // dynamic system prompt's <subagents> section. Re-sending it here would
+  // duplicate it on every delegation.
   return '<subagent id="' + escapeXmlAttribute(record.id) +
     '" name="' + escapeXmlAttribute(record.name) +
     '" type="' + escapeXmlAttribute(record.type) +
     '" status="' + escapeXmlAttribute(record.status) +
-    '" tier="' + escapeXmlAttribute(record.tier) + '">' +
-    xmlTextElement('task', typeof record.task === 'string' ? record.task : '') +
-    '</subagent>';
+    '" tier="' + escapeXmlAttribute(record.tier) + '" />';
 }
 
 function renderReplaceSymbolPayload(record: Record<string, JsonValue>): string {

--- a/electron/src/main/tools/subagent/wait.ts
+++ b/electron/src/main/tools/subagent/wait.ts
@@ -81,23 +81,23 @@ function formatRecordXml(sid: string, record: SubagentRecord): string {
     '" status="' + escapeXmlAttribute(status) + '"' +
     (elapsed !== null ? ' elapsed="' + escapeXmlAttribute(formatElapsed(elapsed)) + '"' : '');
 
-  const taskBlock = record.task
-    ? '<task>' + escapeXmlText(record.task) + '</task>'
-    : '';
-
+  // The task is intentionally omitted: it already lives in the delegate
+  // tool-call args (message history) and is re-injected every turn via the
+  // dynamic system prompt's <subagents> section. Re-sending it here would
+  // duplicate it on every wait call.
   if (record.pendingQuestion) {
-    return '<subagent ' + attrs + '>' + taskBlock +
+    return '<subagent ' + attrs + '>' +
       formatPendingQuestion(record.pendingQuestion) + '</subagent>';
   }
   if (record.result) {
-    return '<subagent ' + attrs + '>' + taskBlock +
+    return '<subagent ' + attrs + '>' +
       '<result>' + escapeXmlText(record.result) + '</result></subagent>';
   }
   if (record.error) {
-    return '<subagent ' + attrs + '>' + taskBlock +
+    return '<subagent ' + attrs + '>' +
       '<error>' + escapeXmlText(record.error) + '</error></subagent>';
   }
-  return '<subagent ' + attrs + '>' + taskBlock + '</subagent>';
+  return '<subagent ' + attrs + '></subagent>';
 }
 
 function formatSubagentRecords(

--- a/electron/src/renderer/utils/config-draft.ts
+++ b/electron/src/renderer/utils/config-draft.ts
@@ -3,7 +3,7 @@ import type { ConfigPatch, ConfigPatchMap } from '../../shared/types/ipc';
 import type { ModelSelection } from '../../shared/types/provider';
 
 /** Nested ConfigPatch keys that need specialized merge (not scalar assign). */
-type NestedPatchKey = 'rag' | 'tier_models' | 'tier_reasoning_effort' | 'mcp_servers' | 'providers' | 'permissions';
+type NestedPatchKey = 'rag' | 'agents_md' | 'tier_models' | 'tier_reasoning_effort' | 'mcp_servers' | 'providers' | 'permissions';
 
 /** Scalar / nullable top-level patch keys applied with simple defined-assign. */
 type ScalarPatchKey = Exclude<keyof ConfigPatch, NestedPatchKey>;
@@ -31,6 +31,9 @@ export function mergeConfigDraft(
   }
   if (updates.rag !== undefined) {
     next.rag = { ...(current.rag ?? {}), ...updates.rag };
+  }
+  if (updates.agents_md !== undefined) {
+    next.agents_md = { ...(current.agents_md ?? {}), ...updates.agents_md };
   }
   return next;
 }
@@ -93,6 +96,10 @@ export function applyConfigDraft(base: Config, draft: ConfigPatch): Config {
     };
   }
 
+  if (draft.agents_md !== undefined) {
+    next.agents_md = { ...base.agents_md, ...draft.agents_md };
+  }
+
   if (draft.tier_models !== undefined) {
     next.tier_models = applySelectionMap(base.tier_models, draft.tier_models);
   }
@@ -119,6 +126,7 @@ export function applyConfigDraft(base: Config, draft: ConfigPatch): Config {
 function isNestedPatchKey(key: keyof ConfigPatch): key is NestedPatchKey {
   return (
     key === 'rag' ||
+    key === 'agents_md' ||
     key === 'tier_models' ||
     key === 'tier_reasoning_effort' ||
     key === 'mcp_servers' ||

--- a/electron/src/shared/types/ipc-boundary.ts
+++ b/electron/src/shared/types/ipc-boundary.ts
@@ -80,6 +80,25 @@ export interface RAGConfig {
   embedding_api_model: ModelSelection | null;
 }
 
+/** Write-enforcement policy applied when a governing AGENTS.md is not in context. */
+export type AgentsMdEnforcePolicy = 'block' | 'inject' | 'warn' | 'off';
+
+/**
+ * AGENTS.md discovery, injection, and write-enforcement settings. See the
+ * `agents_md` block in the config schema for field defaults.
+ */
+export interface AgentsMdConfig {
+  enabled: boolean;
+  /** Ordered instruction-file aliases; first present per directory wins. */
+  filenames: string[];
+  max_file_bytes: number;
+  max_chain_depth: number;
+  enforce_on_write: AgentsMdEnforcePolicy;
+  inject_on_read: boolean;
+  /** When true, also consider `AGENTS.local.md` as a lowest-precedence alias. */
+  include_local: boolean;
+}
+
 /** Non-secret notice about provider compatibility state discarded on load. */
 export interface ConfigDiagnostic {
   readonly code: 'legacy-provider-config-reset';
@@ -111,6 +130,7 @@ export interface Config {
   theme: string;
   personality: string;
   rag: RAGConfig;
+  agents_md: AgentsMdConfig;
   ast_max_file_size: number;
   mcp_startup_timeout: number;
   mcp_per_server_timeout: number;

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -48,6 +48,7 @@ import type {
   ASTIndexProgress,
   IndexRunState,
   RAGConfig,
+  AgentsMdConfig,
   PermissionModeValue,
   PermissionRule,
 } from './ipc-boundary';
@@ -79,6 +80,7 @@ export type {
   ASTIndexProgress,
   IndexRunState,
   RAGConfig,
+  AgentsMdConfig,
   PermissionModeValue,
   PermissionRule,
   UpdaterState,
@@ -338,6 +340,7 @@ export type ConfigPatch = {
   rag?: Partial<RAGConfig> & {
     embedding_api_model?: ModelSelection | null;
   };
+  agents_md?: Partial<AgentsMdConfig>;
   ast_max_file_size?: number;
   mcp_startup_timeout?: number;
   mcp_per_server_timeout?: number;

--- a/electron/tests/integration/architecture-validation.test.ts
+++ b/electron/tests/integration/architecture-validation.test.ts
@@ -340,6 +340,57 @@ describe('Architecture Properties (real modules)', () => {
       expect(manager.getRecord(a.id)?.state).toBe(SubagentState.COMPLETED);
       expect(manager.getRecord(b.id)?.state).toBe(SubagentState.COMPLETED);
     });
+
+    it('returns only the last step text as the result, not full narration', async () => {
+      const manager = new SubagentManager();
+      manager.setRunner(async function* (): AsyncGenerator<StreamEvent> {
+        yield { type: 'content', text: 'Let me search the codebase.' };
+        yield { type: 'step_finish', stepIndex: 0, finishReason: 'tool-calls' };
+        yield { type: 'content', text: 'Reading the file now.' };
+        yield { type: 'step_finish', stepIndex: 1, finishReason: 'tool-calls' };
+        yield { type: 'content', text: 'Here is the final answer.' };
+        yield { type: 'step_finish', stepIndex: 2, finishReason: 'stop' };
+        yield { type: 'finish', finishReason: 'stop' };
+      });
+
+      const record = manager.spawn('s', 'multi-step task', testAgent);
+      await manager.wait([record.id]);
+
+      const result = manager.getRecord(record.id)?.result;
+      expect(result).toBe('Here is the final answer.');
+      expect(result).not.toContain('Let me search');
+      expect(result).not.toContain('Reading the file');
+    });
+
+    it('keeps the last text-bearing step when the final step is tool-only', async () => {
+      const manager = new SubagentManager();
+      manager.setRunner(async function* (): AsyncGenerator<StreamEvent> {
+        yield { type: 'content', text: 'The answer is 42.' };
+        yield { type: 'step_finish', stepIndex: 0, finishReason: 'tool-calls' };
+        // Trailing step performs a tool call and emits no text.
+        yield { type: 'step_finish', stepIndex: 1, finishReason: 'stop' };
+        yield { type: 'finish', finishReason: 'stop' };
+      });
+
+      const record = manager.spawn('s', 'trailing tool task', testAgent);
+      await manager.wait([record.id]);
+
+      expect(manager.getRecord(record.id)?.result).toBe('The answer is 42.');
+    });
+
+    it('falls back to full accumulation when no step boundaries are emitted', async () => {
+      const manager = new SubagentManager();
+      manager.setRunner(async function* (): AsyncGenerator<StreamEvent> {
+        yield { type: 'content', text: 'hello ' };
+        yield { type: 'content', text: 'world' };
+        yield { type: 'finish', finishReason: 'stop' };
+      });
+
+      const record = manager.spawn('s', 'no-step task', testAgent);
+      await manager.wait([record.id]);
+
+      expect(manager.getRecord(record.id)?.result).toBe('hello world');
+    });
   });
 
   describe('3. Responsive control during stream', () => {

--- a/electron/tests/parity/config.test.ts
+++ b/electron/tests/parity/config.test.ts
@@ -12,7 +12,7 @@ const DEFAULT_SELECTION = {
   modelId: 'vendor/models/gpt-4o',
 };
 
-// ── Expected config fields (43 total) ──────────────────────────────────────
+// ── Expected config fields (41 total) ──────────────────────────────────────
 
 interface ConfigFieldExpectation {
   field: string;
@@ -66,6 +66,7 @@ const EXPECTED_FIELDS: ConfigFieldExpectation[] = [
     envOverride: 'ORCHID_PERSONALITY',
   },
   { field: 'rag', type: 'object', defaultValue: undefined }, // nested, checked separately
+  { field: 'agents_md', type: 'object', defaultValue: undefined }, // nested, checked separately
   {
     field: 'ast_max_file_size',
     type: 'number',
@@ -224,6 +225,16 @@ const EXPECTED_FIELDS: ConfigFieldExpectation[] = [
   },
 ];
 
+const EXPECTED_AGENTS_MD_FIELDS = [
+  { field: 'enabled', type: 'boolean', defaultValue: true },
+  { field: 'filenames', type: 'array', defaultValue: ['AGENTS.md', 'CLAUDE.md'] },
+  { field: 'max_file_bytes', type: 'number', defaultValue: 32768 },
+  { field: 'max_chain_depth', type: 'number', defaultValue: 8 },
+  { field: 'enforce_on_write', type: 'string', defaultValue: 'warn' },
+  { field: 'inject_on_read', type: 'boolean', defaultValue: true },
+  { field: 'include_local', type: 'boolean', defaultValue: false },
+];
+
 const EXPECTED_RAG_FIELDS = [
   { field: 'chunk_size', type: 'number', defaultValue: 2000, envOverride: 'ORCHID_RAG_CHUNK_SIZE' },
   {
@@ -290,6 +301,7 @@ describe('Config Parity', () => {
       expect(cfg).toHaveProperty('theme');
       expect(cfg).toHaveProperty('personality');
       expect(cfg).toHaveProperty('rag');
+      expect(cfg).toHaveProperty('agents_md');
       expect(cfg).toHaveProperty('ast_max_file_size');
       expect(cfg).toHaveProperty('mcp_startup_timeout');
       expect(cfg).toHaveProperty('mcp_per_server_timeout');
@@ -330,17 +342,30 @@ describe('Config Parity', () => {
       expect(cfg.rag).toHaveProperty('embedding_model');
       expect(cfg.rag).toHaveProperty('embedding_api_timeout');
       expect(cfg.rag).toHaveProperty('embedding_api_retries');
+
+      // AGENTS.md nested fields (7)
+      expect(cfg.agents_md).toHaveProperty('enabled');
+      expect(cfg.agents_md).toHaveProperty('filenames');
+      expect(cfg.agents_md).toHaveProperty('max_file_bytes');
+      expect(cfg.agents_md).toHaveProperty('max_chain_depth');
+      expect(cfg.agents_md).toHaveProperty('enforce_on_write');
+      expect(cfg.agents_md).toHaveProperty('inject_on_read');
+      expect(cfg.agents_md).toHaveProperty('include_local');
     });
 
-    it('top-level field count matches expected (44 top-level + 10 rag nested fields)', () => {
+    it('top-level field count matches expected (45 top-level + 10 rag nested + 7 agents_md nested fields)', () => {
       const cfg = defaults();
       // Top-level keys count
       const topLevelKeys = Object.keys(cfg);
-      expect(topLevelKeys).toHaveLength(44); // 44 top-level fields (rag is nested)
+      expect(topLevelKeys).toHaveLength(45); // 45 top-level fields (rag, agents_md are nested)
 
       // RAG nested keys count
       const ragKeys = Object.keys(cfg.rag);
       expect(ragKeys).toHaveLength(10);
+
+      // AGENTS.md nested keys count
+      const agentsMdKeys = Object.keys(cfg.agents_md);
+      expect(agentsMdKeys).toHaveLength(7);
     });
   });
 
@@ -366,6 +391,17 @@ describe('Config Parity', () => {
           cfg.rag[expected.field as keyof typeof cfg.rag],
           `RAG field '${expected.field}' default`,
         ).toBe(expected.defaultValue);
+      }
+    });
+
+    it('agents_md nested fields have correct defaults', () => {
+      const cfg = defaults();
+
+      for (const expected of EXPECTED_AGENTS_MD_FIELDS) {
+        expect(
+          cfg.agents_md[expected.field as keyof typeof cfg.agents_md],
+          `AGENTS.md field '${expected.field}' default`,
+        ).toEqual(expected.defaultValue);
       }
     });
 

--- a/electron/tests/unit/agents-md-context.test.ts
+++ b/electron/tests/unit/agents-md-context.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Per-session AGENTS.md context tracker tests (U2).
+ *
+ * Covers the ephemeral AgentsMdContextStore (canonical-path membership,
+ * order-preserving unseen(), mtime staleness, root seeding, clear) and the
+ * SessionManager wiring: scope-keyed isolation so subagents start fresh (R15),
+ * the active-store accessor, and the safe empty fallback for the no-session case.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { AgentsMdContextStore } from '../../src/main/session/agents-md-context';
+import { SessionManager } from '../../src/main/session/manager';
+import { _clearDbCache } from '../../src/main/session/storage';
+import type { AgentsMdEntry } from '../../src/main/agents-md/resolver';
+
+function makeEntry(
+  filePath: string,
+  mtimeMs = 1000,
+  tier: 'root' | 'nested' = 'nested',
+): AgentsMdEntry {
+  return { path: filePath, displayPath: filePath, tier, sizeBytes: 42, mtimeMs };
+}
+
+describe('AgentsMdContextStore', () => {
+  it('markSeen records canonical-path membership', () => {
+    const store = new AgentsMdContextStore();
+    const entry = makeEntry('/ws/pkg/AGENTS.md');
+    expect(store.isSeen(entry.path)).toBe(false);
+
+    store.markSeen(entry);
+    expect(store.isSeen(entry.path)).toBe(true);
+    expect(store.isSeen('/ws/other/AGENTS.md')).toBe(false);
+    expect(store.size).toBe(1);
+  });
+
+  it('unseen returns only not-yet-seen entries, preserving input order', () => {
+    const store = new AgentsMdContextStore();
+    const a = makeEntry('/ws/a/AGENTS.md');
+    const b = makeEntry('/ws/b/AGENTS.md');
+    const c = makeEntry('/ws/c/AGENTS.md');
+    const chain = [a, b, c];
+
+    expect(store.unseen(chain)).toEqual([a, b, c]);
+
+    store.markSeen(b);
+    expect(store.unseen(chain)).toEqual([a, c]);
+
+    store.markSeen(a);
+    store.markSeen(c);
+    expect(store.unseen(chain)).toEqual([]);
+  });
+
+  it('detects staleness by mtime (R16)', () => {
+    const store = new AgentsMdContextStore();
+    const p = '/ws/AGENTS.md';
+    store.markSeen(makeEntry(p, 1000));
+    expect(store.isFresh(makeEntry(p, 1000))).toBe(true);
+
+    // Same path, newer mtime → seen but not fresh, so still returned by unseen.
+    const changed = makeEntry(p, 1001);
+    expect(store.isFresh(changed)).toBe(false);
+    expect(store.unseen([changed])).toEqual([changed]);
+
+    // Re-marking at the new mtime makes it fresh again.
+    store.markSeen(changed);
+    expect(store.isFresh(makeEntry(p, 1001))).toBe(true);
+    expect(store.unseen([changed])).toEqual([]);
+  });
+
+  it('a never-seen entry is not fresh', () => {
+    const store = new AgentsMdContextStore();
+    expect(store.isFresh(makeEntry('/ws/AGENTS.md'))).toBe(false);
+  });
+
+  it('seedRoot marks the root seen so unseen excludes it (R13/R4)', () => {
+    const store = new AgentsMdContextStore();
+    const root = makeEntry('/ws/AGENTS.md', 1000, 'root');
+    const nested = makeEntry('/ws/pkg/AGENTS.md', 1000, 'nested');
+
+    store.seedRoot(root);
+    expect(store.isSeen(root.path)).toBe(true);
+    // Nearest-first chain: the seeded root is filtered out, the nested file remains.
+    expect(store.unseen([nested, root])).toEqual([nested]);
+  });
+
+  it('clear empties the store', () => {
+    const store = new AgentsMdContextStore();
+    store.markSeen(makeEntry('/ws/a/AGENTS.md'));
+    store.markSeen(makeEntry('/ws/b/AGENTS.md'));
+    expect(store.size).toBe(2);
+
+    store.clear();
+    expect(store.size).toBe(0);
+    expect(store.isSeen('/ws/a/AGENTS.md')).toBe(false);
+  });
+
+  it('dedupes by canonical path regardless of displayPath (R14)', () => {
+    const store = new AgentsMdContextStore();
+    store.markSeen({ ...makeEntry('/ws/AGENTS.md'), displayPath: 'AGENTS.md' });
+    store.markSeen({ ...makeEntry('/ws/AGENTS.md'), displayPath: '../ws/AGENTS.md' });
+    expect(store.size).toBe(1);
+  });
+});
+
+describe('SessionManager agents-md scope isolation (R15)', () => {
+  it('main and subagent scopes get separate store instances', () => {
+    const manager = new SessionManager();
+    const main = manager.getAgentsMdContextStore('session-1', 'main');
+    const sub = manager.getAgentsMdContextStore('session-1', 'sub-1');
+    expect(main).not.toBe(sub);
+
+    const entry = makeEntry('/ws/pkg/AGENTS.md');
+    main.markSeen(entry);
+    expect(main.isSeen(entry.path)).toBe(true);
+    // The subagent starts fresh — parent's seen-set is not inherited.
+    expect(sub.isSeen(entry.path)).toBe(false);
+  });
+
+  it('omitted scope normalizes to main (same instance as explicit main)', () => {
+    const manager = new SessionManager();
+    const omitted = manager.getAgentsMdContextStore('session-1');
+    const explicitMain = manager.getAgentsMdContextStore('session-1', 'main');
+    expect(omitted).toBe(explicitMain);
+  });
+
+  it('returns the cached instance for the same session and scope', () => {
+    const manager = new SessionManager();
+    const first = manager.getAgentsMdContextStore('session-1', 'sub-1');
+    const second = manager.getAgentsMdContextStore('session-1', 'sub-1');
+    expect(first).toBe(second);
+  });
+
+  it('isolates stores across sessions', () => {
+    const manager = new SessionManager();
+    const a = manager.getAgentsMdContextStore('session-1', 'main');
+    const b = manager.getAgentsMdContextStore('session-2', 'main');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('getActiveAgentsMdContextStore', () => {
+  let tmpDir: string;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-session-'));
+    manager = new SessionManager({
+      storage: { dbPath: path.join(tmpDir, 'sessions.db') },
+    });
+  });
+
+  afterEach(() => {
+    _clearDbCache();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns the shared empty fallback when no session is active', () => {
+    const first = manager.getActiveAgentsMdContextStore();
+    const second = manager.getActiveAgentsMdContextStore();
+    expect(first).toBe(second);
+    expect(first.size).toBe(0);
+  });
+
+  it('returns the scope store when a session is active', () => {
+    const session = manager.create('default/mimo-v2.5');
+
+    const active = manager.getActiveAgentsMdContextStore();
+    expect(active).toBe(manager.getAgentsMdContextStore(session.id, 'main'));
+
+    const sub = manager.getActiveAgentsMdContextStore(undefined, 'sub-1');
+    expect(sub).toBe(manager.getAgentsMdContextStore(session.id, 'sub-1'));
+    expect(sub).not.toBe(active);
+  });
+
+  it('empty fallback is safe and reports nothing in context', () => {
+    const store = manager.getActiveAgentsMdContextStore();
+    const entry = makeEntry('/ws/AGENTS.md');
+
+    expect(store.isSeen(entry.path)).toBe(false);
+    expect(store.unseen([entry])).toEqual([entry]);
+    expect(() => store.markSeen(entry)).not.toThrow();
+    expect(() => store.isSeen(entry.path)).not.toThrow();
+    expect(() => store.unseen([entry])).not.toThrow();
+  });
+});

--- a/electron/tests/unit/agents-md-enforcement.test.ts
+++ b/electron/tests/unit/agents-md-enforcement.test.ts
@@ -26,6 +26,7 @@ import {
 } from '../../src/main/agents-md/enforce';
 import { resolveAgentsMdChain } from '../../src/main/agents-md/resolver';
 import { AgentsMdContextStore } from '../../src/main/session/agents-md-context';
+import type { ToolHandler } from '../../src/main/tools/types';
 
 /** Build a full Config with `agents_md` overrides applied over the defaults. */
 function agentsConfig(overrides: Partial<AgentsMdConfig> = {}): Config {
@@ -230,6 +231,49 @@ describe('evaluateAgentsMdEnforcement', () => {
     );
   });
 
+  it('still enforces a co-edited sibling when an instruction-file edit is bundled (F4)', () => {
+    write('pkg/AGENTS.md', 'pkg instructions');
+    write('pkg/secret.ts', 'code');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+    // Bundle a trivial edit to the instruction file with a real edit to a sibling
+    // it governs. The bundled self-edit must NOT exempt the file as a governing
+    // file for the sibling target (the old global exemption defeated `block`).
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: pkg/AGENTS.md',
+      '@@ -1 +1 @@',
+      '-pkg instructions',
+      '+pkg instructions (touched)',
+      '*** Update File: pkg/secret.ts',
+      '@@ -1 +1 @@',
+      '-code',
+      '+code (touched)',
+      '*** End Patch',
+    ].join('\n');
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'apply_patch',
+      { patch },
+      workspace,
+      config,
+      store,
+    );
+
+    expect(enforcement).not.toBeNull();
+    expect(enforcement!.policy).toBe('block');
+    // pkg/AGENTS.md governs secret.ts and was never read, so it is still unseen
+    // and the block stands despite the bundled self-edit.
+    expect(enforcement!.unseen.map((e) => e.displayPath)).toContain(
+      path.join('pkg', 'AGENTS.md'),
+    );
+    // The instruction file being edited is still surfaced for the R10 refresh...
+    expect(enforcement!.editedInstructionFiles.map((e) => e.displayPath)).toContain(
+      path.join('pkg', 'AGENTS.md'),
+    );
+    // ...and named in the arg-derived targets for the post-write re-stat (F6).
+    expect(enforcement!.instructionFileTargets).toContain('pkg/AGENTS.md');
+  });
+
   it('treats a seen-but-changed governing file as unseen again (R16)', () => {
     const agentsFile = write('pkg/AGENTS.md', 'version one');
     write('pkg/x.ts', 'code');
@@ -292,7 +336,7 @@ describe('dispatch-level write enforcement', () => {
   });
 
   /** Register a generic-family tool named `write` (enforcement keys off the name). */
-  async function registerWriteTool() {
+  async function registerWriteTool(impl: ToolHandler = handler) {
     const { ToolRegistry } = await import('../../src/main/tools/registry');
     const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
     const registry = new ToolRegistry();
@@ -306,7 +350,7 @@ describe('dispatch-level write enforcement', () => {
         category: 'filesystem',
         riskClass: 'write',
       },
-      handler,
+      impl,
     );
     return registry;
   }
@@ -461,6 +505,211 @@ describe('dispatch-level write enforcement', () => {
 
       expect(result.canonical.status).toBe('complete');
       expect(handler).toHaveBeenCalledOnce();
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  /** A handler that really writes `file_path` to disk and bumps its mtime. */
+  function diskWritingHandler() {
+    return vi.fn(async (rawInput: unknown) => {
+      const input = rawInput as { file_path: string; content?: string };
+      const abs = path.join(workspace, input.file_path);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, input.content ?? '', 'utf-8');
+      const future = new Date(Date.now() + 60_000);
+      fs.utimesSync(abs, future, future);
+      return { status: 'complete' as const, data: { value: 'wrote' } };
+    });
+  }
+
+  it('F6: re-stats an edited instruction file post-write so the next mutation is not blocked', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+    const diskWrite = diskWritingHandler();
+    const registry = await registerWriteTool(diskWrite);
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      // First: edit the instruction file itself (exempt under R10). The handler
+      // writes it to disk and bumps its mtime; Phase B must record the POST-write
+      // mtime, not the stale pre-write one resolved in Phase A.
+      const first = await executeToolCall(
+        { id: 'write-agents-f6', name: 'write', args: { file_path: 'pkg/AGENTS.md', content: 'updated rules' } },
+        registry,
+        { cwd: workspace, sessionId, projectRuntime: { config } as never },
+      );
+      expect(first.canonical.status).toBe('complete');
+      expect(diskWrite).toHaveBeenCalledOnce();
+
+      // The tracker holds the fresh (post-write) mtime: assert via isFresh/unseen,
+      // not just isSeen.
+      const entry = resolveAgentsMdChain('pkg/AGENTS.md', workspace, config)[0];
+      expect(entry).toBeDefined();
+      expect(store.isFresh(entry!)).toBe(true);
+      expect(store.unseen([entry!])).toHaveLength(0);
+
+      // Second: mutate a sibling governed by that instruction file. Not blocked,
+      // because the refresh matched the bumped mtime. (A stale pre-write mtime
+      // would have left it unseen and triggered a spurious block.)
+      const second = await executeToolCall(
+        { id: 'write-sibling-f6', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new code' } },
+        registry,
+        { cwd: workspace, sessionId, projectRuntime: { config } as never },
+      );
+      expect(second.canonical.status).toBe('complete');
+      expect(second.canonical.error?.code).not.toBe('agents_md_not_in_context');
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('F6: marks a newly created instruction file seen so a sibling edit is not blocked', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+    // The parent pkg/AGENTS.md already governs pkg/new; mark it seen so this test
+    // isolates the creation-gap behavior of the brand-new pkg/new/AGENTS.md.
+    resolveAgentsMdChain('pkg/x.ts', workspace, config).forEach((e) => store.markSeen(e));
+
+    const diskWrite = diskWritingHandler();
+    const registry = await registerWriteTool(diskWrite);
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      // First: create a NEW instruction file. It does not exist at Phase A, so it
+      // is never in the governing chain; Phase B stats it post-write and marks it
+      // seen (closing the creation gap).
+      const first = await executeToolCall(
+        { id: 'write-new-agents', name: 'write', args: { file_path: 'pkg/new/AGENTS.md', content: 'new rules' } },
+        registry,
+        { cwd: workspace, sessionId, projectRuntime: { config } as never },
+      );
+      expect(first.canonical.status).toBe('complete');
+
+      // The created file is now tracked as fresh.
+      const created = resolveAgentsMdChain('pkg/new/foo.ts', workspace, config).find(
+        (e) => e.displayPath === path.join('pkg', 'new', 'AGENTS.md'),
+      );
+      expect(created).toBeDefined();
+      expect(store.isFresh(created!)).toBe(true);
+
+      // Second: edit a sibling governed by the just-created file. Not blocked
+      // (without the post-write refresh it would be unseen → blocked).
+      const second = await executeToolCall(
+        { id: 'write-new-sibling', name: 'write', args: { file_path: 'pkg/new/foo.ts', content: 'code' } },
+        registry,
+        { cwd: workspace, sessionId, projectRuntime: { config } as never },
+      );
+      expect(second.canonical.status).toBe('complete');
+      expect(second.canonical.error?.code).not.toBe('agents_md_not_in_context');
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('F7: Phase A degrades gracefully (no rejection) on a partial agents_md config', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerWriteTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      // A partial config with `enabled` truthy but no `filenames` would throw
+      // inside effectiveAgentsMdFilenames; Phase A must catch it and proceed with
+      // no enforcement rather than rejecting the tool call.
+      const partialConfig = { agents_md: { enabled: true } } as never;
+      const result = await executeToolCall(
+        { id: 'write-partial', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        { cwd: workspace, sessionId, projectRuntime: { config: partialConfig } as never },
+      );
+
+      expect(result.canonical.status).toBe('complete');
+      expect(handler).toHaveBeenCalledOnce();
+      expect(result.agentProjection.content).not.toContain('<agents_md_warning>');
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('F8: a failed mutation gets no <agents_md_warning> appended (warn policy)', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const failingHandler = vi.fn(async () => ({
+      status: 'error' as const,
+      data: { value: 'old_string not found' },
+      error: { code: 'edit_not_found', message: 'old_string not found' },
+    }));
+    const registry = await registerWriteTool(failingHandler);
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      // No projectRuntime: the default policy is `warn`.
+      const result = await executeToolCall(
+        { id: 'write-fail-warn', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        { cwd: workspace, sessionId },
+      );
+
+      expect(result.canonical.status).toBe('error');
+      expect(failingHandler).toHaveBeenCalledOnce();
+      // Nothing was modified, so the "you modified files…" warning is NOT appended.
+      expect(result.agentProjection.content).not.toContain('<agents_md_warning>');
+      expect(store.size).toBe(0);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('F8: a failed mutation under inject does not mark unseen files seen', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const failingHandler = vi.fn(async () => ({
+      status: 'error' as const,
+      data: { value: 'old_string not found' },
+      error: { code: 'edit_not_found', message: 'old_string not found' },
+    }));
+    const registry = await registerWriteTool(failingHandler);
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      const result = await executeToolCall(
+        { id: 'write-fail-inject', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        {
+          cwd: workspace,
+          sessionId,
+          projectRuntime: { config: agentsConfig({ enforce_on_write: 'inject' }) } as never,
+        },
+      );
+
+      expect(result.canonical.status).toBe('error');
+      expect(failingHandler).toHaveBeenCalledOnce();
+      // Nothing was modified: no content injected and unseen files NOT marked seen.
+      expect(result.agentProjection.content).not.toContain('<agents_md');
+      expect(store.size).toBe(0);
     } finally {
       _setAgentsMdStoreResolverForTests(null);
       sessionPermissionOverrides.delete(sessionId);

--- a/electron/tests/unit/agents-md-enforcement.test.ts
+++ b/electron/tests/unit/agents-md-enforcement.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Write-path AGENTS.md enforcement tests (U5).
+ *
+ * Covers the pure enforcement evaluator (mutator gating, governing-chain
+ * aggregation, apply_patch fan-out, R10 instruction-file exemption, R16
+ * staleness, R9 out-of-workspace) against temp-dir fixtures and a real
+ * AgentsMdContextStore, plus dispatch-level tests proving the `block`, `warn`,
+ * and `inject` policies behave end-to-end through executeToolCall.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  defaults,
+  type AgentsMdConfig,
+  type Config,
+} from '../../src/main/config';
+import { AGENTS_MD_DEFAULTS } from '../../src/main/agents-md/config';
+import {
+  buildAgentsMdBlockMessage,
+  buildAgentsMdWarningBlock,
+  evaluateAgentsMdEnforcement,
+} from '../../src/main/agents-md/enforce';
+import { resolveAgentsMdChain } from '../../src/main/agents-md/resolver';
+import { AgentsMdContextStore } from '../../src/main/session/agents-md-context';
+
+/** Build a full Config with `agents_md` overrides applied over the defaults. */
+function agentsConfig(overrides: Partial<AgentsMdConfig> = {}): Config {
+  return { ...defaults(), agents_md: { ...AGENTS_MD_DEFAULTS, ...overrides } };
+}
+
+describe('evaluateAgentsMdEnforcement', () => {
+  let root: string;
+  let workspace: string;
+  let store: AgentsMdContextStore;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-enforce-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(workspace);
+    store = new AgentsMdContextStore();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content = 'instructions'): string {
+    const abs = path.join(workspace, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+    return abs;
+  }
+
+  it('block policy surfaces an unseen governing file in `unseen`', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'edit',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      agentsConfig({ enforce_on_write: 'block' }),
+      store,
+    );
+
+    expect(enforcement).not.toBeNull();
+    expect(enforcement!.policy).toBe('block');
+    expect(enforcement!.unseen).toHaveLength(1);
+    expect(enforcement!.unseen[0]?.displayPath).toBe(path.join('pkg', 'AGENTS.md'));
+    expect(enforcement!.editedInstructionFiles).toHaveLength(0);
+  });
+
+  it('returns null when the policy is `off`', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'edit',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      agentsConfig({ enforce_on_write: 'off' }),
+      store,
+    );
+    expect(enforcement).toBeNull();
+  });
+
+  it('returns null when the feature is disabled', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'edit',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      agentsConfig({ enabled: false, enforce_on_write: 'block' }),
+      store,
+    );
+    expect(enforcement).toBeNull();
+  });
+
+  it('returns null for non-mutator tools', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+    const args = { file_path: 'pkg/x.ts' };
+
+    expect(evaluateAgentsMdEnforcement('read', args, workspace, config, store)).toBeNull();
+    expect(evaluateAgentsMdEnforcement('execute_command', { command: 'ls' }, workspace, config, store)).toBeNull();
+    expect(evaluateAgentsMdEnforcement('grep', { pattern: 'x' }, workspace, config, store)).toBeNull();
+  });
+
+  it('applies to all five file mutators', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig({ enforce_on_write: 'warn' });
+
+    for (const toolName of ['edit', 'write', 'rename_symbol', 'replace_symbol']) {
+      const enforcement = evaluateAgentsMdEnforcement(
+        toolName,
+        { file_path: 'pkg/x.ts' },
+        workspace,
+        config,
+        store,
+      );
+      expect(enforcement, toolName).not.toBeNull();
+      expect(enforcement!.unseen, toolName).toHaveLength(1);
+    }
+
+    const patch = evaluateAgentsMdEnforcement(
+      'apply_patch',
+      { patch: '*** Update File: pkg/x.ts\n' },
+      workspace,
+      config,
+      store,
+    );
+    expect(patch).not.toBeNull();
+    expect(patch!.unseen).toHaveLength(1);
+  });
+
+  it('reports no unseen files once the governing file is seen (any policy)', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+
+    const chain = resolveAgentsMdChain('pkg/x.ts', workspace, config);
+    chain.forEach((entry) => store.markSeen(entry));
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'edit',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      config,
+      store,
+    );
+    expect(enforcement).not.toBeNull();
+    expect(enforcement!.unseen).toHaveLength(0);
+  });
+
+  it('aggregates unseen files across an apply_patch touching two trees (R8)', () => {
+    write('pkg/AGENTS.md', 'pkg instructions');
+    write('other/AGENTS.md', 'other instructions');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: pkg/a.ts',
+      '*** Update File: other/b.ts',
+      '*** End Patch',
+    ].join('\n');
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'apply_patch',
+      { patch },
+      workspace,
+      config,
+      store,
+    );
+
+    expect(enforcement).not.toBeNull();
+    const displayPaths = enforcement!.unseen.map((entry) => entry.displayPath).sort();
+    expect(displayPaths).toEqual(
+      [path.join('other', 'AGENTS.md'), path.join('pkg', 'AGENTS.md')].sort(),
+    );
+    // The block message names every unseen file in a single denial.
+    const message = buildAgentsMdBlockMessage(enforcement!.unseen);
+    expect(message).toContain(path.join('pkg', 'AGENTS.md'));
+    expect(message).toContain(path.join('other', 'AGENTS.md'));
+  });
+
+  it('does not enforce a target outside the workspace (R9)', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    const outside = path.join(root, 'outside', 'x.ts');
+    fs.mkdirSync(path.dirname(outside), { recursive: true });
+    fs.writeFileSync(outside, 'code', 'utf-8');
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'edit',
+      { file_path: outside },
+      workspace,
+      agentsConfig({ enforce_on_write: 'block' }),
+      store,
+    );
+
+    expect(enforcement).not.toBeNull();
+    expect(enforcement!.unseen).toHaveLength(0);
+  });
+
+  it('exempts an instruction file being edited and records it for refresh (R10)', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+
+    const enforcement = evaluateAgentsMdEnforcement(
+      'write',
+      { file_path: 'pkg/AGENTS.md' },
+      workspace,
+      config,
+      store,
+    );
+
+    expect(enforcement).not.toBeNull();
+    // The edited instruction file is NOT treated as an unseen governing file...
+    expect(enforcement!.unseen).toHaveLength(0);
+    // ...but is surfaced so the dispatcher can refresh its tracker entry.
+    expect(enforcement!.editedInstructionFiles).toHaveLength(1);
+    expect(enforcement!.editedInstructionFiles[0]?.displayPath).toBe(
+      path.join('pkg', 'AGENTS.md'),
+    );
+  });
+
+  it('treats a seen-but-changed governing file as unseen again (R16)', () => {
+    const agentsFile = write('pkg/AGENTS.md', 'version one');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig({ enforce_on_write: 'block' });
+    const args = { file_path: 'pkg/x.ts' };
+
+    const chain = resolveAgentsMdChain('pkg/x.ts', workspace, config);
+    chain.forEach((entry) => store.markSeen(entry));
+    expect(
+      evaluateAgentsMdEnforcement('edit', args, workspace, config, store)!.unseen,
+    ).toHaveLength(0);
+
+    // Rewrite and bump the mtime so the stored record is stale.
+    fs.writeFileSync(agentsFile, 'version two', 'utf-8');
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(agentsFile, future, future);
+
+    const enforcement = evaluateAgentsMdEnforcement('edit', args, workspace, config, store);
+    expect(enforcement!.unseen).toHaveLength(1);
+    expect(enforcement!.unseen[0]?.displayPath).toBe(path.join('pkg', 'AGENTS.md'));
+  });
+
+  it('escapes XML metacharacters in the warning block', () => {
+    const block = buildAgentsMdWarningBlock([
+      {
+        path: '/w/pkg/AGENTS.md',
+        displayPath: 'pkg/<weird> & "AGENTS".md',
+        tier: 'nested',
+        sizeBytes: 1,
+        mtimeMs: 1,
+      },
+    ]);
+    expect(block).toContain('<agents_md_warning>');
+    expect(block).toContain('&lt;weird&gt;');
+    expect(block).toContain('&amp;');
+    expect(block).not.toContain('<weird>');
+  });
+});
+
+describe('dispatch-level write enforcement', () => {
+  const sessionId = `agents-md-enforcement-${Date.now()}`;
+  let root: string;
+  let workspace: string;
+  let store: AgentsMdContextStore;
+  let handler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-enforce-dispatch-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(path.join(workspace, 'pkg'), { recursive: true });
+    fs.writeFileSync(path.join(workspace, 'pkg', 'AGENTS.md'), 'nested dispatch rules', 'utf-8');
+    fs.writeFileSync(path.join(workspace, 'pkg', 'x.ts'), 'code', 'utf-8');
+    store = new AgentsMdContextStore();
+    handler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'wrote' } }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  /** Register a generic-family tool named `write` (enforcement keys off the name). */
+  async function registerWriteTool() {
+    const { ToolRegistry } = await import('../../src/main/tools/registry');
+    const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
+    const registry = new ToolRegistry();
+    registry.register(
+      {
+        name: 'write',
+        description: 'Write a file',
+        inputSchema: z.object({ file_path: z.string(), content: z.string().optional() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'filesystem',
+        riskClass: 'write',
+      },
+      handler,
+    );
+    return registry;
+  }
+
+  it('block: denies the mutation with a terminal error and never runs the handler', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerWriteTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      const result = await executeToolCall(
+        { id: 'write-block', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        {
+          cwd: workspace,
+          sessionId,
+          projectRuntime: { config: agentsConfig({ enforce_on_write: 'block' }) } as never,
+        },
+      );
+
+      expect(result.canonical.status).toBe('error');
+      expect(result.canonical.error?.code).toBe('agents_md_not_in_context');
+      expect(result.agentProjection.content).toContain(path.join('pkg', 'AGENTS.md'));
+      expect(result.agentProjection.content).toContain('blocked');
+      expect(handler).not.toHaveBeenCalled();
+      // Nothing was injected, so the tracker stays empty.
+      expect(store.size).toBe(0);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('warn: runs the handler and appends an <agents_md_warning> without marking seen', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerWriteTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      // No projectRuntime: the default policy is `warn` (FALLBACK_CONFIG).
+      const result = await executeToolCall(
+        { id: 'write-warn', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        { cwd: workspace, sessionId },
+      );
+
+      expect(result.canonical.status).toBe('complete');
+      expect(handler).toHaveBeenCalledOnce();
+      expect(result.agentProjection.content).toContain('<agents_md_warning>');
+      expect(result.agentProjection.content).toContain(path.join('pkg', 'AGENTS.md'));
+      // The warning does not inject content, so the file is NOT marked seen.
+      expect(store.size).toBe(0);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('inject: runs the handler, appends the <agents_md> content, and marks seen', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerWriteTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      const result = await executeToolCall(
+        { id: 'write-inject', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        {
+          cwd: workspace,
+          sessionId,
+          projectRuntime: { config: agentsConfig({ enforce_on_write: 'inject' }) } as never,
+        },
+      );
+
+      expect(result.canonical.status).toBe('complete');
+      expect(handler).toHaveBeenCalledOnce();
+      expect(result.agentProjection.content).toContain('<agents_md');
+      expect(result.agentProjection.content).toContain('nested dispatch rules');
+      // Injection puts the content in context, so the entry is marked seen.
+      expect(store.size).toBe(1);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('R10: editing an instruction file itself is allowed under block and refreshes it', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerWriteTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      const result = await executeToolCall(
+        { id: 'write-agents', name: 'write', args: { file_path: 'pkg/AGENTS.md', content: 'new' } },
+        registry,
+        {
+          cwd: workspace,
+          sessionId,
+          projectRuntime: { config: agentsConfig({ enforce_on_write: 'block' }) } as never,
+        },
+      );
+
+      // Not blocked: the instruction file being edited is exempt (R10).
+      expect(result.canonical.status).toBe('complete');
+      expect(handler).toHaveBeenCalledOnce();
+      // Phase B refreshed the tracker entry for the edited instruction file.
+      expect(store.size).toBe(1);
+      const entry = resolveAgentsMdChain('pkg/AGENTS.md', workspace, agentsConfig())[0];
+      expect(store.isSeen(entry!.path)).toBe(true);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('R17: never blocks when no store is resolvable, even under block policy', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerWriteTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    // Simulate the no-session degradation: the store resolver yields nothing.
+    _setAgentsMdStoreResolverForTests(() => null);
+
+    try {
+      const result = await executeToolCall(
+        { id: 'write-nostore', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        {
+          cwd: workspace,
+          sessionId,
+          projectRuntime: { config: agentsConfig({ enforce_on_write: 'block' }) } as never,
+        },
+      );
+
+      expect(result.canonical.status).toBe('complete');
+      expect(handler).toHaveBeenCalledOnce();
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+});

--- a/electron/tests/unit/agents-md-injection.test.ts
+++ b/electron/tests/unit/agents-md-injection.test.ts
@@ -226,6 +226,41 @@ describe('buildAgentsMdInjection', () => {
     expect(refreshed!.xml).toContain('version two');
   });
 
+  it('excludes the root tier from re-injection even when it changes, but re-injects a changed nested file (F5/R4/R16)', () => {
+    const rootFile = write('AGENTS.md', 'root instructions');
+    const nestedFile = write('pkg/AGENTS.md', 'nested one');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig();
+    const args = { file_path: 'pkg/x.ts' };
+
+    // Seed the root (U3) and mark the nested file seen, so only changes surface.
+    const chain = resolveAgentsMdChain('pkg/x.ts', workspace, config);
+    const rootEntry = chain.find((entry) => entry.tier === 'root');
+    const nestedEntry = chain.find((entry) => entry.tier === 'nested');
+    expect(rootEntry).toBeDefined();
+    expect(nestedEntry).toBeDefined();
+    store.seedRoot(rootEntry!);
+    store.markSeen(nestedEntry!);
+
+    // Bump BOTH files' mtimes on disk mid-turn.
+    const future = new Date(Date.now() + 60_000);
+    fs.writeFileSync(rootFile, 'root instructions (changed)', 'utf-8');
+    fs.utimesSync(rootFile, future, future);
+    fs.writeFileSync(nestedFile, 'nested two', 'utf-8');
+    fs.utimesSync(nestedFile, future, future);
+
+    const injection = buildAgentsMdInjection('read', args, workspace, config, store);
+
+    // The changed nested file re-injects (R16)...
+    expect(injection).not.toBeNull();
+    expect(injection!.xml).toContain('nested two');
+    expect(injection!.injected).toHaveLength(1);
+    expect(injection!.injected[0]?.tier).toBe('nested');
+    // ...but the changed root is never re-injected by the nested mechanism (R4/F5).
+    expect(injection!.xml).not.toContain('tier="root"');
+    expect(injection!.xml).not.toContain('root instructions (changed)');
+  });
+
   it('escapes XML metacharacters in rendered content', () => {
     write('pkg/AGENTS.md', '<script> & "quotes" >');
     write('pkg/x.ts', 'code');

--- a/electron/tests/unit/agents-md-injection.test.ts
+++ b/electron/tests/unit/agents-md-injection.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Read-path AGENTS.md injection tests (U4).
+ *
+ * Covers the pure injection builder (path extraction, chain resolution, unseen
+ * computation, byte cap, XML rendering/escaping, directory synthetic-child
+ * resolution, staleness) against temp-dir fixtures and a real
+ * AgentsMdContextStore, plus one dispatch-level test proving a `read` call's
+ * agent projection gains an `<agents_md>` block end-to-end.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  defaults,
+  type AgentsMdConfig,
+  type Config,
+} from '../../src/main/config';
+import { AGENTS_MD_DEFAULTS } from '../../src/main/agents-md/config';
+import { buildAgentsMdInjection } from '../../src/main/agents-md/inject';
+import { resolveAgentsMdChain } from '../../src/main/agents-md/resolver';
+import { AgentsMdContextStore } from '../../src/main/session/agents-md-context';
+
+/** Build a full Config with `agents_md` overrides applied over the defaults. */
+function agentsConfig(overrides: Partial<AgentsMdConfig> = {}): Config {
+  return { ...defaults(), agents_md: { ...AGENTS_MD_DEFAULTS, ...overrides } };
+}
+
+describe('buildAgentsMdInjection', () => {
+  let root: string;
+  let workspace: string;
+  let store: AgentsMdContextStore;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-inject-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(workspace);
+    store = new AgentsMdContextStore();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content = 'instructions'): string {
+    const abs = path.join(workspace, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+    return abs;
+  }
+
+  it('injects an unseen nested file governing a read target', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/lib/x.ts', 'code');
+
+    const injection = buildAgentsMdInjection(
+      'read',
+      { file_path: 'pkg/lib/x.ts' },
+      workspace,
+      agentsConfig(),
+      store,
+    );
+
+    expect(injection).not.toBeNull();
+    expect(injection!.xml).toContain('nested instructions');
+    expect(injection!.xml).toContain('<agents_md');
+    expect(injection!.xml).toContain(`path="${path.join('pkg', 'AGENTS.md')}"`);
+    expect(injection!.xml).toContain('tier="nested"');
+    expect(injection!.injected).toHaveLength(1);
+    expect(injection!.injected[0]?.displayPath).toBe(path.join('pkg', 'AGENTS.md'));
+  });
+
+  it('dedupes: a second build after marking seen returns null', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/lib/x.ts', 'code');
+    const config = agentsConfig();
+    const args = { file_path: 'pkg/lib/x.ts' };
+
+    const first = buildAgentsMdInjection('read', args, workspace, config, store);
+    expect(first).not.toBeNull();
+
+    // The dispatcher marks injected entries seen after appending.
+    first!.injected.forEach((entry) => store.markSeen(entry));
+
+    const second = buildAgentsMdInjection('read', args, workspace, config, store);
+    expect(second).toBeNull();
+  });
+
+  it('never re-injects the seeded root, only the unseen nested file (R4)', () => {
+    write('AGENTS.md', 'root instructions');
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig();
+
+    // Seed the root exactly as the session-start hook does (U3).
+    const rootEntry = resolveAgentsMdChain('pkg/x.ts', workspace, config)
+      .find((entry) => entry.tier === 'root');
+    expect(rootEntry).toBeDefined();
+    store.seedRoot(rootEntry!);
+
+    const injection = buildAgentsMdInjection(
+      'read',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      config,
+      store,
+    );
+
+    expect(injection).not.toBeNull();
+    expect(injection!.xml).toContain('nested instructions');
+    expect(injection!.xml).not.toContain('root instructions');
+    expect(injection!.injected).toHaveLength(1);
+    expect(injection!.injected[0]?.tier).toBe('nested');
+  });
+
+  it('returns null when inject_on_read is false', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+
+    const injection = buildAgentsMdInjection(
+      'read',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      agentsConfig({ inject_on_read: false }),
+      store,
+    );
+    expect(injection).toBeNull();
+  });
+
+  it('returns null when the feature is disabled', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+
+    const injection = buildAgentsMdInjection(
+      'read',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      agentsConfig({ enabled: false }),
+      store,
+    );
+    expect(injection).toBeNull();
+  });
+
+  it('returns null for non-injectable tools (fan-out and mutators)', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig();
+    const args = { file_path: 'pkg/x.ts' };
+
+    expect(buildAgentsMdInjection('grep', args, workspace, config, store)).toBeNull();
+    expect(buildAgentsMdInjection('glob', args, workspace, config, store)).toBeNull();
+    expect(buildAgentsMdInjection('rag_search', args, workspace, config, store)).toBeNull();
+    expect(buildAgentsMdInjection('edit', args, workspace, config, store)).toBeNull();
+    expect(buildAgentsMdInjection('write', args, workspace, config, store)).toBeNull();
+  });
+
+  it('returns null for a missing, empty, or non-string path arg', () => {
+    write('pkg/AGENTS.md', 'nested instructions');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig();
+
+    expect(buildAgentsMdInjection('read', {}, workspace, config, store)).toBeNull();
+    expect(buildAgentsMdInjection('read', { file_path: '' }, workspace, config, store)).toBeNull();
+    expect(buildAgentsMdInjection('read', { file_path: '   ' }, workspace, config, store)).toBeNull();
+    expect(buildAgentsMdInjection('read', { file_path: 123 }, workspace, config, store)).toBeNull();
+    // find_symbol_references treats file_path as optional — omitted skips injection.
+    expect(buildAgentsMdInjection('find_symbol_references', { symbol_name: 'x' }, workspace, config, store)).toBeNull();
+  });
+
+  it('read_directory injects the AGENTS.md inside the directory itself (synthetic child)', () => {
+    write('docs/AGENTS.md', 'docs instructions');
+    fs.mkdirSync(path.join(workspace, 'docs'), { recursive: true });
+
+    const injection = buildAgentsMdInjection(
+      'read_directory',
+      { directory_path: 'docs' },
+      workspace,
+      agentsConfig(),
+      store,
+    );
+
+    expect(injection).not.toBeNull();
+    expect(injection!.xml).toContain('docs instructions');
+    expect(injection!.injected[0]?.displayPath).toBe(path.join('docs', 'AGENTS.md'));
+  });
+
+  it('renders an over-cap file with truncated="true" and a read pointer (R5)', () => {
+    write('pkg/AGENTS.md', 'y'.repeat(100));
+    write('pkg/x.ts', 'code');
+
+    const injection = buildAgentsMdInjection(
+      'read',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      agentsConfig({ max_file_bytes: 50 }),
+      store,
+    );
+
+    expect(injection).not.toBeNull();
+    expect(injection!.xml).toContain('truncated="true"');
+    expect(injection!.xml).toContain('y'.repeat(50));
+    expect(injection!.xml).not.toContain('y'.repeat(51));
+    expect(injection!.xml).toContain('use read');
+  });
+
+  it('re-injects a seen entry whose mtime changed on disk (R16)', () => {
+    const agentsFile = write('pkg/AGENTS.md', 'version one');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig();
+    const args = { file_path: 'pkg/x.ts' };
+
+    const first = buildAgentsMdInjection('read', args, workspace, config, store);
+    expect(first).not.toBeNull();
+    first!.injected.forEach((entry) => store.markSeen(entry));
+    expect(buildAgentsMdInjection('read', args, workspace, config, store)).toBeNull();
+
+    // Rewrite and bump the mtime so the stored record is stale.
+    fs.writeFileSync(agentsFile, 'version two', 'utf-8');
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(agentsFile, future, future);
+
+    const refreshed = buildAgentsMdInjection('read', args, workspace, config, store);
+    expect(refreshed).not.toBeNull();
+    expect(refreshed!.xml).toContain('version two');
+  });
+
+  it('escapes XML metacharacters in rendered content', () => {
+    write('pkg/AGENTS.md', '<script> & "quotes" >');
+    write('pkg/x.ts', 'code');
+
+    const injection = buildAgentsMdInjection(
+      'read',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      agentsConfig(),
+      store,
+    );
+
+    expect(injection).not.toBeNull();
+    expect(injection!.xml).toContain('&lt;script&gt;');
+    expect(injection!.xml).toContain('&amp;');
+    expect(injection!.xml).not.toContain('<script>');
+  });
+});
+
+describe('dispatch-level read-path injection', () => {
+  const sessionId = `agents-md-injection-${Date.now()}`;
+  let root: string;
+  let workspace: string;
+  let store: AgentsMdContextStore;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-dispatch-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(path.join(workspace, 'pkg'), { recursive: true });
+    fs.writeFileSync(path.join(workspace, 'pkg', 'AGENTS.md'), 'nested dispatch rules', 'utf-8');
+    fs.writeFileSync(path.join(workspace, 'pkg', 'x.ts'), 'code', 'utf-8');
+    store = new AgentsMdContextStore();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('appends an <agents_md> block to a read tool projection end-to-end', async () => {
+    // Lazy imports keep the heavy dispatch graph out of the pure-builder suite.
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { ToolRegistry } = await import('../../src/main/tools/registry');
+    const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+
+    const registry = new ToolRegistry();
+    registry.register(
+      {
+        name: 'read',
+        description: 'Read a file',
+        inputSchema: z.object({ file_path: z.string() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'filesystem',
+        riskClass: 'read-only',
+      },
+      async () => ({ status: 'complete' as const, data: { value: 'file body' } }),
+    );
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    // The production resolver uses a native `createRequire` that cannot load
+    // `.ts` under vitest, so inject the session store directly for this test.
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      const first = await executeToolCall(
+        { id: 'read-call', name: 'read', args: { file_path: 'pkg/x.ts' } },
+        registry,
+        { cwd: workspace, sessionId },
+      );
+
+      expect(first.canonical.status).toBe('complete');
+      expect(first.agentProjection.content).toContain('<agents_md');
+      expect(first.agentProjection.content).toContain('nested dispatch rules');
+      // The block is inserted inside the tool_result envelope, before the close.
+      expect(first.agentProjection.content.indexOf('<agents_md')).toBeLessThan(
+        first.agentProjection.content.lastIndexOf('</tool_result>'),
+      );
+      // Injection marked the entry seen, so a second read does not re-inject.
+      expect(store.size).toBe(1);
+
+      const second = await executeToolCall(
+        { id: 'read-call-2', name: 'read', args: { file_path: 'pkg/x.ts' } },
+        registry,
+        { cwd: workspace, sessionId },
+      );
+      expect(second.agentProjection.content).not.toContain('<agents_md');
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+});

--- a/electron/tests/unit/agents-md-resolver.test.ts
+++ b/electron/tests/unit/agents-md-resolver.test.ts
@@ -1,0 +1,305 @@
+/**
+ * AGENTS.md resolver + config tests (U1).
+ *
+ * Covers the governing-chain resolver (upward walk, alias precedence, depth
+ * cap, symlink containment, case-insensitive matching, non-existent targets),
+ * the `agents_md` config schema/defaults/deep-merge, and the byte-capped
+ * content reader.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  configSchema,
+  defaults,
+  mergeLayers,
+  type AgentsMdConfig,
+  type Config,
+} from '../../src/main/config';
+import {
+  AGENTS_LOCAL_FILENAME,
+  AGENTS_MD_DEFAULTS,
+  effectiveAgentsMdFilenames,
+} from '../../src/main/agents-md/config';
+import {
+  readAgentsMdContent,
+  resolveAgentsMdChain,
+} from '../../src/main/agents-md/resolver';
+
+/** Build a full Config with `agents_md` overrides applied over the defaults. */
+function agentsConfig(overrides: Partial<AgentsMdConfig> = {}): Config {
+  return { ...defaults(), agents_md: { ...AGENTS_MD_DEFAULTS, ...overrides } };
+}
+
+describe('resolveAgentsMdChain', () => {
+  let root: string;
+  let workspace: string;
+  let outside: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-'));
+    workspace = path.join(root, 'workspace');
+    outside = path.join(root, 'outside');
+    fs.mkdirSync(workspace);
+    fs.mkdirSync(outside);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content = 'instructions'): string {
+    const abs = path.join(workspace, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+    return abs;
+  }
+
+  it('collects a nested file and the root file, nearest first with correct tiers', () => {
+    const rootFile = write('AGENTS.md', 'root');
+    const nestedFile = write('pkg/AGENTS.md', 'nested');
+    write('pkg/lib/x.ts', 'code');
+
+    const chain = resolveAgentsMdChain('pkg/lib/x.ts', workspace, agentsConfig());
+
+    expect(chain.map((e) => e.path)).toEqual([nestedFile, rootFile]);
+    expect(chain.map((e) => e.tier)).toEqual(['nested', 'root']);
+    expect(chain.map((e) => e.displayPath)).toEqual([
+      path.join('pkg', 'AGENTS.md'),
+      'AGENTS.md',
+    ]);
+    expect(chain[0]?.sizeBytes).toBe(Buffer.byteLength('nested'));
+    expect(typeof chain[0]?.mtimeMs).toBe('number');
+  });
+
+  it('returns only the first configured alias when a directory has several', () => {
+    const agentsFile = write('pkg/AGENTS.md', 'primary');
+    write('pkg/CLAUDE.md', 'alias');
+    write('pkg/y.ts', 'code');
+
+    const chain = resolveAgentsMdChain('pkg/y.ts', workspace, agentsConfig());
+
+    expect(chain).toHaveLength(1);
+    expect(chain[0]?.path).toBe(agentsFile);
+  });
+
+  it('falls back to a later alias when the primary is absent', () => {
+    const claudeFile = write('pkg/CLAUDE.md', 'alias');
+    write('pkg/y.ts', 'code');
+
+    const chain = resolveAgentsMdChain('pkg/y.ts', workspace, agentsConfig());
+
+    expect(chain).toHaveLength(1);
+    expect(chain[0]?.path).toBe(claudeFile);
+  });
+
+  it('caps the upward walk at max_chain_depth', () => {
+    write('AGENTS.md', 'root');
+    write('a/AGENTS.md', 'a');
+    write('a/b/AGENTS.md', 'b');
+    write('a/b/c/AGENTS.md', 'c');
+    const deepFile = write('a/b/c/d/AGENTS.md', 'd');
+    write('a/b/c/d/file.ts', 'code');
+
+    const chain = resolveAgentsMdChain(
+      'a/b/c/d/file.ts',
+      workspace,
+      agentsConfig({ max_chain_depth: 2 }),
+    );
+
+    // Only the two nearest directories are walked; the root is never reached.
+    expect(chain).toHaveLength(2);
+    expect(chain.map((e) => e.tier)).toEqual(['nested', 'nested']);
+    expect(chain[0]?.path).toBe(deepFile);
+    expect(chain.some((e) => e.tier === 'root')).toBe(false);
+  });
+
+  it('excludes an instruction file whose symlink target escapes cwd', () => {
+    const outsideFile = path.join(outside, 'AGENTS.md');
+    fs.writeFileSync(outsideFile, 'escaped', 'utf-8');
+    const rootFile = write('AGENTS.md', 'root');
+    fs.mkdirSync(path.join(workspace, 'nested'));
+    fs.symlinkSync(outsideFile, path.join(workspace, 'nested', 'AGENTS.md'));
+    write('nested/code.ts', 'code');
+
+    const chain = resolveAgentsMdChain('nested/code.ts', workspace, agentsConfig());
+
+    // The escaping nested file is dropped; the contained root file survives.
+    expect(chain.map((e) => e.path)).toEqual([rootFile]);
+    expect(chain.map((e) => e.tier)).toEqual(['root']);
+  });
+
+  it('matches filenames case-insensitively while preserving the on-disk name', () => {
+    const lowerFile = write('agents.md', 'lowercase on disk');
+    write('code.ts', 'code');
+
+    const chain = resolveAgentsMdChain('code.ts', workspace, agentsConfig());
+
+    expect(chain).toHaveLength(1);
+    expect(chain[0]?.path).toBe(lowerFile);
+    expect(chain[0]?.displayPath).toBe('agents.md');
+    expect(chain[0]?.tier).toBe('root');
+  });
+
+  it('returns an empty chain for a target outside cwd', () => {
+    write('AGENTS.md', 'root');
+    const outsideTarget = path.join(outside, 'file.ts');
+    fs.writeFileSync(outsideTarget, 'code', 'utf-8');
+
+    expect(resolveAgentsMdChain(outsideTarget, workspace, agentsConfig())).toEqual([]);
+    expect(resolveAgentsMdChain('../outside/file.ts', workspace, agentsConfig())).toEqual([]);
+  });
+
+  it('considers AGENTS.local.md only when include_local is true, as lowest precedence', () => {
+    const localFile = write('solo/AGENTS.local.md', 'local only');
+    write('solo/z.ts', 'code');
+
+    expect(
+      resolveAgentsMdChain('solo/z.ts', workspace, agentsConfig({ include_local: false })),
+    ).toEqual([]);
+
+    const withLocal = resolveAgentsMdChain(
+      'solo/z.ts',
+      workspace,
+      agentsConfig({ include_local: true }),
+    );
+    expect(withLocal.map((e) => e.path)).toEqual([localFile]);
+
+    // When a primary alias is also present, it wins over the local file.
+    const primaryFile = write('solo/AGENTS.md', 'primary');
+    const preferred = resolveAgentsMdChain(
+      'solo/z.ts',
+      workspace,
+      agentsConfig({ include_local: true }),
+    );
+    expect(preferred.map((e) => e.path)).toEqual([primaryFile]);
+  });
+
+  it('resolves the governing chain for a target whose components do not exist yet', () => {
+    const rootFile = write('AGENTS.md', 'root');
+    const nestedFile = write('src/AGENTS.md', 'nested');
+    // src/deep/ does not exist on disk; the target is a file about to be created.
+
+    const chain = resolveAgentsMdChain(
+      'src/deep/new-file.ts',
+      workspace,
+      agentsConfig(),
+    );
+
+    expect(chain.map((e) => e.path)).toEqual([nestedFile, rootFile]);
+    expect(chain.map((e) => e.tier)).toEqual(['nested', 'root']);
+  });
+
+  it('returns an empty chain when the workspace itself cannot be canonicalized', () => {
+    const missing = path.join(root, 'missing-workspace');
+    expect(resolveAgentsMdChain('file.ts', missing, agentsConfig())).toEqual([]);
+  });
+});
+
+describe('readAgentsMdContent', () => {
+  let root: string;
+  let workspace: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-content-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(workspace);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function entryFor(content: string) {
+    fs.writeFileSync(path.join(workspace, 'AGENTS.md'), content, 'utf-8');
+    fs.writeFileSync(path.join(workspace, 'f.ts'), 'code', 'utf-8');
+    const chain = resolveAgentsMdChain('f.ts', workspace, agentsConfig());
+    const entry = chain.find((e) => e.tier === 'root');
+    expect(entry).toBeDefined();
+    return entry!;
+  }
+
+  it('returns full content without truncation at exactly max_file_bytes', () => {
+    const content = 'x'.repeat(100);
+    const entry = entryFor(content);
+
+    const result = readAgentsMdContent(entry, 100);
+    expect(result.truncated).toBe(false);
+    expect(result.content).toBe(content);
+  });
+
+  it('returns a head plus truncated flag when the file exceeds max_file_bytes', () => {
+    const content = 'y'.repeat(100);
+    const entry = entryFor(content);
+
+    const result = readAgentsMdContent(entry, 99);
+    expect(result.truncated).toBe(true);
+    expect(result.content).toBe('y'.repeat(99));
+  });
+});
+
+describe('effectiveAgentsMdFilenames', () => {
+  it('returns the configured aliases in order by default', () => {
+    expect(effectiveAgentsMdFilenames(agentsConfig())).toEqual(['AGENTS.md', 'CLAUDE.md']);
+  });
+
+  it('appends AGENTS.local.md last when include_local is true', () => {
+    const names = effectiveAgentsMdFilenames(agentsConfig({ include_local: true }));
+    expect(names).toEqual(['AGENTS.md', 'CLAUDE.md', AGENTS_LOCAL_FILENAME]);
+  });
+
+  it('trims entries, drops empties, and de-duplicates case-insensitively', () => {
+    const names = effectiveAgentsMdFilenames(
+      agentsConfig({ filenames: ['  AGENTS.md  ', '', 'claude.md', 'CLAUDE.md', 'custom.md'] }),
+    );
+    expect(names).toEqual(['AGENTS.md', 'claude.md', 'custom.md']);
+  });
+});
+
+describe('agents_md config schema', () => {
+  it('populates the documented defaults', () => {
+    expect(defaults().agents_md).toEqual(AGENTS_MD_DEFAULTS);
+    expect(AGENTS_MD_DEFAULTS).toEqual({
+      enabled: true,
+      filenames: ['AGENTS.md', 'CLAUDE.md'],
+      max_file_bytes: 32768,
+      max_chain_depth: 8,
+      enforce_on_write: 'warn',
+      inject_on_read: true,
+      include_local: false,
+    });
+  });
+
+  it('fills sibling defaults from a partial agents_md override', () => {
+    const parsed = configSchema.parse({ agents_md: { max_chain_depth: 3 } });
+    expect(parsed.agents_md.max_chain_depth).toBe(3);
+    expect(parsed.agents_md.max_file_bytes).toBe(32768);
+    expect(parsed.agents_md.enforce_on_write).toBe('warn');
+  });
+
+  it('rejects an unknown top-level key under the strict schema', () => {
+    expect(configSchema.safeParse({ agents_md_bogus: {} }).success).toBe(false);
+  });
+
+  it('rejects an invalid enforce_on_write policy and non-positive integers', () => {
+    expect(
+      configSchema.safeParse({ agents_md: { enforce_on_write: 'explode' } }).success,
+    ).toBe(false);
+    expect(configSchema.safeParse({ agents_md: { max_file_bytes: 0 } }).success).toBe(false);
+    expect(configSchema.safeParse({ agents_md: { max_chain_depth: -1 } }).success).toBe(false);
+  });
+
+  it('deep-merges a partial project override without wiping sibling fields', () => {
+    const merged = mergeLayers(
+      defaults() as unknown as Record<string, unknown>,
+      {},
+      { agents_md: { enforce_on_write: 'block' } },
+    );
+    const parsed = configSchema.parse(merged);
+    expect(parsed.agents_md.enforce_on_write).toBe('block');
+    expect(parsed.agents_md.max_file_bytes).toBe(32768);
+    expect(parsed.agents_md.include_local).toBe(false);
+  });
+});

--- a/electron/tests/unit/agents-md-resolver.test.ts
+++ b/electron/tests/unit/agents-md-resolver.test.ts
@@ -9,7 +9,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   configSchema,
@@ -143,6 +143,19 @@ describe('resolveAgentsMdChain', () => {
     expect(chain[0]?.tier).toBe('root');
   });
 
+  it('prefers the exact-case file when both cases coexist, deterministically (F2)', () => {
+    // A case-sensitive FS can hold both `AGENTS.md` and `agents.md`; the
+    // configured (exact-case) name must win regardless of readdir order.
+    const exactFile = write('both/AGENTS.md', 'exact case');
+    write('both/agents.md', 'lower case');
+    write('both/code.ts', 'code');
+
+    const chain = resolveAgentsMdChain('both/code.ts', workspace, agentsConfig());
+    expect(chain).toHaveLength(1);
+    expect(chain[0]?.path).toBe(exactFile);
+    expect(chain[0]?.displayPath).toBe(path.join('both', 'AGENTS.md'));
+  });
+
   it('returns an empty chain for a target outside cwd', () => {
     write('AGENTS.md', 'root');
     const outsideTarget = path.join(outside, 'file.ts');
@@ -195,6 +208,28 @@ describe('resolveAgentsMdChain', () => {
   it('returns an empty chain when the workspace itself cannot be canonicalized', () => {
     const missing = path.join(root, 'missing-workspace');
     expect(resolveAgentsMdChain('file.ts', missing, agentsConfig())).toEqual([]);
+  });
+
+  it('canonicalizes the cwd once and serves repeats from a bounded cache (F1)', () => {
+    write('AGENTS.md', 'root');
+    write('pkg/x.ts', 'code');
+    const config = agentsConfig();
+    const cwdKey = path.resolve(workspace);
+
+    const realpathSpy = vi.spyOn(fs.realpathSync, 'native');
+    try {
+      const first = resolveAgentsMdChain('pkg/x.ts', workspace, config);
+      expect(first.length).toBeGreaterThan(0);
+      for (let i = 0; i < 25; i++) {
+        expect(resolveAgentsMdChain('pkg/x.ts', workspace, config)).toEqual(first);
+      }
+      // Only the cwd canonicalization is cached; count just those calls. Without
+      // the cache this would be 26 (one per resolve); with it, exactly one.
+      const cwdCalls = realpathSpy.mock.calls.filter((call) => call[0] === cwdKey).length;
+      expect(cwdCalls).toBe(1);
+    } finally {
+      realpathSpy.mockRestore();
+    }
   });
 });
 
@@ -289,6 +324,28 @@ describe('agents_md config schema', () => {
     ).toBe(false);
     expect(configSchema.safeParse({ agents_md: { max_file_bytes: 0 } }).success).toBe(false);
     expect(configSchema.safeParse({ agents_md: { max_chain_depth: -1 } }).success).toBe(false);
+  });
+
+  it('bounds max_file_bytes, max_chain_depth, and filenames length (F10)', () => {
+    // At the upper bounds still parses.
+    expect(
+      configSchema.safeParse({ agents_md: { max_file_bytes: 2_097_152, max_chain_depth: 32 } })
+        .success,
+    ).toBe(true);
+    expect(
+      configSchema.safeParse({
+        agents_md: { filenames: Array.from({ length: 16 }, (_, i) => `f${i}.md`) },
+      }).success,
+    ).toBe(true);
+
+    // Above the bounds is rejected (DoS guard: readAgentsMdContent allocs max_file_bytes).
+    expect(configSchema.safeParse({ agents_md: { max_file_bytes: 2_097_153 } }).success).toBe(false);
+    expect(configSchema.safeParse({ agents_md: { max_chain_depth: 33 } }).success).toBe(false);
+    expect(
+      configSchema.safeParse({
+        agents_md: { filenames: Array.from({ length: 17 }, (_, i) => `f${i}.md`) },
+      }).success,
+    ).toBe(false);
   });
 
   it('deep-merges a partial project override without wiping sibling fields', () => {

--- a/electron/tests/unit/agents-md-root-injection.test.ts
+++ b/electron/tests/unit/agents-md-root-injection.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Root AGENTS.md injection tests (U3).
+ *
+ * Covers the pure helpers in `project/agents-md.ts`: locating the workspace-root
+ * instruction file (`findRootAgentsMdEntry`) and appending its byte-capped
+ * content to the system prompt (`appendRootAgentsMd`). The chat.ts wiring is not
+ * unit-tested here — it is verified by typecheck plus the existing chat and
+ * personality suites staying green.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  defaults,
+  type AgentsMdConfig,
+  type Config,
+} from '../../src/main/config';
+import { AGENTS_MD_DEFAULTS } from '../../src/main/agents-md/config';
+import {
+  appendRootAgentsMd,
+  findRootAgentsMdEntry,
+} from '../../src/main/project/agents-md';
+import type { ProjectRuntime } from '../../src/main/project/runtime';
+
+const BASE_PROMPT = 'You are a helpful assistant.';
+
+/** Build a full Config with `agents_md` overrides applied over the defaults. */
+function agentsConfig(overrides: Partial<AgentsMdConfig> = {}): Config {
+  return { ...defaults(), agents_md: { ...AGENTS_MD_DEFAULTS, ...overrides } };
+}
+
+/** Minimal runtime carrying only the fields the helpers read. */
+function makeRuntime(projectDir: string, config: Config): ProjectRuntime {
+  return {
+    projectDir,
+    config,
+    agents: new Map(),
+    skills: new Map(),
+    personalities: new Map(),
+  };
+}
+
+describe('root AGENTS.md injection', () => {
+  let root: string;
+  let workspace: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-root-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(workspace);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content = 'instructions'): string {
+    const abs = path.join(workspace, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+    return abs;
+  }
+
+  it('appends the root file content and reports a root-tier entry', () => {
+    const rootFile = write('AGENTS.md', 'root instructions');
+    const config = agentsConfig();
+
+    const entry = findRootAgentsMdEntry(workspace, config);
+    expect(entry).not.toBeNull();
+    expect(entry?.tier).toBe('root');
+    expect(entry?.path).toBe(rootFile);
+    expect(entry?.displayPath).toBe('AGENTS.md');
+
+    const result = appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config));
+    expect(result).toBe(
+      `${BASE_PROMPT}\n\n## Project instructions (AGENTS.md)\n\nroot instructions\n`,
+    );
+    expect(result.startsWith(BASE_PROMPT)).toBe(true);
+    expect(result).toContain('root instructions');
+  });
+
+  it('returns the prompt unchanged when no root instruction file exists', () => {
+    const config = agentsConfig();
+
+    expect(findRootAgentsMdEntry(workspace, config)).toBeNull();
+    expect(appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config))).toBe(
+      BASE_PROMPT,
+    );
+  });
+
+  it('returns the prompt unchanged when the feature is disabled, even with a root file', () => {
+    write('AGENTS.md', 'root instructions');
+    const config = agentsConfig({ enabled: false });
+
+    expect(findRootAgentsMdEntry(workspace, config)).toBeNull();
+    expect(appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config))).toBe(
+      BASE_PROMPT,
+    );
+  });
+
+  it('injects only the first configured alias when the root has several', () => {
+    write('AGENTS.md', 'primary content');
+    write('CLAUDE.md', 'alias content');
+    const config = agentsConfig();
+
+    const entry = findRootAgentsMdEntry(workspace, config);
+    expect(entry?.displayPath).toBe('AGENTS.md');
+
+    const result = appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config));
+    expect(result).toContain('primary content');
+    expect(result).not.toContain('alias content');
+    expect(result).toContain('## Project instructions (AGENTS.md)');
+  });
+
+  it('truncates an over-cap root file and appends a read pointer note', () => {
+    write('AGENTS.md', 'x'.repeat(100));
+    const config = agentsConfig({ max_file_bytes: 10 });
+
+    const entry = findRootAgentsMdEntry(workspace, config);
+    expect(entry?.sizeBytes).toBe(100);
+
+    const result = appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config));
+    expect(result).toContain('x'.repeat(10));
+    expect(result).not.toContain('x'.repeat(11));
+    expect(result).toContain('[truncated to 10 bytes');
+    expect(result).toContain('use read for the full file]');
+  });
+
+  it('does not add a truncation note for a file at exactly max_file_bytes', () => {
+    write('AGENTS.md', 'y'.repeat(10));
+    const config = agentsConfig({ max_file_bytes: 10 });
+
+    const result = appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config));
+    expect(result).toContain('y'.repeat(10));
+    expect(result).not.toContain('[truncated');
+  });
+
+  it('picks up a root AGENTS.local.md only when include_local is true and no alias precedes it', () => {
+    write('AGENTS.local.md', 'local only');
+
+    expect(findRootAgentsMdEntry(workspace, agentsConfig({ include_local: false }))).toBeNull();
+
+    const config = agentsConfig({ include_local: true });
+    const entry = findRootAgentsMdEntry(workspace, config);
+    expect(entry?.displayPath).toBe('AGENTS.local.md');
+
+    const result = appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config));
+    expect(result).toContain('local only');
+    expect(result).toContain('## Project instructions (AGENTS.local.md)');
+  });
+
+  it('returns null for a nested-only setup with no root instruction file', () => {
+    write('pkg/AGENTS.md', 'nested only');
+    const config = agentsConfig();
+
+    expect(findRootAgentsMdEntry(workspace, config)).toBeNull();
+    expect(appendRootAgentsMd(BASE_PROMPT, makeRuntime(workspace, config))).toBe(
+      BASE_PROMPT,
+    );
+  });
+});

--- a/electron/tests/unit/agents-md-subagent.test.ts
+++ b/electron/tests/unit/agents-md-subagent.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Subagent AGENTS.md handling tests (U6).
+ *
+ * Covers the two U6 guarantees plus the no-session degradation they rely on:
+ * - Subagents START FRESH WITH THE ROOT: `seedSubagentRootAgentsMd` seeds only
+ *   the subagent's scope-keyed store with the root instruction file (R13/R15),
+ *   never touching the parent/main store, so the nested read-path mechanism
+ *   never re-injects the root for the subagent (R4).
+ * - The renderer `tool:execute` UI path opts out of AGENTS.md injection and
+ *   write enforcement via `agentsMdDisabled` (R17/UI).
+ * - Dispatch without a session degrades safely: no injection, no blocking (R17).
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  defaults,
+  type AgentsMdConfig,
+  type Config,
+} from '../../src/main/config';
+import { AGENTS_MD_DEFAULTS } from '../../src/main/agents-md/config';
+import { buildAgentsMdInjection } from '../../src/main/agents-md/inject';
+import {
+  findRootAgentsMdEntry,
+  seedSubagentRootAgentsMd,
+} from '../../src/main/project/agents-md';
+import type { ProjectRuntime } from '../../src/main/project/runtime';
+import { AgentsMdContextStore } from '../../src/main/session/agents-md-context';
+import { SessionManager } from '../../src/main/session/manager';
+import { _clearDbCache } from '../../src/main/session/storage';
+import type { AgentsMdEntry } from '../../src/main/agents-md/resolver';
+
+/** Build a full Config with `agents_md` overrides applied over the defaults. */
+function agentsConfig(overrides: Partial<AgentsMdConfig> = {}): Config {
+  return { ...defaults(), agents_md: { ...AGENTS_MD_DEFAULTS, ...overrides } };
+}
+
+/** Minimal ProjectRuntime carrying only what the AGENTS.md helpers read. */
+function runtimeFor(projectDir: string, config: Config): ProjectRuntime {
+  return { projectDir, config } as unknown as ProjectRuntime;
+}
+
+function makeEntry(
+  filePath: string,
+  mtimeMs = 1000,
+  tier: 'root' | 'nested' = 'nested',
+): AgentsMdEntry {
+  return { path: filePath, displayPath: filePath, tier, sizeBytes: 42, mtimeMs };
+}
+
+describe('subagent AGENTS.md seeding and scope isolation', () => {
+  const sessionId = `agents-md-subagent-${Date.now()}`;
+  let tmpDir: string;
+  let workspace: string;
+  let manager: SessionManager;
+  let config: Config;
+  let runtime: ProjectRuntime;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-subagent-'));
+    workspace = path.join(tmpDir, 'workspace');
+    fs.mkdirSync(path.join(workspace, 'pkg'), { recursive: true });
+    fs.writeFileSync(path.join(workspace, 'AGENTS.md'), 'root instructions', 'utf-8');
+    fs.writeFileSync(path.join(workspace, 'pkg', 'AGENTS.md'), 'nested instructions', 'utf-8');
+    fs.writeFileSync(path.join(workspace, 'pkg', 'x.ts'), 'code', 'utf-8');
+    manager = new SessionManager({
+      storage: { dbPath: path.join(tmpDir, 'sessions.db') },
+    });
+    config = agentsConfig();
+    runtime = runtimeFor(workspace, config);
+  });
+
+  afterEach(() => {
+    _clearDbCache();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('seeds the root into the given scope store only; other scopes stay empty', () => {
+    const rootEntry = findRootAgentsMdEntry(workspace, config);
+    expect(rootEntry).not.toBeNull();
+
+    seedSubagentRootAgentsMd(sessionId, 'sub-1', runtime, manager);
+
+    const subStore = manager.getAgentsMdContextStore(sessionId, 'sub-1');
+    expect(subStore.isSeen(rootEntry!.path)).toBe(true);
+    expect(subStore.size).toBe(1);
+    // A fresh store for a different scope is still empty (no inheritance).
+    expect(manager.getAgentsMdContextStore(sessionId, 'sub-2').size).toBe(0);
+  });
+
+  it('seeding a subagent scope does not mark the main scope, and vice versa (R15)', () => {
+    seedSubagentRootAgentsMd(sessionId, 'sub-1', runtime, manager);
+
+    const sub = manager.getAgentsMdContextStore(sessionId, 'sub-1');
+    const main = manager.getAgentsMdContextStore(sessionId, 'main');
+    const rootEntry = findRootAgentsMdEntry(workspace, config)!;
+
+    // The subagent seed landed in the subagent scope...
+    expect(sub.isSeen(rootEntry.path)).toBe(true);
+    // ...and did NOT touch the parent/main store.
+    expect(main.isSeen(rootEntry.path)).toBe(false);
+    expect(main.size).toBe(0);
+
+    // Vice versa: marking the main scope does not leak into the subagent scope.
+    const nested = makeEntry(path.join(workspace, 'pkg', 'AGENTS.md'));
+    main.markSeen(nested);
+    expect(main.isSeen(nested.path)).toBe(true);
+    expect(sub.isSeen(nested.path)).toBe(false);
+  });
+
+  it('a subagent store seeded with the root injects only the nested file on read (R4)', () => {
+    seedSubagentRootAgentsMd(sessionId, 'sub-1', runtime, manager);
+    const subStore = manager.getAgentsMdContextStore(sessionId, 'sub-1');
+
+    const injection = buildAgentsMdInjection(
+      'read',
+      { file_path: 'pkg/x.ts' },
+      workspace,
+      config,
+      subStore,
+    );
+
+    expect(injection).not.toBeNull();
+    expect(injection!.xml).toContain('nested instructions');
+    expect(injection!.xml).not.toContain('root instructions');
+    expect(injection!.injected).toHaveLength(1);
+    expect(injection!.injected[0]?.tier).toBe('nested');
+  });
+
+  it('no-ops without a session id (never throws, seeds nothing)', () => {
+    expect(() =>
+      seedSubagentRootAgentsMd(undefined, 'sub-1', runtime, manager),
+    ).not.toThrow();
+    expect(manager.getAgentsMdContextStore(sessionId, 'sub-1').size).toBe(0);
+  });
+
+  it('seeds nothing when there is no root instruction file', () => {
+    const bare = path.join(tmpDir, 'bare');
+    fs.mkdirSync(bare);
+    seedSubagentRootAgentsMd(sessionId, 'sub-1', runtimeFor(bare, config), manager);
+    expect(manager.getAgentsMdContextStore(sessionId, 'sub-1').size).toBe(0);
+  });
+
+  it('seeds nothing when the feature is disabled', () => {
+    const disabled = runtimeFor(workspace, agentsConfig({ enabled: false }));
+    seedSubagentRootAgentsMd(sessionId, 'sub-1', disabled, manager);
+    expect(manager.getAgentsMdContextStore(sessionId, 'sub-1').size).toBe(0);
+  });
+});
+
+describe('dispatch-level UI gating (agentsMdDisabled)', () => {
+  const sessionId = `agents-md-subagent-ui-${Date.now()}`;
+  let root: string;
+  let workspace: string;
+  let store: AgentsMdContextStore;
+  let writeHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-subagent-ui-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(path.join(workspace, 'pkg'), { recursive: true });
+    fs.writeFileSync(path.join(workspace, 'pkg', 'AGENTS.md'), 'nested dispatch rules', 'utf-8');
+    fs.writeFileSync(path.join(workspace, 'pkg', 'x.ts'), 'code', 'utf-8');
+    store = new AgentsMdContextStore();
+    writeHandler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'wrote' } }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  async function registerReadTool() {
+    const { ToolRegistry } = await import('../../src/main/tools/registry');
+    const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
+    const registry = new ToolRegistry();
+    registry.register(
+      {
+        name: 'read',
+        description: 'Read a file',
+        inputSchema: z.object({ file_path: z.string() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'filesystem',
+        riskClass: 'read-only',
+      },
+      async () => ({ status: 'complete' as const, data: { value: 'file body' } }),
+    );
+    return registry;
+  }
+
+  async function registerWriteTool() {
+    const { ToolRegistry } = await import('../../src/main/tools/registry');
+    const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
+    const registry = new ToolRegistry();
+    registry.register(
+      {
+        name: 'write',
+        description: 'Write a file',
+        inputSchema: z.object({ file_path: z.string(), content: z.string().optional() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'filesystem',
+        riskClass: 'write',
+      },
+      writeHandler,
+    );
+    return registry;
+  }
+
+  it('read with agentsMdDisabled does not append an <agents_md> block', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerReadTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      const gated = await executeToolCall(
+        { id: 'read-ui', name: 'read', args: { file_path: 'pkg/x.ts' } },
+        registry,
+        { cwd: workspace, sessionId, agentsMdDisabled: true },
+      );
+
+      expect(gated.canonical.status).toBe('complete');
+      expect(gated.agentProjection.content).not.toContain('<agents_md');
+      // Nothing was injected, so the tracker stays empty.
+      expect(store.size).toBe(0);
+
+      // Control: the same store with the flag off DOES inject — proving the
+      // flag (not an empty store) is what gated the injection.
+      const control = await executeToolCall(
+        { id: 'read-ui-control', name: 'read', args: { file_path: 'pkg/x.ts' } },
+        registry,
+        { cwd: workspace, sessionId },
+      );
+      expect(control.agentProjection.content).toContain('<agents_md');
+      expect(store.size).toBe(1);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('write with agentsMdDisabled is not blocked under the block policy', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const registry = await registerWriteTool();
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    _setAgentsMdStoreResolverForTests(() => store);
+    const blockRuntime = {
+      config: agentsConfig({ enforce_on_write: 'block' }),
+    } as never;
+
+    try {
+      const gated = await executeToolCall(
+        { id: 'write-ui', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        { cwd: workspace, sessionId, agentsMdDisabled: true, projectRuntime: blockRuntime },
+      );
+
+      // Enforcement was skipped, so the mutation ran despite the unseen file.
+      expect(gated.canonical.status).toBe('complete');
+      expect(writeHandler).toHaveBeenCalledTimes(1);
+
+      // Control: the same store/policy with the flag off IS blocked.
+      const control = await executeToolCall(
+        { id: 'write-ui-control', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+        registry,
+        { cwd: workspace, sessionId, projectRuntime: blockRuntime },
+      );
+      expect(control.canonical.status).toBe('error');
+      expect(control.canonical.error?.code).toBe('agents_md_not_in_context');
+      expect(writeHandler).toHaveBeenCalledTimes(1);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+});
+
+describe('dispatch-level no-session degradation (R17)', () => {
+  let root: string;
+  let workspace: string;
+  let store: AgentsMdContextStore;
+  let writeHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-agents-md-subagent-nosession-'));
+    workspace = path.join(root, 'workspace');
+    fs.mkdirSync(path.join(workspace, 'pkg'), { recursive: true });
+    fs.writeFileSync(path.join(workspace, 'pkg', 'AGENTS.md'), 'nested dispatch rules', 'utf-8');
+    fs.writeFileSync(path.join(workspace, 'pkg', 'x.ts'), 'code', 'utf-8');
+    store = new AgentsMdContextStore();
+    writeHandler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'wrote' } }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('read with no sessionId injects nothing even with a resolvable store', async () => {
+    const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
+      '../../src/main/llm/tool-dispatch'
+    );
+    const { ToolRegistry } = await import('../../src/main/tools/registry');
+    const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
+    const registry = new ToolRegistry();
+    registry.register(
+      {
+        name: 'read',
+        description: 'Read a file',
+        inputSchema: z.object({ file_path: z.string() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'filesystem',
+        riskClass: 'read-only',
+      },
+      async () => ({ status: 'complete' as const, data: { value: 'file body' } }),
+    );
+    // A store with unseen content: if injection wrongly ran, it would inject.
+    _setAgentsMdStoreResolverForTests(() => store);
+
+    try {
+      const result = await executeToolCall(
+        { id: 'read-nosession', name: 'read', args: { file_path: 'pkg/x.ts' } },
+        registry,
+        { cwd: workspace }, // no sessionId
+      );
+
+      expect(result.canonical.status).toBe('complete');
+      expect(result.agentProjection.content).not.toContain('<agents_md');
+      expect(store.size).toBe(0);
+    } finally {
+      _setAgentsMdStoreResolverForTests(null);
+    }
+  });
+
+  it('write with no sessionId is not blocked under the block policy', async () => {
+    const { executeToolCall } = await import('../../src/main/llm/tool-dispatch');
+    const { ToolRegistry } = await import('../../src/main/tools/registry');
+    const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
+    const registry = new ToolRegistry();
+    registry.register(
+      {
+        name: 'write',
+        description: 'Write a file',
+        inputSchema: z.object({ file_path: z.string(), content: z.string().optional() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'filesystem',
+        riskClass: 'write',
+      },
+      writeHandler,
+    );
+    // No session → no session permission override; allow the mutator via a
+    // project-config rule so the AGENTS.md path (not permission) is under test.
+    const blockRuntime = {
+      config: {
+        ...agentsConfig({ enforce_on_write: 'block' }),
+        permissions: { write: 'allow' },
+      },
+    } as never;
+
+    const result = await executeToolCall(
+      { id: 'write-nosession', name: 'write', args: { file_path: 'pkg/x.ts', content: 'new' } },
+      registry,
+      { cwd: workspace, projectRuntime: blockRuntime }, // no sessionId
+    );
+
+    expect(result.canonical.status).toBe('complete');
+    expect(writeHandler).toHaveBeenCalledOnce();
+  });
+});

--- a/electron/tests/unit/apply-patch.test.ts
+++ b/electron/tests/unit/apply-patch.test.ts
@@ -711,8 +711,7 @@ describe('apply_patch agentProjector', () => {
 
     const result = projector(canonical(data));
 
-    expect(result.content).toContain('<file path="obsolete.txt" operation="delete" status="complete"');
-    expect(result.content).toContain('<file path="obsolete.txt" operation="delete" status="complete">\n</file>');
+    expect(result.content).toContain('<file path="obsolete.txt" operation="delete" status="complete" />');
     expect(result.content).not.toContain('<old_string>');
     expect(result.content).not.toContain('<new_string>');
   });
@@ -754,7 +753,7 @@ describe('apply_patch agentProjector', () => {
     expect(result.content).not.toContain('<bye>');
   });
 
-  it('renders old_string/new_string from hunks', () => {
+  it('renders file attributes without duplicating hunk content', () => {
     const data: ApplyPatchResultData = {
       files: [
         {
@@ -787,10 +786,9 @@ describe('apply_patch agentProjector', () => {
 
     const result = projector(canonical(data));
 
-    expect(result.content).toContain('<old_string>');
-    expect(result.content).toContain('function greet() {\n  return "hi";\n}');
-    expect(result.content).toContain('<new_string>');
-    expect(result.content).toContain('function greet() {\n  return "hello";\n}');
+    expect(result.content).toContain('<file path="src/util.ts" operation="update" status="complete" />');
+    expect(result.content).not.toContain('<old_string>');
+    expect(result.content).not.toContain('<new_string>');
   });
 
   it('F11: counts unique file paths in summary (not operations)', () => {

--- a/electron/tests/unit/filesystem-tool-results.test.ts
+++ b/electron/tests/unit/filesystem-tool-results.test.ts
@@ -403,8 +403,9 @@ describe('XML agent projections', () => {
           new_string: 'changed',
         },
     }, registry, context);
-    expect(edit.agentProjection.content).toContain('<old_string>needle first</old_string>');
-    expect(edit.agentProjection.content).toContain('<new_string>changed first</new_string>');
+    expect(edit.agentProjection.content).toContain('1 replacement');
+    expect(edit.agentProjection.content).not.toContain('<old_string>');
+    expect(edit.agentProjection.content).not.toContain('<new_string>');
     expect(edit.agentProjection.content).not.toContain('@@');
 
     const glob = await executeToolCall({
@@ -438,7 +439,7 @@ describe('XML agent projections', () => {
     expect(directory.agentProjection.content).not.toContain('format="dynamic-system-prompt"');
   });
 
-  it('write projection: empty body has no preview payload', async () => {
+  it('write projection: empty file reports summary without content', async () => {
     const registry = new ToolRegistry();
     registry.register(writeDefinition, writeHandler);
     const execution = await executeToolCall(
@@ -453,12 +454,11 @@ describe('XML agent projections', () => {
     expect(execution.canonical.status).toBe('complete');
     expect(fileWriteDataSchema.parse(execution.canonical.data).content).toBe('');
     expect(execution.agentProjection.content).toContain('name="write"');
+    expect(execution.agentProjection.content).toContain('0 lines');
     expect(execution.agentProjection.content).not.toContain('<preview>');
-    expect(execution.agentProjection.content).not.toContain('<head>');
-    expect(execution.agentProjection.content).not.toContain('<tail>');
   });
 
-  it('write projection: short files use a full <preview>', async () => {
+  it('write projection: short files report summary without content', async () => {
     const registry = new ToolRegistry();
     registry.register(writeDefinition, writeHandler);
     const content = Array.from({ length: 8 }, (_, i) => `line-${i + 1}`).join('\n') + '\n';
@@ -472,14 +472,12 @@ describe('XML agent projections', () => {
       { cwd: tmpDir, sessionId: SESSION_ID },
     );
     expect(fileWriteDataSchema.parse(execution.canonical.data).content).toBe(content);
-    expect(execution.agentProjection.content).toContain('<preview>');
-    expect(execution.agentProjection.content).toContain('line-1');
-    expect(execution.agentProjection.content).toContain('line-8');
-    expect(execution.agentProjection.content).not.toContain('<head>');
-    expect(execution.agentProjection.content).not.toContain('<tail>');
+    expect(execution.agentProjection.content).toContain('8 lines');
+    expect(execution.agentProjection.content).not.toContain('<preview>');
+    expect(execution.agentProjection.content).not.toContain('line-1');
   });
 
-  it('write projection: long files include full content in preview', async () => {
+  it('write projection: long files report summary without content', async () => {
     const registry = new ToolRegistry();
     registry.register(writeDefinition, writeHandler);
     const lines = Array.from({ length: 20 }, (_, i) => `line-${i + 1}`);
@@ -495,12 +493,9 @@ describe('XML agent projections', () => {
     );
     const proj = execution.agentProjection.content;
     expect(fileWriteDataSchema.parse(execution.canonical.data).content).toContain('line-10');
-    expect(proj).toContain('<preview>');
-    expect(proj).toContain('line-1');
-    expect(proj).toContain('line-10');
-    expect(proj).toContain('line-20');
-    expect(proj).not.toContain('<head>');
-    expect(proj).not.toContain('<tail>');
+    expect(proj).toContain('20 lines');
+    expect(proj).not.toContain('<preview>');
+    expect(proj).not.toContain('line-1');
   });
 });
 

--- a/electron/tests/unit/llm-orchestrator.test.ts
+++ b/electron/tests/unit/llm-orchestrator.test.ts
@@ -1966,6 +1966,14 @@ describe('streamChat', () => {
     expect(events.indexOf(usageEvents[1]!)).toBeLessThan(
       events.findIndex((event) => event.type === 'finish'),
     );
+
+    // Each completed step also emits a step_finish boundary (used by the
+    // subagent manager to isolate the final step's text as the result).
+    const stepFinishEvents = events.filter((event) => event.type === 'step_finish');
+    expect(stepFinishEvents).toMatchObject([
+      { type: 'step_finish', stepIndex: 0, finishReason: 'tool-calls' },
+      { type: 'step_finish', stepIndex: 1, finishReason: 'stop' },
+    ]);
     expect(aiSdkMocks.streamText).toHaveBeenCalledWith(expect.objectContaining({
       include: { requestMessages: true },
     }));

--- a/electron/tests/unit/permission-resolver.test.ts
+++ b/electron/tests/unit/permission-resolver.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { defaults } from '../../src/main/config/schema';
 import {
+  extractPathsFromArgs,
   resolvePermission,
   resolveToolScope,
 } from '../../src/main/permissions/resolver';
@@ -92,6 +93,25 @@ describe('permission resolver', () => {
     ].join('\n');
 
     expect(resolveToolScope('apply_patch', { patch }, workspace)).toBe('outside');
+  });
+
+  it('extracts apply_patch paths from indented (space/tab) headers like the parser (F3)', () => {
+    // The real parser trims lines before matching header markers, so indented
+    // headers are valid; extraction must see them too (or enforcement + scope
+    // detection are bypassed).
+    const patch = [
+      '*** Begin Patch',
+      '   *** Add File: pkg/x.ts',
+      '+content',
+      '\t*** Delete File: pkg/old.ts',
+      '   *** Move to: pkg/moved.ts',
+      '*** End Patch',
+    ].join('\n');
+
+    const paths = extractPathsFromArgs('apply_patch', { patch });
+    expect(paths).toContain('pkg/x.ts');
+    expect(paths).toContain('pkg/old.ts');
+    expect(paths).toContain('pkg/moved.ts');
   });
 
   it('classifies grep by its directory_path scope', () => {

--- a/electron/tests/unit/subagent-tools.test.ts
+++ b/electron/tests/unit/subagent-tools.test.ts
@@ -155,6 +155,20 @@ describe('delegate_to_subagent', () => {
     expect(records[0].state).toBe(SubagentState.PENDING);
   });
 
+  it('omits the task from the projection (already in args + system prompt)', async () => {
+    const { handler } = buildDelegateTool(agents, manager);
+
+    const result = (await handler({
+      name: 'review auth',
+      task: 'Review the authentication module for security issues',
+      type: 'code-reviewer',
+    }, toolContext)) as ToolExecutionResult;
+
+    expect(result.agentProjection.content).not.toContain('Review the authentication module');
+    expect(result.agentProjection.content).not.toContain('<task>');
+    expect(result.agentProjection.content).toContain('review auth');
+  });
+
   it('should use agent default tier when tier not specified', async () => {
     const { handler } = buildDelegateTool(agents, manager);
 

--- a/electron/tests/unit/subagent-tools.test.ts
+++ b/electron/tests/unit/subagent-tools.test.ts
@@ -365,7 +365,7 @@ describe('wait_for_subagent', () => {
     expect(result.agentProjection.content).not.toContain('private result');
   });
 
-  it('should include task in the output', async () => {
+  it('omits the task from the output (already in delegate args + system prompt)', async () => {
     const { handler } = buildWaitTool(manager);
     const record = manager.spawn('test', 'Review the auth module', codeReviewerAgent);
     manager.markCompleted(record.id, 'Looks good');
@@ -374,7 +374,9 @@ describe('wait_for_subagent', () => {
       subagent_ids: [record.id],
     })) as ToolExecutionResult;
 
-    expect(result.agentProjection.content).toContain('Review the auth module');
+    expect(result.agentProjection.content).not.toContain('Review the auth module');
+    expect(result.agentProjection.content).not.toContain('<task>');
+    expect(result.agentProjection.content).toContain('Looks good');
   });
 
   it('formats elapsed time and omits token usage from the output', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AGENTS.md discovery with session-scoped context tracking and configurable filename aliases, limits, and optional `AGENTS.local.md`.
  * Root AGENTS.md is injected into chat and delegated-agent prompts.
  * Eligible read operations automatically receive relevant nested instructions.
  * Eligible write operations enforce configurable `block`, `warn`, `inject`, or `off` policies for unseen governing instruction files.
* **Bug Fixes**
  * Improved detection of indented file paths in patch operations.
* **Documentation**
  * Expanded AGENTS.md behavior and configuration documentation, including the new config schema.
* **Tests**
  * Added comprehensive coverage for discovery, injection, enforcement, session isolation, and delegated subagent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->