### PR TITLE
fix(chat): preserve context across chain transitions

### DIFF
--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -412,6 +412,41 @@ function attachUsageToLatestAssistant(messages: Message[], usage: Usage): boolea
   return false;
 }
 
+/** Append the current uncommitted live tail to a turn-local message snapshot. */
+function appendLiveTailMessages(
+  messages: Message[],
+  agent: ActiveAgent,
+  context: Pick<AgentContext, 'response' | 'thinking' | 'usage'> | undefined,
+): void {
+  const partialResponse = context?.response ?? '';
+  const thinking = context?.thinking ?? '';
+  const usage = context?.usage ?? null;
+
+  if (thinking.length > agent.thinkingCommittedLength) {
+    const segment = thinking.slice(agent.thinkingCommittedLength);
+    if (segment.trim()) {
+      messages.push(makeThinkingMessage(
+        segment,
+        textSegmentIdAtOffset(agent, 'thinking', agent.thinkingCommittedLength),
+      ));
+    }
+  }
+
+  const remaining = partialResponse.slice(agent.responseCommittedLength);
+  if (remaining) {
+    messages.push(makeAssistantMessage(
+      remaining,
+      usage,
+      textSegmentIdAtOffset(agent, 'text', agent.responseCommittedLength),
+    ));
+  } else if (usage && !attachUsageToLatestAssistant(messages, usage)) {
+    messages.push({
+      ...makeAssistantMessage('', usage),
+      hidden: true,
+    });
+  }
+}
+
 /**
  * Flush partial stream content into turnMessages (thinking + uncommitted
  * assistant text). Shared by forceAbort, replace-on-send, and error paths.
@@ -419,34 +454,12 @@ function attachUsageToLatestAssistant(messages: Message[], usage: Usage): boolea
 function flushPartialTurnContent(agent: ActiveAgent, context: AgentContext | undefined): void {
   const partialResponse = context?.response ?? '';
   const thinking = context?.thinking ?? '';
-  const usage = (context?.usage as Usage | null) ?? null;
-
-  if (thinking && thinking.length > agent.thinkingCommittedLength) {
-    const seg = thinking.slice(agent.thinkingCommittedLength);
-    if (seg.trim()) {
-      agent.turnMessages.push(makeThinkingMessage(
-        seg,
-        textSegmentIdAtOffset(agent, 'thinking', agent.thinkingCommittedLength),
-      ));
-    }
+  appendLiveTailMessages(agent.turnMessages, agent, context);
+  if (thinking.length > agent.thinkingCommittedLength) {
     agent.thinkingCommittedLength = thinking.length;
   }
-
-  const remaining = partialResponse.slice(agent.responseCommittedLength);
-  if (remaining) {
-    agent.turnMessages.push(makeAssistantMessage(
-      remaining,
-      usage,
-      textSegmentIdAtOffset(agent, 'text', agent.responseCommittedLength),
-    ));
+  if (partialResponse.length > agent.responseCommittedLength) {
     agent.responseCommittedLength = partialResponse.length;
-  } else if (usage) {
-    if (!attachUsageToLatestAssistant(agent.turnMessages, usage)) {
-      agent.turnMessages.push({
-        ...makeAssistantMessage('', usage),
-        hidden: true,
-      });
-    }
   }
 }
 
@@ -912,6 +925,25 @@ function classifyErrorKind(title: string | null | undefined, detail: string): Ch
 function turnMessagesFromAgent(agent: ActiveAgent): Message[] {
   const turnBase = agent.messages.slice(agent.priorMessageCount);
   return [...turnBase, ...agent.turnMessages];
+}
+
+/** Materialize the current live tail without mutating committed turn state. */
+function checkpointMessagesFromAgent(agent: ActiveAgent, context: AgentContext): Message[] {
+  const checkpoint = turnMessagesFromAgent(agent);
+  appendLiveTailMessages(checkpoint, agent, context);
+  return checkpoint;
+}
+
+/** Persist one bounded main-turn checkpoint after a provider step completes. */
+function checkpointActiveTurn(agent: ActiveAgent, context: AgentContext): void {
+  try {
+    getSessionManager().updateActiveChainMessages(
+      checkpointMessagesFromAgent(agent, context),
+      agent.sessionId,
+    );
+  } catch (err) {
+    console.debug('Failed to checkpoint active chat chain (non-fatal):', err);
+  }
 }
 
 /**
@@ -1634,6 +1666,7 @@ export function registerChatIPC(): void {
             type: 'usage',
             usage: context.usage,
         });
+        checkpointActiveTurn(activeAgent, context);
       }
 
       // Forward tool call streaming events to renderer
@@ -1854,10 +1887,17 @@ export function registerChatIPC(): void {
       if (!sessionId) return null;
       const session = getSessionManager().getSession(sessionId);
       if (!session) return null;
+      const liveAgent = activeAgents.get(sessionId);
+      const live = liveAgent && !liveAgent.finalized
+        ? snapshotForAgent(liveAgent)
+        : null;
       return {
         sessionId,
-        messages: flattenSessionMessages(session),
-        live: getLiveChatSnapshot(sessionId),
+        // The active chain may contain a durable step checkpoint. Keep the
+        // renderer's history base at turn start while `live` supplies the same
+        // tool/text tail, avoiding duplicate bubbles and cumulative usage.
+        messages: liveAgent && live ? [...liveAgent.messages] : flattenSessionMessages(session),
+        live,
       };
     },
   );

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -163,6 +163,7 @@ type ChatStatePayload = {
 
 const activeAgents = new Map<string, ActiveAgent>();
 const sessionsStarting = new Set<string>();
+const pendingCheckpoints = new Map<string, { timer: ReturnType<typeof setTimeout>; messages: Message[] }>();
 /**
  * Single-flight draft session create per window. Concurrent first sends from
  * draft mode share one in-flight ensure promise so only one session is created.
@@ -191,6 +192,7 @@ function nextAgentGeneration(sessionId: string): number {
 }
 
 function disposeActiveAgent(sessionId: string, active: ActiveAgent): void {
+  cancelPendingCheckpoint(sessionId);
   // Only clear the map slot if we still own it (a newer agent may have replaced us).
   if (activeAgents.get(sessionId) === active) {
     activeAgents.delete(sessionId);
@@ -417,6 +419,7 @@ function appendLiveTailMessages(
   messages: Message[],
   agent: ActiveAgent,
   context: Pick<AgentContext, 'response' | 'thinking' | 'usage'> | undefined,
+  opts?: { placeholderWhenEmpty?: boolean },
 ): void {
   const partialResponse = context?.response ?? '';
   const thinking = context?.thinking ?? '';
@@ -436,6 +439,12 @@ function appendLiveTailMessages(
   if (remaining) {
     messages.push(makeAssistantMessage(
       remaining,
+      usage,
+      textSegmentIdAtOffset(agent, 'text', agent.responseCommittedLength),
+    ));
+  } else if (opts?.placeholderWhenEmpty && messages.length === 0) {
+    messages.push(makeAssistantMessage(
+      partialResponse,
       usage,
       textSegmentIdAtOffset(agent, 'text', agent.responseCommittedLength),
     ));
@@ -934,15 +943,36 @@ function checkpointMessagesFromAgent(agent: ActiveAgent, context: AgentContext):
   return checkpoint;
 }
 
-/** Persist one bounded main-turn checkpoint after a provider step completes. */
+const CHECKPOINT_DEBOUNCE_MS = 300;
+
+/** Persist one bounded main-turn checkpoint, debounced per session. */
 function checkpointActiveTurn(agent: ActiveAgent, context: AgentContext): void {
-  try {
-    getSessionManager().updateActiveChainMessages(
-      checkpointMessagesFromAgent(agent, context),
-      agent.sessionId,
-    );
-  } catch (err) {
-    console.debug('Failed to checkpoint active chat chain (non-fatal):', err);
+  const sessionId = agent.sessionId;
+  const messages = checkpointMessagesFromAgent(agent, context);
+  const existing = pendingCheckpoints.get(sessionId);
+  if (existing) {
+    existing.messages = messages;
+    return;
+  }
+  const timer = setTimeout(() => {
+    pendingCheckpoints.delete(sessionId);
+    const active = activeAgents.get(sessionId);
+    if (!active || active.finalized) return;
+    try {
+      getSessionManager().updateActiveChainMessages(messages, sessionId);
+    } catch (err) {
+      console.debug('Failed to checkpoint active chat chain (non-fatal):', err);
+    }
+  }, CHECKPOINT_DEBOUNCE_MS);
+  pendingCheckpoints.set(sessionId, { timer, messages });
+}
+
+/** Cancel any pending debounced checkpoint for a session. */
+function cancelPendingCheckpoint(sessionId: string): void {
+  const pending = pendingCheckpoints.get(sessionId);
+  if (pending) {
+    clearTimeout(pending.timer);
+    pendingCheckpoints.delete(sessionId);
   }
 }
 
@@ -1974,36 +2004,12 @@ export function registerChatIPC(): void {
         const partial = context.response ?? '';
         const thinking = context.thinking ?? '';
         const usage = context.usage ?? null;
-        // Flush reasoning before final text
+        appendLiveTailMessages(existing.turnMessages, existing, context, { placeholderWhenEmpty: true });
         if (thinking.length > existing.thinkingCommittedLength) {
-          const thinkingOffset = existing.thinkingCommittedLength;
-          const thinkSeg = thinking.slice(thinkingOffset);
           existing.thinkingCommittedLength = thinking.length;
-          if (thinkSeg.trim()) {
-            existing.turnMessages.push(makeThinkingMessage(
-              thinkSeg,
-              textSegmentIdAtOffset(existing, 'thinking', thinkingOffset),
-            ));
-          }
         }
-        const remaining = partial.slice(existing.responseCommittedLength);
-        if (remaining || existing.turnMessages.length === 0) {
-          existing.turnMessages.push(
-            makeAssistantMessage(
-              remaining || partial,
-              usage,
-              textSegmentIdAtOffset(existing, 'text', existing.responseCommittedLength),
-            ),
-          );
+        if (partial.length > existing.responseCommittedLength) {
           existing.responseCommittedLength = partial.length;
-        } else if (usage) {
-          const last = existing.turnMessages[existing.turnMessages.length - 1];
-          if (last && last.role === MessageRole.ASSISTANT && last.type === MessageType.TEXT) {
-            existing.turnMessages[existing.turnMessages.length - 1] = {
-              ...last,
-              usage,
-            };
-          }
         }
         // existing.messages already includes the user message for this turn
         const fullHistory = [...existing.messages, ...existing.turnMessages];

--- a/electron/src/main/llm/history.ts
+++ b/electron/src/main/llm/history.ts
@@ -45,6 +45,7 @@ function coalesceConsecutiveToolCallMessages(messages: Message[]): Message[] {
         ...previous,
         content: [previous.content, message.content].filter(Boolean).join('\n'),
         tool_calls: [...(previous.tool_calls ?? []), ...(message.tool_calls ?? [])],
+        tool_call_id: null,
       };
       continue;
     }

--- a/electron/src/main/llm/history.ts
+++ b/electron/src/main/llm/history.ts
@@ -18,6 +18,43 @@
 import type { Message, ApiMessage } from '../../shared/types/message';
 import { MessageType, MessageRole, messageToApiFormat } from '../../shared/types/message';
 
+function isReplayableToolCallMessage(message: Message): boolean {
+  return message.role === MessageRole.ASSISTANT &&
+    message.type === MessageType.TOOL_CALL &&
+    !message.hidden &&
+    !message.excludeFromModel &&
+    Boolean(message.tool_calls?.length);
+}
+
+/**
+ * Runtime lifecycle events persist one assistant message per parallel tool
+ * call. Providers require those adjacent calls to be replayed as one assistant
+ * tool-call group followed by all of the group's results.
+ */
+function coalesceConsecutiveToolCallMessages(messages: Message[]): Message[] {
+  const normalized: Message[] = [];
+
+  for (const message of messages) {
+    const previous = normalized.at(-1);
+    if (
+      previous &&
+      isReplayableToolCallMessage(previous) &&
+      isReplayableToolCallMessage(message)
+    ) {
+      normalized[normalized.length - 1] = {
+        ...previous,
+        content: [previous.content, message.content].filter(Boolean).join('\n'),
+        tool_calls: [...(previous.tool_calls ?? []), ...(message.tool_calls ?? [])],
+      };
+      continue;
+    }
+
+    normalized.push(message);
+  }
+
+  return normalized;
+}
+
 /**
  * Convert persisted display history to API history.
  *
@@ -25,6 +62,8 @@ import { MessageType, MessageRole, messageToApiFormat } from '../../shared/types
  * @returns API-shaped messages with pairing invariant enforced
  */
 export function toApiMessages(messages: Message[]): ApiMessage[] {
+  const replayMessages = coalesceConsecutiveToolCallMessages(messages);
+
   // ── Pre-pass: collect tool_call_ids that have a properly-sequenced
   // matching TOOL_RESULT ──
   //
@@ -38,7 +77,7 @@ export function toApiMessages(messages: Message[]): ApiMessage[] {
   const survivingToolCallIds = new Set<string>();
   const pendingToolCallIds = new Set<string>();
 
-  for (const msg of messages) {
+  for (const msg of replayMessages) {
     // Skip error messages
     if (msg.type === MessageType.ERROR) {
       continue;
@@ -89,7 +128,7 @@ export function toApiMessages(messages: Message[]): ApiMessage[] {
   const apiMessages: ApiMessage[] = [];
   let lastAssistantToolCallIds = new Set<string>();
 
-  for (const msg of messages) {
+  for (const msg of replayMessages) {
     // Skip error messages
     if (msg.type === MessageType.ERROR) {
       continue;

--- a/electron/tests/unit/chat-ipc.test.ts
+++ b/electron/tests/unit/chat-ipc.test.ts
@@ -278,6 +278,21 @@ const mocks = vi.hoisted(() => {
       if (activeSession?.id === updated.id) activeSession = updated;
       return chain;
     }),
+    updateActiveChainMessages: vi.fn((messages: unknown[], sessionId?: string) => {
+      const target = sessionId
+        ? sessionsById.get(sessionId) ?? null
+        : activeSession;
+      if (!target?.activeChainId) return null;
+      const updated = {
+        ...target,
+        chains: target.chains.map((chain: { id: string }) =>
+          chain.id === target.activeChainId ? { ...chain, messages } : chain
+        ),
+      };
+      sessionsById.set(updated.id, updated);
+      if (activeSession?.id === updated.id) activeSession = updated;
+      return updated;
+    }),
     persistTurn: vi.fn((params: { messages: unknown[]; status?: string }, sessionId?: string) => {
       const target = sessionId
         ? sessionsById.get(sessionId) ?? null
@@ -353,6 +368,7 @@ const mocks = vi.hoisted(() => {
       sessionManager.switchTo.mockClear();
       sessionManager.clearActive.mockClear();
       sessionManager.startChain.mockClear();
+      sessionManager.updateActiveChainMessages.mockClear();
       sessionManager.persistTurn.mockClear();
       sessionManager.setReasoningEffortOverride.mockClear();
       sessionManager.setPermissionMode.mockClear();
@@ -883,8 +899,87 @@ describe('chat IPC driver streaming', () => {
     expect(stateEventsAfterMoreChunks.map(([, event]) => event)).not.toContainEqual(
       expect.objectContaining({ response: expect.any(String) }),
     );
+    expect(mocks.sessionManager.updateActiveChainMessages).not.toHaveBeenCalled();
 
     releaseFinish!();
+    await waitForDoneCount(send, 1);
+  });
+
+  it('checkpoints active turn messages at provider step boundaries', async () => {
+    const sessionId = 'bcbcbcbc-bcbc-4bcb-8bcb-bcbcbcbcbcbc';
+    const selection = {
+      connectionId: '11111111-1111-4111-8111-111111111111',
+      modelId: 'vendor/path/model',
+    };
+    mocks.sessionManager._setActive({
+      ...makeSession(sessionId),
+      model: selection.modelId,
+      selection,
+      modelLabel: selection.modelId,
+    });
+    let releaseStream: (() => void) | undefined;
+    const streamGate = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    mocks.streamChat.mockImplementationOnce(async function* () {
+      yield { type: 'thinking', text: 'Inspecting the workspace' };
+      yield {
+        type: 'tool_call',
+        toolCallId: 'tc-checkpoint-1',
+        toolName: 'read',
+        args: '{"path":"README.md"}',
+      };
+      yield successfulToolResult('tc-checkpoint-1', 'Orchid');
+      yield { type: 'content', text: 'Checking files' };
+      yield {
+        type: 'usage',
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 20,
+          total_tokens: 120,
+          cached_tokens: 10,
+        },
+      };
+      await streamGate;
+      yield { type: 'finish', finishReason: 'stop' };
+    });
+
+    const send = vi.fn();
+    const chatSend = mocks.handlers.get(IPC_CHANNELS.CHAT_SEND)!;
+    await chatSend({ sender: { id: 605, send } }, { message: 'Keep this turn durable' });
+    await vi.waitFor(() => {
+      expect(mocks.sessionManager.updateActiveChainMessages).toHaveBeenCalledTimes(1);
+    });
+
+    const [checkpoint, checkpointSessionId] =
+      mocks.sessionManager.updateActiveChainMessages.mock.calls[0] as [
+        Array<Record<string, unknown>>,
+        string,
+      ];
+    expect(checkpointSessionId).toBe(sessionId);
+    expect(checkpoint).toEqual([
+      expect.objectContaining({ role: MessageRole.USER, content: 'Keep this turn durable' }),
+      expect.objectContaining({ type: MessageType.THINKING, content: 'Inspecting the workspace' }),
+      expect.objectContaining({ type: MessageType.TOOL_CALL, tool_call_id: 'tc-checkpoint-1' }),
+      expect.objectContaining({ type: MessageType.TOOL_RESULT, tool_call_id: 'tc-checkpoint-1' }),
+      expect.objectContaining({
+        role: MessageRole.ASSISTANT,
+        content: 'Checking files',
+        usage: expect.objectContaining({ prompt_tokens: 100 }),
+      }),
+    ]);
+    expect(mocks.sessionManager.persistTurn).not.toHaveBeenCalled();
+    expect(mocks.sessionManager.getSession(sessionId)?.activeChainId).toBe('chain-1');
+    const chatSnapshot = mocks.handlers.get(IPC_CHANNELS.CHAT_SNAPSHOT)!;
+    const liveSnapshot = await chatSnapshot(
+      { sender: { id: 605, send } },
+      { sessionId },
+    ) as { messages: Array<Record<string, unknown>> };
+    expect(liveSnapshot.messages).toEqual([
+      expect.objectContaining({ role: MessageRole.USER, content: 'Keep this turn durable' }),
+    ]);
+
+    releaseStream?.();
     await waitForDoneCount(send, 1);
   });
 

--- a/electron/tests/unit/chat-ipc.test.ts
+++ b/electron/tests/unit/chat-ipc.test.ts
@@ -974,10 +974,15 @@ describe('chat IPC driver streaming', () => {
     const liveSnapshot = await chatSnapshot(
       { sender: { id: 605, send } },
       { sessionId },
-    ) as { messages: Array<Record<string, unknown>> };
+    ) as { messages: Array<Record<string, unknown>>; live: { response: string; toolCalls: Array<{ toolCallId: string }> } | null };
     expect(liveSnapshot.messages).toEqual([
       expect.objectContaining({ role: MessageRole.USER, content: 'Keep this turn durable' }),
     ]);
+    expect(liveSnapshot.live).not.toBeNull();
+    expect(liveSnapshot.live!.toolCalls).toEqual([
+      expect.objectContaining({ toolCallId: 'tc-checkpoint-1' }),
+    ]);
+    expect(liveSnapshot.live!.response).toBe('Checking files');
 
     releaseStream?.();
     await waitForDoneCount(send, 1);

--- a/electron/tests/unit/history.test.ts
+++ b/electron/tests/unit/history.test.ts
@@ -33,6 +33,54 @@ function makeToolCall(id: string, name: string, args: string = '{}'): ToolCall {
 }
 
 describe('toApiMessages match-set', () => {
+  it('replays consecutive parallel tool calls as one assistant call group', () => {
+    const firstCall = makeToolCall('tc-parallel-1', 'read');
+    const secondCall = makeToolCall('tc-parallel-2', 'grep');
+    const messages: Message[] = [
+      makeMessage({
+        role: MessageRole.USER,
+        content: 'Read and grep in parallel',
+        type: MessageType.TEXT,
+      }),
+      makeMessage({
+        role: MessageRole.ASSISTANT,
+        type: MessageType.TOOL_CALL,
+        tool_calls: [firstCall],
+        tool_call_id: firstCall.id,
+      }),
+      makeMessage({
+        role: MessageRole.ASSISTANT,
+        type: MessageType.TOOL_CALL,
+        tool_calls: [secondCall],
+        tool_call_id: secondCall.id,
+      }),
+      makeMessage({
+        role: MessageRole.TOOL,
+        content: 'file contents',
+        type: MessageType.TOOL_RESULT,
+        tool_call_id: firstCall.id,
+      }),
+      makeMessage({
+        role: MessageRole.TOOL,
+        content: 'grep results',
+        type: MessageType.TOOL_RESULT,
+        tool_call_id: secondCall.id,
+      }),
+    ];
+
+    const result = toApiMessages(messages);
+
+    expect(result).toHaveLength(4);
+    expect(result[1].tool_calls?.map((call) => call.id)).toEqual([
+      firstCall.id,
+      secondCall.id,
+    ]);
+    expect(result.slice(2).map((message) => message.tool_call_id)).toEqual([
+      firstCall.id,
+      secondCall.id,
+    ]);
+  });
+
   it('rebuilds match-set from surviving tool_calls only (partial filter)', () => {
     const tc1 = makeToolCall('tc-1', 'read');
     const tc2 = makeToolCall('tc-2', 'grep');


### PR DESCRIPTION
Replay adjacent parallel tool calls as one assistant group so paired results remain in provider history.

Checkpoint active turns at provider-step boundaries while keeping live snapshot hydration deduplicated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live chat snapshots during streaming so in-progress thinking, responses, tool activity, and usage updates are preserved at provider step boundaries.
  - Fixed handling of consecutive parallel tool calls when preparing conversation history for AI providers.
  - Ensured tool calls and their results remain correctly paired and ordered.

- **Tests**
  - Added coverage for mid-turn checkpoints, live snapshots, and parallel tool-call history handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->