### PR TITLE
Perf/batch 2 renderer hydration

### DIFF
--- a/electron/src/renderer/components/ChatStream.tsx
+++ b/electron/src/renderer/components/ChatStream.tsx
@@ -55,6 +55,8 @@ export const CHAIN_COLLAPSE_THRESHOLD = 20;
 
 /** Live tool arguments belong to the cheap tail, not the committed-history memo. */
 const NO_TOOL_BLOCKS: ToolBlock[] = [];
+const NO_SUBAGENTS: readonly SubagentRecord[] = [];
+const NO_SESSION_CHAINS: readonly Chain[] = [];
 
 interface ChatStreamProps {
   /** Whether the chat surface is currently available for presentation work. */
@@ -202,8 +204,8 @@ export function ChatStream({
   onRetry,
   usage,
   currentTurnUsage = null,
-  subagents = [],
-  sessionChains = [],
+  subagents = NO_SUBAGENTS,
+  sessionChains = NO_SESSION_CHAINS,
   sessionId = null,
   streamStartTime = null,
   interrupted,
@@ -256,11 +258,10 @@ export function ChatStream({
     setExpandedChainIndexes(new Set());
   }, [sessionId]);
 
-  // Committed history is independent of per-token stream text and wall-clock
-  // elapsed ticks. Keep it stable so long sessions do not rebuild O(n) lists.
-  // Live footer usage: current-turn snapshot while streaming; full usage when idle.
-  const footerLiveUsage =
-    status === 'streaming' ? currentTurnUsage : usage;
+  // Committed history is independent of per-token stream text, live usage,
+  // and wall-clock elapsed ticks. Keep it stable so long sessions do not
+  // rebuild O(n) lists. The active footer receives live usage below.
+  const historyUsage = status === 'streaming' ? null : usage;
   // Current-turn tool generation is rendered by the live tail. Excluding it
   // here keeps argument-only frame updates from rebuilding committed history.
   const historyToolBlocks = status === 'streaming' ? NO_TOOL_BLOCKS : toolBlocks;
@@ -270,7 +271,7 @@ export function ChatStream({
         messages,
         toolBlocks: historyToolBlocks,
         status,
-        liveUsage: footerLiveUsage,
+        liveUsage: historyUsage,
         subagents,
         sessionChains,
         interrupted: Boolean(interrupted),
@@ -280,7 +281,7 @@ export function ChatStream({
       messages,
       historyToolBlocks,
       status,
-      footerLiveUsage,
+      historyUsage,
       subagents,
       sessionChains,
       interrupted,
@@ -314,6 +315,55 @@ export function ChatStream({
   const liveGroupedItems = useMemo(
     () => foldStreamActivityGroups(liveItems),
     [liveItems],
+  );
+  // Keep stable history nodes by identity across live-only frames. They still
+  // participate in the same flat keyed sequence as the tail so a segment that
+  // commits before CHAT_DONE retains its DOM node at the live→history boundary.
+  const historyNodes = useMemo(
+    () => historyItems.map((item) =>
+      renderStreamItem(item, alwaysExpandToolGroups, expandChain, subagents),
+    ),
+    [historyItems, alwaysExpandToolGroups, expandChain, subagents],
+  );
+  const liveTailNodes = useMemo(
+    () => liveGroupedItems.map((item) =>
+      renderStreamItem(item, alwaysExpandToolGroups, expandChain, subagents),
+    ),
+    [liveGroupedItems, alwaysExpandToolGroups, expandChain, subagents],
+  );
+  const activeFooterNode = useMemo(() => {
+    if (!history.activeFooter) return null;
+    return renderStreamItem(
+      {
+        ...history.activeFooter,
+        usage:
+          status === 'streaming'
+            ? currentTurnUsage ?? history.activeFooter.usage
+            : history.activeFooter.usage,
+        elapsedSeconds:
+          status === 'streaming' && streamStartTime != null
+            ? liveElapsedSeconds
+            : undefined,
+      },
+      alwaysExpandToolGroups,
+      expandChain,
+      subagents,
+    );
+  }, [
+    history.activeFooter,
+    status,
+    currentTurnUsage,
+    streamStartTime,
+    liveElapsedSeconds,
+    alwaysExpandToolGroups,
+    expandChain,
+    subagents,
+  ]);
+  const streamNodes = useMemo(
+    () => activeFooterNode
+      ? [...historyNodes, ...liveTailNodes, activeFooterNode]
+      : [...historyNodes, ...liveTailNodes],
+    [historyNodes, liveTailNodes, activeFooterNode],
   );
 
   if (
@@ -379,27 +429,11 @@ export function ChatStream({
         )}
 
         {/* History + live tail + active footer render as ONE keyed sequence.
-            Separate JSX child expressions would each reconcile as their own
-            slot, so at turn end the committed bubble/footer (in history) would
-            unmount the live one (in the tail) and remount — replaying the
-            orchid-rise entrance animation as a visible flicker. One flat array
-            lets React match the shared keys (seg id / footer-chain id) and
-            reuse the DOM nodes across the live→committed swap. */}
-        {[
-          ...historyItems,
-          ...liveGroupedItems,
-          ...(history.activeFooter
-            ? [{
-                ...history.activeFooter,
-                elapsedSeconds:
-                  status === 'streaming' && streamStartTime != null
-                    ? liveElapsedSeconds
-                    : undefined,
-              }]
-            : []),
-        ].map((item) =>
-          renderStreamItem(item, alwaysExpandToolGroups, expandChain, subagents),
-        )}
+            History nodes remain referentially stable across live-only frames,
+            while the small tail/footer path updates independently. Keeping the
+            final nodes flat lets React retain shared segment/footer keys across
+            the live→committed swap instead of replaying entrance animation. */}
+        {streamNodes}
       </div>
       {isUserScrolledUp ? (
         <Button

--- a/electron/src/renderer/components/ToolActivityGroup.tsx
+++ b/electron/src/renderer/components/ToolActivityGroup.tsx
@@ -49,10 +49,15 @@ export function ToolActivityGroup({
   );
 
   const [expanded, setExpanded] = useState(alwaysExpand);
+  const [hasExpanded, setHasExpanded] = useState(alwaysExpand);
 
   useEffect(() => {
     if (alwaysExpand) setExpanded(true);
   }, [alwaysExpand]);
+
+  useEffect(() => {
+    if (expanded) setHasExpanded(true);
+  }, [expanded]);
 
   const summary = useMemo(
     () =>
@@ -122,10 +127,10 @@ export function ToolActivityGroup({
         </span>
       </button>
 
-      <CollapsibleRegion open={expanded} id={panelId}>
+      <CollapsibleRegion open={expanded} id={panelId} lazyMount>
         <div className="orchid-tool-activity-body">
           <div className="tool-activity-group-children orchid-tool-activity-children">
-            {items.map((child, i) => {
+            {(expanded || hasExpanded) && items.map((child, i) => {
               if (child.kind === 'tool') {
                 return (
                   <ToolCallBlock

--- a/electron/src/renderer/components/ToolResults/ToolResultShell.tsx
+++ b/electron/src/renderer/components/ToolResults/ToolResultShell.tsx
@@ -18,6 +18,16 @@ export interface ToolResultShellProps {
 }
 
 const expansionChoices = new Map<string, boolean>();
+const MAX_EXPANSION_CHOICES = 100;
+
+function rememberExpansionChoice(choiceKey: string, expanded: boolean): void {
+  expansionChoices.delete(choiceKey);
+  if (expansionChoices.size >= MAX_EXPANSION_CHOICES) {
+    const oldestKey = expansionChoices.keys().next().value;
+    if (oldestKey) expansionChoices.delete(oldestKey);
+  }
+  expansionChoices.set(choiceKey, expanded);
+}
 
 export function terminalStatusForBlock(block: ToolBlock): TerminalToolResultStatus | null {
   if (block.status === 'generating' || block.status === 'running') return null;
@@ -85,6 +95,7 @@ export function ToolResultShell({
   // explicit choice is retained through live-to-terminal replacement and
   // hydration; lifecycle updates never change it implicitly.
   const [expanded, setExpanded] = useState(() => expansionChoices.get(choiceKey) ?? false);
+  const [hasExpanded, setHasExpanded] = useState(expanded);
   const [announcement, setAnnouncement] = useState('');
   const active = block.status === 'generating' || block.status === 'running';
 
@@ -92,8 +103,13 @@ export function ToolResultShell({
     setAnnouncement(`${status} tool result`);
   }, [status]);
 
+  useEffect(() => {
+    if (expanded) setHasExpanded(true);
+  }, [expanded]);
+
   const displayTitle = title ?? block.toolName;
   const body = useMemo(() => {
+    if (!expanded && !hasExpanded) return null;
     if (block.status === 'generating') return <div className="orchid-tool-args-stream">streaming args: {block.partialArgs || '{'}</div>;
     if (block.status === 'running') {
       const value = canonical?.data && typeof canonical.data === 'object' && !Array.isArray(canonical.data)
@@ -106,15 +122,15 @@ export function ToolResultShell({
         : <div className="orchid-tool-running-hint">Running…</div>;
     }
     return canonical ? <ResultBody block={block} canonical={canonical} /> : null;
-  }, [block, canonical]);
+  }, [block, canonical, expanded, hasExpanded]);
 
   const toggle = () => {
     const next = !expanded;
-    expansionChoices.set(choiceKey, next);
+    rememberExpansionChoice(choiceKey, next);
     setExpanded(next);
   };
   const collapse = () => {
-    expansionChoices.set(choiceKey, false);
+    rememberExpansionChoice(choiceKey, false);
     setExpanded(false);
   };
 
@@ -142,7 +158,7 @@ export function ToolResultShell({
           />
         </span>
       </button>
-      <CollapsibleRegion open={expanded} id={panelId}>
+      <CollapsibleRegion open={expanded} id={panelId} lazyMount>
         <div
           className="orchid-tool-block-content min-w-0"
           aria-describedby={announcementId}

--- a/electron/src/renderer/components/ui/CollapsibleRegion.tsx
+++ b/electron/src/renderer/components/ui/CollapsibleRegion.tsx
@@ -1,13 +1,16 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import { useEffect, useState, type HTMLAttributes, type ReactNode } from 'react';
 
 export interface CollapsibleRegionProps extends HTMLAttributes<HTMLDivElement> {
   open: boolean;
   children: ReactNode;
   contentClassName?: string;
+  /** Defer the initial child mount until this region is first opened. */
+  lazyMount?: boolean;
 }
 
 /**
  * Keeps disclosure content mounted while animating its visible height.
+ * Lazy regions defer their children until first opened, then retain them.
  * Presentational only — the owning control supplies aria-expanded/controls.
  */
 export function CollapsibleRegion({
@@ -15,8 +18,15 @@ export function CollapsibleRegion({
   children,
   className = '',
   contentClassName = '',
+  lazyMount = false,
   ...props
 }: CollapsibleRegionProps) {
+  const [hasOpened, setHasOpened] = useState(open);
+
+  useEffect(() => {
+    if (open) setHasOpened(true);
+  }, [open]);
+
   const regionClasses = `orchid-collapsible-region ${open ? 'is-open' : ''} ${className}`
     .trim()
     .replace(/\s+/g, ' ');
@@ -31,7 +41,7 @@ export function CollapsibleRegion({
       inert={open ? undefined : true}
       {...props}
     >
-      <div className={contentClasses}>{children}</div>
+      <div className={contentClasses}>{(!lazyMount || open || hasOpened) ? children : null}</div>
     </div>
   );
 }

--- a/electron/tests/unit/chat-rendering-contract.test.ts
+++ b/electron/tests/unit/chat-rendering-contract.test.ts
@@ -294,8 +294,9 @@ describe('chat rendering contract (U5)', () => {
       const src = read('components/ChatStream.tsx');
       // Active/last-chain footers prefer live usage over persisted chain sums
       // so CHAT_USAGE events paint the agent: line before the turn commits.
-      expect(src).toMatch(/footerLiveUsage/);
+      expect(src).toMatch(/const historyUsage = status === 'streaming' \? null : usage/);
       expect(src).toMatch(/currentTurnUsage/);
+      expect(src).toMatch(/usage:\s*status === 'streaming'\s*\?\s*currentTurnUsage/);
       expect(src).toMatch(/isLastChain \? liveUsage \?\? chainUsage/);
       expect(src).toMatch(/isLastTurn\s*\?\s*liveUsage \?\? turnLastAssistantUsage/);
       // Must not gate live usage on idle/error only (regression: mid-stream stuck).

--- a/electron/tests/unit/chat-stable-history.test.tsx
+++ b/electron/tests/unit/chat-stable-history.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const renderCounts = vi.hoisted(() => new Map<string, number>());
+const footerUsages = vi.hoisted(() => new Map<string, number | null>());
+
+vi.mock('../../src/renderer/components/MessageWidget', () => ({
+  MessageWidget: ({ message }: { message: { id: string } }) => {
+    renderCounts.set(message.id, (renderCounts.get(message.id) ?? 0) + 1);
+    return <div data-testid={`message-${message.id}`} />;
+  },
+}));
+
+vi.mock('../../src/renderer/components/ChainFooter', () => ({
+  ChainFooter: ({ usage }: { usage: { total_tokens: number } | null }) => {
+    footerUsages.set('active', usage?.total_tokens ?? null);
+    return <div data-testid="active-footer">{usage?.total_tokens ?? 'none'}</div>;
+  },
+}));
+
+import { ChatStream } from '../../src/renderer/components/ChatStream';
+import { MessageRole, MessageType, type Message, type Usage } from '../../src/shared/types/message';
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  renderCounts.clear();
+  footerUsages.clear();
+});
+
+function message(id: string, role: MessageRole, content: string): Message {
+  return {
+    id,
+    role,
+    content,
+    type: MessageType.TEXT,
+    tool_calls: null,
+    tool_call_id: null,
+    name: null,
+    thinking: null,
+    timestamp: '2026-07-27T00:00:00.000Z',
+    usage: null,
+    hidden: false,
+    tool_result: null,
+  };
+}
+
+const history = [
+  message('history-user', MessageRole.USER, 'Explain the cache.'),
+  message('history-assistant', MessageRole.ASSISTANT, 'The cache is bounded.'),
+];
+
+function usage(totalTokens: number): Usage {
+  return {
+    prompt_tokens: totalTokens - 1,
+    completion_tokens: 1,
+    total_tokens: totalTokens,
+    cached_tokens: 0,
+  };
+}
+
+function props(streamingContent: string, streamRevision: number, currentTurnUsage: Usage) {
+  return {
+    messages: history,
+    streamingContent,
+    toolBlocks: [],
+    streamRevision,
+    status: 'streaming' as const,
+    error: null,
+    usage: null,
+    currentTurnUsage,
+    onClearError: vi.fn(),
+    streamSegments: [{ kind: 'text' as const, id: 'live-text', content: streamingContent }],
+  };
+}
+
+describe('ChatStream stable history boundary', () => {
+  it('does not recreate committed rows for a live-only stream revision while the active footer updates', () => {
+    const view = render(
+      <ChatStream {...props('first live token', 1, usage(10))} />,
+    );
+    const historyRendersBeforeLiveUpdate = {
+      user: renderCounts.get('history-user') ?? 0,
+      assistant: renderCounts.get('history-assistant') ?? 0,
+    };
+
+    view.rerender(
+      <ChatStream {...props('second live token', 2, usage(20))} />,
+    );
+
+    expect(renderCounts.get('history-user')).toBe(historyRendersBeforeLiveUpdate.user);
+    expect(renderCounts.get('history-assistant')).toBe(historyRendersBeforeLiveUpdate.assistant);
+    expect(footerUsages.get('active')).toBe(20);
+  });
+
+  it('keeps a live row mounted when SESSION_UPDATED commits it before CHAT_DONE', () => {
+    const view = render(
+      <ChatStream {...props('final answer', 1, usage(10))} />,
+    );
+    const liveNode = screen.getByTestId('message-live-text');
+
+    view.rerender(
+      <ChatStream
+        {...props('final answer', 2, usage(20))}
+        messages={[
+          ...history,
+          message('live-text', MessageRole.ASSISTANT, 'final answer'),
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByTestId('message-live-text')).toHaveLength(1);
+    expect(screen.getByTestId('message-live-text')).toBe(liveNode);
+  });
+});

--- a/electron/tests/unit/tool-result-lazy-mount.test.tsx
+++ b/electron/tests/unit/tool-result-lazy-mount.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { CanonicalToolResult } from '../../src/shared/types/tool-result';
+import type { ToolBlock } from '../../src/renderer/hooks/useChat';
+import { ToolActivityGroup } from '../../src/renderer/components/ToolActivityGroup';
+import {
+  resetToolResultExpansionState,
+  ToolResultShell,
+} from '../../src/renderer/components/ToolResults/ToolResultShell';
+import { registerToolResultRenderer } from '../../src/renderer/components/ToolResults/registry';
+import { CollapsibleRegion } from '../../src/renderer/components/ui/CollapsibleRegion';
+
+afterEach(() => {
+  cleanup();
+  resetToolResultExpansionState();
+});
+
+const result: CanonicalToolResult = {
+  schemaVersion: 1,
+  family: 'generic',
+  status: 'complete',
+  completeness: 'complete',
+  data: { value: 'result' },
+};
+
+function block(id: string): ToolBlock {
+  return {
+    id,
+    toolName: 'lazy_probe',
+    status: 'complete',
+    partialArgs: '',
+    args: '{}',
+    agentProjection: '',
+    toolResult: result,
+    startedAt: '2026-07-27T00:00:00.000Z',
+    finishedAt: '2026-07-27T00:00:00.000Z',
+  };
+}
+
+describe('lazy tool disclosure mounting', () => {
+  it('mounts a lazy region immediately when initially open', () => {
+    render(
+      <CollapsibleRegion open lazyMount>
+        <div data-testid="initially-open-probe">details</div>
+      </CollapsibleRegion>,
+    );
+
+    expect(screen.getByTestId('initially-open-probe')).toBeTruthy();
+  });
+
+  it('does not render a closed lazy region until first expansion, then retains it after collapse', () => {
+    let renders = 0;
+    function Probe() {
+      renders += 1;
+      return <div data-testid="region-probe">details</div>;
+    }
+
+    const { rerender } = render(
+      <CollapsibleRegion open={false} lazyMount>
+        <Probe />
+      </CollapsibleRegion>,
+    );
+    expect(renders).toBe(0);
+    expect(screen.queryByTestId('region-probe')).toBeNull();
+
+    rerender(
+      <CollapsibleRegion open lazyMount>
+        <Probe />
+      </CollapsibleRegion>,
+    );
+    expect(renders).toBe(1);
+    expect(screen.getByTestId('region-probe')).toBeTruthy();
+
+    rerender(
+      <CollapsibleRegion open={false} lazyMount>
+        <Probe />
+      </CollapsibleRegion>,
+    );
+    expect(renders).toBe(2);
+    expect(screen.getByTestId('region-probe')).toBeTruthy();
+  });
+
+  it('defers tool result renderers and tool activity children while their disclosures are closed', () => {
+    let resultRendererRenders = 0;
+    const restore = registerToolResultRenderer('lazy_probe', () => {
+      resultRendererRenders += 1;
+      return <div data-testid="tool-result-probe">result body</div>;
+    });
+    try {
+      const shell = render(<ToolResultShell block={block('shell')} />);
+      expect(resultRendererRenders).toBe(0);
+      expect(screen.queryByTestId('tool-result-probe')).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: /lazy_probe/i }));
+      expect(resultRendererRenders).toBeGreaterThan(0);
+      expect(screen.getByTestId('tool-result-probe')).toBeTruthy();
+
+      fireEvent.click(screen.getByTitle('Click to collapse'));
+      expect(screen.getByTestId('tool-result-probe')).toBeTruthy();
+      shell.unmount();
+      const rendersAfterShellExpansion = resultRendererRenders;
+
+      render(
+        <ToolActivityGroup
+          items={[{
+            kind: 'thought',
+            message: {
+              id: 'deferred-thought',
+              role: 'assistant',
+              content: 'deferred group thought',
+              type: 'thinking',
+              tool_calls: null,
+              tool_call_id: null,
+              name: null,
+              thinking: null,
+              timestamp: '2026-07-27T00:00:00.000Z',
+              usage: null,
+              hidden: false,
+              tool_result: null,
+            },
+          }]}
+        />,
+      );
+      expect(resultRendererRenders).toBe(rendersAfterShellExpansion);
+      expect(screen.queryByText('deferred group thought')).toBeNull();
+      fireEvent.click(screen.getByRole('button', { name: /activity/i }));
+      expect(screen.getByText('deferred group thought')).toBeTruthy();
+      fireEvent.click(screen.getByRole('button', { name: /activity/i }));
+      expect(screen.getByText('deferred group thought')).toBeTruthy();
+      expect(resultRendererRenders).toBe(rendersAfterShellExpansion);
+    } finally {
+      restore();
+    }
+  });
+
+  it('bounds retained expansion choices', () => {
+    const { unmount } = render(
+      <>
+        {Array.from({ length: 101 }, (_, index) => (
+          <ToolResultShell key={index} block={block(`choice-${index}`)} />
+        ))}
+      </>,
+    );
+    for (const button of screen.getAllByRole('button')) fireEvent.click(button);
+    unmount();
+
+    render(<ToolResultShell block={block('choice-0')} />);
+    expect(screen.getByRole('button', { name: /lazy_probe/i }).getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/review.md
+++ b/review.md
@@ -16,7 +16,7 @@ The highest-leverage corrections are:
 3. Stop subagent-only updates from invalidating the main transcript.
 4. Fix worker cancellation/health behavior and offload the remaining unbounded synchronous operations.
 
-No P0 data-loss or security-critical performance defect was identified. This report contains **7 P1 findings** and **8 P2 findings**.
+No P0 data-loss or security-critical performance defect was identified. This report contains **6 P1 findings** and **8 P2 findings**.
 
 ## Existing safeguards to preserve
 
@@ -428,38 +428,6 @@ Profile 100, 1,000, 2,000, and 5,000 visible items during a fixed 60-frame strea
 
 ---
 
-### F-15 — Collapsed tool results eagerly create their full hidden DOM
-
-**Severity:** P1
-**Confidence:** High; children always mount.
-**Primary files:**
-
-- `electron/src/renderer/components/ui/CollapsibleRegion.tsx:34`
-- `electron/src/renderer/components/ToolResults/ToolResultShell.tsx:96`
-- `electron/src/renderer/components/ToolResults/ToolResultShell.tsx:145`
-- `electron/src/renderer/components/ToolResults/FileContentToolResult.tsx:54`
-- `electron/src/renderer/components/ToolResults/diff-view.tsx:42`
-
-**Evidence and impact**
-
-Closed disclosures remain mounted for animation/state preservation. `ToolResultShell` also builds the result body before passing it into the closed region. Tool-heavy histories therefore create every hidden file line, search result, directory row, and diff line during hydration.
-
-The UI looks compact while retaining a large invisible DOM and parsing/render cost.
-
-**Recommended fix**
-
-1. Add a `lazyMount` or equivalent mode to `CollapsibleRegion`/`ToolResultShell`.
-2. Do not instantiate the result body until first expansion.
-3. After first expansion, keep it mounted if state preservation and collapse animation require it.
-4. Apply the same behavior to collapsed tool-activity groups.
-5. Bound the module-global expansion-state map or clear it on session disposal.
-
-**Verification**
-
-Load 20 chains containing 50 large read/diff results each. Compare session-switch scripting time, node count, heap, and first-expansion latency before and after lazy mounting.
-
----
-
 ### F-18 — RAG download/body stalls can hold indexing indefinitely
 
 **Severity:** P2
@@ -564,8 +532,7 @@ These items were not promoted to primary findings because impact or provider beh
 ### Batch 2 — Renderer streaming and hydration
 
 1. F-02: add a lightweight/deferred streaming Markdown path.
-2. F-15: lazy-mount collapsed tool-result bodies.
-3. F-14: isolate stable history from the live tail.
+2. F-14: isolate stable history from the live tail.
 
 Profile after each change; virtualization should be introduced only if stable-history isolation and lazy mounting do not meet the frame budget.
 

--- a/review.md
+++ b/review.md
@@ -16,7 +16,7 @@ The highest-leverage corrections are:
 3. Stop subagent-only updates from invalidating the main transcript.
 4. Fix worker cancellation/health behavior and offload the remaining unbounded synchronous operations.
 
-No P0 data-loss or security-critical performance defect was identified. This report contains **6 P1 findings** and **8 P2 findings**.
+No P0 data-loss or security-critical performance defect was identified. This report contains **6 P1 findings** and **7 P2 findings**.
 
 ## Existing safeguards to preserve
 
@@ -398,36 +398,6 @@ Serve deterministic 1/5/10 MiB fixtures, including deeply nested and table-heavy
 
 ---
 
-### F-14 — Every streaming frame still remaps the visible transcript
-
-**Severity:** P2
-**Confidence:** Medium-high; scaling needs React profiling.
-**Primary files:**
-
-- `electron/src/renderer/components/ChatStream.tsx:53`
-- `electron/src/renderer/components/ChatStream.tsx:382`
-- `electron/src/renderer/components/ChatStream.tsx:394`
-- `electron/src/renderer/components/ChatStream.tsx:550`
-
-**Evidence and impact**
-
-History construction is memoized separately, which is good, but every live frame still spreads history and live items into a new array, creates React elements for every visible row, and reconciles the entire keyed sequence. The newest 20 chains remain fully mounted, and legacy mega-chains have no item-level windowing.
-
-`MessageWidget` memoization avoids some deep work but cannot remove the O(visible item count) parent traversal.
-
-**Recommended fix**
-
-1. Isolate stable history behind a memoized history component or memoized node sequence.
-2. Keep the live tail and active footer in a small independently updating subtree while preserving live-to-committed key continuity.
-3. After measurement, add `content-visibility` or windowing for old chain bodies if commit duration still exceeds budget.
-4. Prefer a small local boundary before introducing a virtualization dependency.
-
-**Verification**
-
-Profile 100, 1,000, 2,000, and 5,000 visible items during a fixed 60-frame stream. Chart commit duration and verify stable-history components do not rerender for live-only deltas.
-
----
-
 ### F-18 — RAG download/body stalls can hold indexing indefinitely
 
 **Severity:** P2
@@ -529,12 +499,11 @@ These items were not promoted to primary findings because impact or provider beh
 
 ## Recommended implementation order
 
-### Batch 2 — Renderer streaming and hydration
+### Batch 2 — Renderer streaming
 
 1. F-02: add a lightweight/deferred streaming Markdown path.
-2. F-14: isolate stable history from the live tail.
 
-Profile after each change; virtualization should be introduced only if stable-history isolation and lazy mounting do not meet the frame budget.
+Profile before introducing virtualization or windowing for old chain bodies.
 
 ### Batch 3 — Subagent live/durable separation
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved chat streaming to reduce unnecessary updates and preserve message elements during live-to-completed transitions.
  * Tool activity and result panels now load their contents only when first opened, while preserving displayed content after collapsing.
  * Limited remembered expansion preferences to prevent outdated choices from accumulating.
* **Tests**
  * Added coverage for stable chat rendering, deferred tool content loading, and expansion behavior.
* **Documentation**
  * Updated review findings and implementation priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->