### PR TITLE
Perf/eager tool execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ src/
 │   │   ├── message-factories.ts    # Build AI SDK message objects
 │   │   ├── response-unwrap.ts      # Unwrap provider response shapes
 │   │   ├── tool-dispatch.ts # executeToolCall() — timeout + output offloading
+│   │   ├── eager-tool-executor.ts # EagerToolExecutor — start tools as their input streams
 │   │   ├── model-metadata.ts # Per-model token limits and capabilities
 │   │   └── middleware/      # AI SDK middleware stack
 │   │       ├── index.ts     # createMiddlewareStack() — retry + quirks + throttle
@@ -293,6 +294,7 @@ idle → [USER_INPUT] → streaming → [TOOL_CALL] → toolExecuting → [TOOL_
 - Each main-agent and subagent turn builds a registry from its frozen project runtime; the process singleton remains only for non-turn compatibility surfaces
 - Built-in tools: filesystem, search, process, AST, RAG, todo, web, skill, MCP, subagent
 - MCP tools are merged from the leased project-owned `MCPManager` at stream time; leases keep superseded managers alive until their turns finish
+- **Eager execution** (`llm/eager-tool-executor.ts`, wired in `orchestrator.ts`): a tool starts executing as soon as its input is streamed — reconstructed from `tool-input-start/delta/end` parts because the AI SDK defers `execute` to `model-call-end`. Every launch routes through the unchanged `executeToolCall`, so permission gating, AGENTS.md enforcement, timeouts, and output offloading apply identically; the SDK's deferred `execute` awaits the same memoized promise (exactly-once).
 - Tool results pass through two layers before reaching the LLM:
   1. **Agent projection** (`result.ts`): each tool family has an `AgentProjector` that transforms canonical result data into the LLM-visible XML. Projectors must not truncate — they send full content and rely on the offloading layer for size control.
   2. **Output offloading** (`tool-dispatch.ts`): if the projected content exceeds `tool_output_inline_threshold` (config, default 20 KB) and the tool is not in `TOOLS_WITHOUT_OUTPUT_OFFLOAD` (`provider-quirks.ts`), the content is written to a per-session cache file and replaced with a compact pointer. When no session is active (e.g., subagent context), content is hard-truncated to the threshold with a warning instead.

--- a/docs/plans/2026-07-30-001-perf-eager-tool-execution-plan.md
+++ b/docs/plans/2026-07-30-001-perf-eager-tool-execution-plan.md
@@ -1,0 +1,323 @@
+---
+title: "perf: Eager tool execution during model streaming"
+type: perf
+date: 2026-07-30
+branch: perf/eager-tool-execution
+---
+
+# Eager Tool Execution During Model Streaming
+
+## Summary
+
+Start executing a tool call as soon as its arguments finish streaming, even while the model is still generating subsequent tool calls in the same step. Today the AI SDK defers **all** tool execution until the model finishes the entire step, then runs the batch via `Promise.all`. This change overlaps tool execution with the tail of the model's generation, reducing wall-clock latency for multi-tool steps without altering the agentic loop, message accumulation, usage accounting, or result semantics.
+
+The mechanism is **pre-execution memoization**: Orchid kicks off `executeToolCall` when it sees the incremental `tool-input-available` stream chunk, stores the promise keyed by `toolCallId`, and the tool's AI SDK `execute` callback becomes a thin shim that awaits the already-running promise. The SDK continues to own the multi-step loop entirely.
+
+## Problem Frame
+
+The core agent loop delegates tool execution to the Vercel AI SDK (`ai@7.0.19`). Each tool is registered with an `execute` callback (`orchestrator.ts:1023`, skill `:1065`, MCP `:1124`), and `streamText` drives the multi-step loop via `stopWhen` (`orchestrator.ts:585-658`). The XState agent machine is informational-only for tools (`agent-machine.ts:319-387`) — it never schedules execution.
+
+Inside the SDK, `executeToolsFromStream` (`node_modules/ai/dist/index.js:7688`) governs timing:
+
+- As the model streams, each completed tool call emits a `tool-call` chunk **incrementally**, per tool, mid-stream. The UI-facing stream surfaces this as `tool-input-available` (`index.js:7344`) carrying the validated `input`, `toolCallId`, `toolName`, and `providerExecuted` flag.
+- The SDK only **collects** these: `toolCallsToExecute.push(chunk)` (`index.js:7731`, `:7791`).
+- Execution happens only on the `model-call-end` chunk — after the model finishes the **entire** step — via `Promise.all(toolCallsToExecute.map(...))` (`index.js:7795-7831`).
+
+Consequence: when a step contains tool calls #1…#N, tool #1 does not begin until #2…#N have finished *generating*. There is no SDK option to change this; the deferral to `model-call-end` is unconditional.
+
+Orchid already receives the incremental `tool-input-available` chunk and even pauses its idle watchdog there (`orchestrator.ts:744-759`) — it simply does not act on it. The hook point for eager execution already exists in the event stream.
+
+**Why this is semantically safe:** within a single assistant step, all tool calls are generated without any results available to the model, so they are independent by construction. The SDK already executes them concurrently via `Promise.all`. Starting them earlier overlaps execution with generation but does not change the set of concurrent operations or their relative ordering — any race that could occur with eager execution (e.g., two tools touching the AGENTS.md seen-tracker) can already occur today.
+
+**Expected magnitude:** the saving per step is `min(remaining generation time of #2…#N, execution time of #1…#N-1)`. Largest for steps mixing a slow tool (`execute_command` build, slow MCP tool) with others, or steps with many calls. Modest for the common case of a few fast `read`/`grep` calls. This is a latency refinement, not a throughput change.
+
+## Requirements
+
+**Eager execution**
+
+- R1. When a tool call's arguments are fully streamed (`tool-input-available`), its handler begins executing immediately, without waiting for the rest of the step to finish generating.
+- R2. Eager execution applies uniformly to registry tools, the per-agent `skill` tool, and MCP tools.
+- R3. Provider-executed tools (`providerExecuted: true`) are never eagerly executed locally — the provider owns their execution.
+
+**Correctness preservation**
+
+- R4. Each tool call executes exactly once. The SDK's `execute` callback returns the result of the eager run; it never triggers a second execution.
+- R5. If a tool call was not eagerly started for any reason, the `execute` callback falls back to running it normally — behavior is identical to today.
+- R6. Tool results, canonical status, agent projections, output offloading, AGENTS.md injection/enforcement, and permission gating are byte-for-byte identical to the current path (all still flow through `executeToolCall`).
+- R7. Cancelling the turn (abort signal) cancels eagerly-started tools in flight, exactly as it cancels tools today.
+- R8. A tool handler that throws produces the same error result it produces today; the error surfaces through the SDK's normal tool-error handling.
+
+**Lifecycle**
+
+- R9. Eager-execution state is scoped to a single `streamChat` invocation and does not leak across turns or idle-retry attempts.
+- R10. The idle watchdog, usage accounting, and step-event delivery continue to behave as they do today.
+
+**Verification**
+
+- R11. A test demonstrates that a tool's handler is invoked before the model finishes generating a subsequent tool call in the same step (the defining behavior of this change).
+
+## Key Technical Decisions
+
+**KTD-1. Pre-execution memoization, not a manual agent loop.**
+The alternative — taking over the agentic loop from the SDK (the "manual agent loop" cookbook pattern) and calling `streamText` one step at a time — would also achieve eager execution, but forces reimplementation of multi-step message accumulation, reasoning/thinking pass-back (required by Anthropic), per-step usage aggregation, `onStepFinish`, `stopWhen`, and middleware application. Memoization keeps all of that intact: the SDK still calls `execute` at `model-call-end` via `Promise.all`, but each `execute` awaits work that started earlier. The change is confined to `buildToolMap` and the `tool-input-available` handler.
+
+**KTD-2. A coordinator object bridges `buildToolMap` and the stream loop.**
+`buildToolMap` knows the correct registry per tool (main `registry`, a one-shot `skillRegistry`, or a per-MCP-tool `dynamicRegistry`), but the `tool-input-available` chunk arrives later in the stream loop, keyed by `toolCallId` (unknown at build time) and `toolName`. A small `EagerToolExecutor` coordinator resolves this:
+- `buildToolMap` registers a **launcher** per internal tool name, each bound to its own registry + frozen `ToolDispatchOptions`.
+- The stream loop calls `coordinator.start(toolName, toolCallId, input)` on `tool-input-available`; the coordinator looks up the launcher, invokes `executeToolCall`, and stores the promise keyed by `toolCallId`.
+- The `execute` shim calls `coordinator.take(toolCallId)`; if a promise exists it awaits it, otherwise it falls back to a direct `executeToolCall` (R5).
+This keeps registry knowledge inside `buildToolMap` and avoids the stream loop needing per-tool registry resolution.
+
+**KTD-3. Key launchers by internal tool name; key in-flight promises by `toolCallId`.**
+MCP tools are registered in the SDK tool map under a provider-mangled name (`toProviderMcpToolName`), but the stream loop normalizes chunk tool names back to internal names via `toInternalToolName` (`orchestrator.ts:748`). Launchers are therefore keyed by **internal** name so the loop's normalized name resolves directly. In-flight promises are keyed by `toolCallId` (globally unique), which is what the `execute` shim receives in `executionOptions.toolCallId`.
+
+**KTD-4. Eager execution uses the turn-level abort signal only.**
+The SDK's per-call abort signal is created inside `executeToolsFromStream` and is only available inside the `execute` callback — not at `tool-input-available` time. Eager execution passes `dispatchOptions.abortSignal` (the parent-turn signal, `tool-dispatch.ts:123`), which is the signal user cancellation (Esc) aborts. The fallback path inside the shim still combines both via `withSdkAbortSignal` as today. Net effect: user cancellation works for eager tools; the SDK's secondary per-call signal is only relevant on the fallback path. This matches the cancellation guarantee users observe today.
+
+**KTD-5. Coordinator lifetime matches `tools`, not the idle-retry attempt.**
+`buildToolMap` runs once per `streamChat` (`orchestrator.ts:465`), outside the idle-retry loop (`:505`), while `seenToolCallIds` is per-attempt (`:547-548`). The coordinator is created alongside `tools` (once) and shared with both the `execute` closures and the per-attempt stream loop. Because `toolCallId`s are globally unique, stale entries from an idle-aborted attempt can never collide with a later attempt's IDs; an aborted attempt's rejected promise is simply never looked up again. No per-attempt clearing is required, though `take()` removes entries on read so the map stays bounded by in-flight + unread tools.
+
+**KTD-6. Trigger on `tool-input-available`, skip `providerExecuted` and duplicates.**
+The stream loop already has a `case 'tool-input-available': case 'tool-call':` branch (`orchestrator.ts:744`). Eager start is added there, guarded by: `toolCallId` present, `part.providerExecuted !== true` (R3), and not already started (idempotent against the dual `tool-input-available`/`tool-call` labeling and any repeated chunks). The parsed `part.input ?? part.args` object is passed directly to `executeToolCall` (which accepts pre-parsed args, `tool-dispatch.ts:168-182`) — not the stringified form used for the UI `StreamEvent`.
+
+**KTD-7. `executeToolCall` and the projection/offload pipeline are unchanged.**
+All size control, AGENTS.md handling, permission gating, and canonicalization live inside `executeToolCall` (`tool-dispatch.ts:149`). Eager execution calls the same function with the same frozen `ToolDispatchOptions`, so R6 holds by construction. No projection-level or offload-level changes.
+
+## High-Level Technical Design
+
+**Current timing (SDK-deferred):**
+
+```
+model stream:  ──[tool#1 args]──[tool#2 args]──[tool#3 args]──┤ model-call-end
+                                                                  │
+SDK:           collect #1      collect #2       collect #3        ├─ Promise.all(exec #1,#2,#3)
+                                                                  │      ▲
+execute #1 ───────────────────────────────────────────────────────┘      │
+                                                            (idle gap — #1 waits for #3 to finish generating)
+```
+
+**Proposed timing (eager):**
+
+```
+model stream:  ──[tool#1 args]──[tool#2 args]──[tool#3 args]──┤ model-call-end
+                       │                │               │
+tool-input-available:  ▼                ▼               ▼
+coordinator.start(#1)  start(#2)        start(#3)
+       │                  │                │
+exec #1 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│                │          ← runs while #2,#3 still generate
+exec #2                 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓│
+exec #3                                  ▓▓▓▓▓▓▓▓▓▓▓
+                                                          │
+model-call-end → SDK Promise.all(execute shims) ──────────┤  each shim awaits the
+                                                          │  already-running promise
+                                                          ▼  (usually already resolved)
+                                                   tool-output-available
+```
+
+**Coordinator shape:**
+
+```
+EagerToolExecutor
+  ├─ launchers: Map<internalToolName, (toolCallId, input) => Promise<ToolExecutionResult>>
+  │     └─ populated by buildToolMap, one per tool, bound to its registry + dispatchOptions
+  ├─ inflight:  Map<toolCallId, Promise<ToolExecutionResult>>
+  ├─ start(toolName, toolCallId, input):
+  │     launcher = launchers.get(toolName); if none → no-op (fallback path will run it)
+  │     if inflight.has(toolCallId) → no-op (idempotent)
+  │     inflight.set(toolCallId, launcher(toolCallId, input))
+  └─ take(toolCallId): Promise<ToolExecutionResult> | undefined
+        pops and returns inflight.get(toolCallId)   ← used by the execute shim
+```
+
+**Execute shim (per tool, in buildToolMap):**
+
+```
+execute: async (args, { toolCallId, abortSignal }) => {
+  const eager = coordinator.take(toolCallId);
+  if (eager) return eager;                       // R4: await the eager run, no re-exec
+  return executeToolCall(                        // R5: defensive fallback (today's behavior)
+    { id: toolCallId, name, args },
+    registry,
+    withSdkAbortSignal(dispatchOptions, abortSignal),
+  );
+}
+```
+
+## Implementation Units
+
+### U1. EagerToolExecutor coordinator
+
+**Goal:** A small, pure module that bridges eager start (stream loop) and await (execute shim), with launcher registration and in-flight promise tracking.
+
+**Requirements:** R2, R4, R5, R9
+
+**Dependencies:** None
+
+**Files:**
+- `electron/src/main/llm/eager-tool-executor.ts` — new file
+- `electron/tests/unit/eager-tool-executor.test.ts` — new file
+
+**Approach:**
+- `type ToolLauncher = (toolCallId: string, input: unknown) => Promise<ToolExecutionResult>`
+- `class EagerToolExecutor`:
+  - `registerLauncher(internalToolName: string, launcher: ToolLauncher): void`
+  - `start(internalToolName: string, toolCallId: string, input: unknown): void` — no-op if no launcher or already in-flight (idempotent); otherwise invoke launcher and store the promise. Launcher exceptions must not throw synchronously out of `start` — the launcher returns a promise, so a rejection is captured in the stored promise and surfaces when awaited (R8).
+  - `take(toolCallId: string): Promise<ToolExecutionResult> | undefined` — returns and deletes the in-flight entry (bounds memory, R9).
+  - `has(toolCallId: string): boolean` — optional, for tests/logging.
+- No SDK imports; depends only on the `ToolExecutionResult` type. Fully unit-testable without mocking `ai`.
+
+**Patterns to follow:** plain-class coordinators in `llm/` (e.g., the snapshot builder in `context-snapshot.ts`).
+
+**Test scenarios:**
+- `start` with a registered launcher invokes it once and stores the promise; `take` returns the same promise and removes it.
+- `start` is idempotent: a second `start` for the same `toolCallId` does not re-invoke the launcher.
+- `start` with no launcher for the tool name is a no-op; subsequent `take` returns `undefined` (fallback path).
+- `take` for an unknown `toolCallId` returns `undefined`.
+- A launcher that returns a rejected promise: `take` returns the rejecting promise (error propagates to awaiter, not to `start`).
+- Two different tool names register independent launchers; interleaved starts resolve to the correct promises.
+
+**Verification:** Unit tests pass with fake launchers (no real tools, no SDK).
+
+### U2. Wire launchers and execute shims into buildToolMap
+
+**Goal:** Register a launcher for every tool (registry, skill, MCP) bound to its correct registry, and replace each `execute` body with the await-or-fallback shim.
+
+**Requirements:** R2, R3, R4, R5, R6, R8
+
+**Dependencies:** U1
+
+**Files:**
+- `electron/src/main/llm/orchestrator.ts` — modify `buildToolMap` (`:997-1152`): accept an `EagerToolExecutor`, register launchers, swap `execute` bodies
+- `electron/tests/unit/build-tool-map-eager.test.ts` — new file
+
+**Approach:**
+- Add a parameter `eager: EagerToolExecutor` to `buildToolMap` (after `skillOptions`).
+- For **registry tools** (`:1014-1045`): define a launcher `(toolCallId, input) => executeToolCall({ id: toolCallId, name: definition.name, args: input }, registry, dispatchOptions)` and `eager.registerLauncher(definition.name, launcher)`. Replace the `execute` body with the shim: `const p = eager.take(executionOptions.toolCallId); if (p) return p; return executeToolCall({ id, name, args }, registry, withSdkAbortSignal(dispatchOptions, executionOptions.abortSignal))`.
+- For the **skill tool** (`:1049-1087`): same, bound to `skillRegistry`; launcher key is the skill tool's internal name (`definition.name`, i.e. `skill`).
+- For **MCP tools** (`:1090-1148`): launcher bound to the per-tool `dynamicRegistry` and the **internal** name (`definition.name`), not `providerName` (KTD-3). The shim is identical, using `internalName` in the fallback `executeToolCall`.
+- `toModelOutput` is unchanged for all three — it parses whatever the shim returns, which is the same `ToolExecutionResult` shape as today.
+- The fallback path preserves `withSdkAbortSignal` exactly as today; the eager path relies on `dispatchOptions.abortSignal` already embedded in the launcher's options (KTD-4).
+
+**Patterns to follow:** the existing per-category `execute`/`toModelOutput` construction already in `buildToolMap`; keep the three categories structurally parallel.
+
+**Test scenarios:**
+- A registry tool: after `eager.start(name, id, input)`, calling the tool's `execute(args, { toolCallId: id })` returns the eager result and the underlying handler runs exactly once (spy count === 1) (R4).
+- A registry tool with no eager start: `execute` falls back and runs the handler once, returning an identical result (R5 parity).
+- Skill tool and MCP tool each honor eager start and fallback (R2).
+- MCP launcher is keyed by internal name: `eager.start(internalName, ...)` is picked up by the MCP tool's `execute` even though the SDK map key is the provider name (KTD-3).
+- Eager result and fallback result are deep-equal for the same input (R6).
+- A handler that throws: eager promise rejects and `execute` rejects with the same error (R8).
+
+**Verification:** Unit tests build a real `ToolRegistry` with a stub handler, call `buildToolMap`, and drive `execute` directly. No SDK stream needed.
+
+### U3. Trigger eager start from the stream loop
+
+**Goal:** On `tool-input-available`, start eager execution for eligible tools.
+
+**Requirements:** R1, R3, R10
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `electron/src/main/llm/orchestrator.ts` — create the coordinator next to `tools` (`:465`), pass it to `buildToolMap`, and invoke `coordinator.start(...)` in the `tool-input-available`/`tool-call` case (`:744-759`)
+- `electron/tests/unit/orchestrator-eager-execution.test.ts` — new file (see Testing Strategy)
+
+**Approach:**
+- In `streamChat`, before `buildToolMap`: `const eager = new EagerToolExecutor();` and pass it into `buildToolMap(...)` (KTD-5: same lifetime as `tools`, outside the idle-retry loop).
+- In the `case 'tool-input-available': case 'tool-call':` branch (`:744`), after computing `toolCallId` and `toolName` (internal), add:
+  ```
+  if (toolCallId && part.providerExecuted !== true) {
+    eager.start(toolName, toolCallId, part.input ?? part.args);
+  }
+  ```
+  `eager.start` is itself idempotent, so the dual-label case and repeated chunks are safe (KTD-6). The existing `pauseIdleForTool()` and `StreamEvent` yield remain unchanged (R10).
+- The parsed input object (`part.input ?? part.args`) is passed directly — not `stringifyToolInput(...)` — because `executeToolCall` accepts pre-parsed args.
+- `providerExecuted` is read from the chunk (present per `index.js:7349`); provider-executed tools are skipped (R3). Their `execute` is never called by the SDK anyway, so the shim is never hit for them.
+
+**Patterns to follow:** the existing guards in this branch (`seenToolCallIds`, `deliveredAny`). Eager start is independent of `seenToolCallIds` (it keys on the coordinator's own in-flight set) but sits in the same branch for locality.
+
+**Test scenarios:** see Testing Strategy (timing assertion is the headline test, R11).
+- `tool-input-available` for a non-provider tool triggers exactly one `eager.start`.
+- `tool-input-available` with `providerExecuted: true` triggers no start.
+- Repeated `tool-input-available`/`tool-call` chunks for the same id start only once.
+- Idle watchdog still pauses on `tool-input-available` (unchanged behavior).
+
+**Verification:** The orchestrator integration test (below) plus the coordinator/shim unit tests.
+
+### U4. Regression guardrails
+
+**Goal:** Ensure the existing dispatch behaviors are provably unchanged through the eager path.
+
+**Requirements:** R6, R7, R10
+
+**Dependencies:** U2, U3
+
+**Files:**
+- `electron/tests/unit/eager-tool-executor.test.ts` — extend (abort propagation)
+- `electron/tests/unit/agents-md-enforcement.test.ts` — extend with an eager-path parity case (reuse the existing `executeToolCall` harness)
+
+**Approach:**
+- **Cancellation (R7):** create an `AbortController`, pass its signal in `dispatchOptions`, `start` a long-running stub tool, abort, and assert the stored promise resolves/rejects to the cancelled terminal execution that `executeToolCall` already produces for an aborted signal (`tool-dispatch.ts:158-166`).
+- **AGENTS.md parity (R6):** run one write-tool call through the eager path and one through the direct path with the same session tracker state; assert identical enforcement outcomes for `block`/`warn`/`inject`. This reuses the existing `executeToolCall` test harness in `agents-md-enforcement.test.ts`.
+- **Output offloading parity (R6):** assert a large tool result is offloaded identically whether produced eagerly or via fallback (same `ToolExecutionResult.agentProjection`).
+
+**Patterns to follow:** the dynamic-import + `executeToolCall` harness already established in `agents-md-enforcement.test.ts:359+`.
+
+**Test scenarios:**
+- Abort before/during eager execution yields the same cancelled result as today.
+- AGENTS.md `block` denies an eagerly-started write exactly as it denies a direct write.
+- Offloaded projection content is byte-identical across eager vs fallback.
+
+**Verification:** Extended suites pass; no changes to `tool-dispatch.ts` required (this unit only adds tests, confirming KTD-7).
+
+## Testing Strategy
+
+**Unit (no SDK):** U1 coordinator and U2 `buildToolMap` shim tests exercise the full eager-vs-fallback logic with stub handlers and a real `ToolRegistry`. These cover R2, R4, R5, R6, R8, R9 deterministically.
+
+**Integration (mocked SDK stream):** the headline timing test (R1, R11) drives `streamChat` against a mocked `streamText`. `streamChat` obtains the SDK via `importESM('ai')` (`orchestrator.ts:367`); the test mocks the `ai` module (vitest `vi.mock` / module stub) so `streamText` returns an object whose `fullStream` is a hand-authored async generator emitting, in order:
+1. `start-step`
+2. `tool-input-available` for tool A (a slow stub handler that records its start timestamp and awaits a controllable promise)
+3. a measurable delay (e.g., a few `await setTimeout` ticks simulating tool B's generation)
+4. `tool-input-available` for tool B
+5. `model-call-end` / `finish-step`
+
+Assertion: tool A's handler start timestamp is recorded **before** step 4 completes (i.e., before the model "finishes" generating B) — the defining behavior. A secondary assertion confirms each handler ran exactly once and both results were yielded as `tool_result` events.
+
+A fallback integration case emits `tool-call` chunks but bypasses eager start (e.g., provider-executed flag) and asserts behavior matches the pre-change path.
+
+**Parity (existing harness):** U4 reuses `agents-md-enforcement.test.ts` patterns to prove dispatch-side behavior is unchanged.
+
+**Manual smoke:** run a turn that emits several tool calls (e.g., multiple `read`/`grep`) and a turn with one slow `execute_command` alongside a fast tool; confirm results are correct and observe earlier tool-result arrival in the tool rail.
+
+## Risks & Dependencies
+
+**Risk: tool-approval coupling (latent).**
+The SDK's `executeToolsFromStream` resolves tool approval before pushing to `toolCallsToExecute` (`index.js:7721-7793`). Orchid passes no `toolApproval` to `streamText` (`orchestrator.ts:585-658`), so every tool is `not-applicable` → auto-executed, and eager start matches current semantics. If a tool-approval system is added later (a `feat/tool-permission-system-plan.md` exists), eager start would bypass the approval gate and must be reconciled then. Mitigation: document this coupling in `eager-tool-executor.ts`; gate `eager.start` behind a future "approval not required" check if/when approval lands.
+
+**Risk: SDK per-call abort signal not applied to eager runs.**
+Eager execution uses only `dispatchOptions.abortSignal` (KTD-4). The SDK's secondary per-call signal (created inside `executeToolsFromStream`) does not propagate to eager work. User cancellation (Esc → turn abort) is fully covered; only an SDK-internal per-call abort (not a user-facing path today) would differ. Acceptable; revisit if the SDK gains user-visible per-tool cancellation.
+
+**Risk: nondeterministic within-step ordering.**
+Eager tools start at staggered times as their inputs complete, rather than all at `model-call-end`. The set of concurrently-running tools is unchanged (the SDK already runs the batch via `Promise.all`), so no new races are introduced — but timing-sensitive tests must not assume a fixed completion order. Mitigation: tests assert start-time ordering (deterministic, driven by the mocked stream) and execution counts, not completion order.
+
+**Risk: memory growth in the in-flight map.**
+`take()` deletes entries on read, and the SDK reads every started tool at `model-call-end`, so the map is bounded by tools started-but-not-yet-awaited within a step. The coordinator is garbage-collected with the `streamChat` generator. A tool started eagerly but never awaited (e.g., the stream errors before `model-call-end`) leaves a promise that settles and is collected with the coordinator. No unbounded growth.
+
+**Risk: idle-retry attempt reuse.**
+The coordinator outlives individual idle-retry attempts (KTD-5). An attempt that idle-aborts leaves rejected promises in the map; later attempts use fresh `toolCallId`s and never look them up. Confirmed safe by ID uniqueness; a per-attempt `clear()` could be added for tidiness but is not required for correctness.
+
+**Dependency: none on the worker-pool offload plan.**
+This change is orthogonal to `2026-07-24-001-refactor-worker-pool-tool-offload-plan.md`. Eager execution calls the same `executeToolCall`; whether a handler runs inline or in a worker is decided inside it. The two can land in either order.
+
+## Sources / Research
+
+- SDK deferral (decisive): `executeToolsFromStream` — `node_modules/ai/dist/index.js:7688`; collect at `:7731`/`:7791`; execute at `model-call-end` via `Promise.all` at `:7795-7831`.
+- Incremental `tool-input-available` UI chunk with `input`/`toolCallId`/`providerExecuted`: `node_modules/ai/dist/index.js:7344-7354`.
+- SDK version: `ai@7.0.19` (`electron/package.json:52`).
+- Orchid stream loop: `streamChat` (`orchestrator.ts:346`), `buildToolMap` call (`:465-479`), `streamText` invocation (`:585-658`), idle-retry loop (`:505`), per-attempt seen-sets (`:547-548`), `tool-input-available`/`tool-call` case (`:744-759`).
+- `buildToolMap` execute wiring: registry (`:1023-1036`), skill (`:1065-1078`), MCP (`:1124-1139`); `toModelOutput` (`:1037-1043`).
+- Helpers: `streamToolCallId` (`:1257`), `stringifyToolInput` (`:1246`), `toInternalToolName` (`:87`), `toProviderMcpToolName` (`:74`), `withSdkAbortSignal` (`:1154`).
+- Dispatch contract: `executeToolCall` (`tool-dispatch.ts:149`), `ToolDispatchOptions.abortSignal` (`tool-dispatch.ts:123`), aborted-signal short-circuit (`:158-166`), pre-parsed args handling (`:168-182`).
+- XState machine is informational-only for tools: `agent-machine.ts:319-387`.
+- Existing `executeToolCall` test harness: `electron/tests/unit/agents-md-enforcement.test.ts:359+`.
+- AI SDK docs (lifecycle hooks, parallel tool calls): ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling, /resources/recipes/node/call-tools-in-parallel.

--- a/electron/src/main/llm/eager-tool-executor.ts
+++ b/electron/src/main/llm/eager-tool-executor.ts
@@ -1,0 +1,79 @@
+/**
+ * Eager tool execution coordinator.
+ *
+ * The AI SDK defers every tool call's `execute` until the model finishes the
+ * whole step (`model-call-end`), then runs them via `Promise.all`. This
+ * coordinator lets a tool start executing the moment its own input is fully
+ * streamed (`tool-input-available`), overlapping execution with the generation
+ * of subsequent tool calls in the same step.
+ *
+ * Mechanism (pre-execution memoization):
+ * - `buildToolMap` registers a launcher per internal tool name, bound to the
+ *   correct registry and frozen dispatch options.
+ * - The stream loop calls `start()` on `tool-input-available`, which invokes the
+ *   launcher and stores the in-flight promise keyed by `toolCallId`.
+ * - The tool's SDK `execute` shim calls `getOrStart()` when the SDK reaches
+ *   `model-call-end`: it awaits the already-running promise if `start()` won the
+ *   race, or starts the execution itself if it runs first. Either way exactly one
+ *   execution happens. With no launcher registered it returns `undefined` and the
+ *   shim falls back to a normal `executeToolCall`.
+ *
+ * The coordinator owns no execution logic — `executeToolCall` is unchanged.
+ */
+import type { ToolExecutionResult } from '../../shared/types/tool-result';
+
+/** Starts a tool execution; returns the in-flight result promise. */
+export type EagerToolLauncher = (
+  toolCallId: string,
+  input: unknown,
+) => Promise<ToolExecutionResult>;
+
+export class EagerToolExecutor {
+  /** Launchers keyed by internal tool name (MCP names are pre-normalized). */
+  private readonly launchers = new Map<string, EagerToolLauncher>();
+  /** In-flight executions keyed by toolCallId. */
+  private readonly inflight = new Map<string, Promise<ToolExecutionResult>>();
+
+  /** Register the launcher for one internal tool name (last registration wins). */
+  registerLauncher(internalToolName: string, launcher: EagerToolLauncher): void {
+    this.launchers.set(internalToolName, launcher);
+  }
+
+  /**
+   * Begin executing a tool call from the stream loop (fire-and-forget). Delegates
+   * to `getOrStart`, so a later `execute` shim call awaits the same run.
+   */
+  start(toolCallId: string, internalToolName: string, input: unknown): void {
+    this.getOrStart(toolCallId, internalToolName, input);
+  }
+
+  /**
+   * Return the single memoized execution promise for a tool call, creating it via
+   * the launcher on first call. Both the stream loop (`start`) and the tool's
+   * `execute` shim call this, so whichever runs first owns the execution and the
+   * other awaits it — guaranteeing exactly one run regardless of their ordering.
+   *
+   * Returns `undefined` when no launcher is registered (unknown or
+   * provider-executed tool), signalling the caller to fall back to a direct
+   * `executeToolCall`. Synchronous launcher failures are captured as a rejected
+   * promise so they surface through the SDK's normal error path.
+   */
+  getOrStart(
+    toolCallId: string,
+    internalToolName: string,
+    input: unknown,
+  ): Promise<ToolExecutionResult> | undefined {
+    const existing = this.inflight.get(toolCallId);
+    if (existing) return existing;
+    const launcher = this.launchers.get(internalToolName);
+    if (!launcher) return undefined;
+    let promise: Promise<ToolExecutionResult>;
+    try {
+      promise = launcher(toolCallId, input);
+    } catch (error) {
+      promise = Promise.reject(error);
+    }
+    this.inflight.set(toolCallId, promise);
+    return promise;
+  }
+}

--- a/electron/src/main/llm/eager-tool-executor.ts
+++ b/electron/src/main/llm/eager-tool-executor.ts
@@ -2,21 +2,28 @@
  * Eager tool execution coordinator.
  *
  * The AI SDK defers every tool call's `execute` until the model finishes the
- * whole step (`model-call-end`), then runs them via `Promise.all`. This
- * coordinator lets a tool start executing the moment its own input is fully
- * streamed (`tool-input-available`), overlapping execution with the generation
- * of subsequent tool calls in the same step.
+ * whole step (`model-call-end`), then runs them via `Promise.all` — even though
+ * each tool's input is streamed incrementally. This coordinator lets a tool
+ * start executing as soon as its own input is available, overlapping execution
+ * with the generation of subsequent tool calls in the same step.
+ *
+ * Two trigger paths feed the same idempotent memoization:
+ * - Delta reconstruction (primary): the stream loop accumulates
+ *   `tool-input-delta` text and calls `start()` once the input is complete
+ *   (`tool-input-end`, or the next tool / text / step boundary as a backstop).
+ * - `tool-input-available`: the stream loop also calls `start()` on the SDK's
+ *   validated input part. Whichever signal arrives first wins.
  *
  * Mechanism (pre-execution memoization):
  * - `buildToolMap` registers a launcher per internal tool name, bound to the
  *   correct registry and frozen dispatch options.
- * - The stream loop calls `start()` on `tool-input-available`, which invokes the
- *   launcher and stores the in-flight promise keyed by `toolCallId`.
+ * - `start()` is a fire-and-forget wrapper over `getOrStart()`, which invokes
+ *   the launcher and stores the in-flight promise keyed by `toolCallId`.
  * - The tool's SDK `execute` shim calls `getOrStart()` when the SDK reaches
- *   `model-call-end`: it awaits the already-running promise if `start()` won the
- *   race, or starts the execution itself if it runs first. Either way exactly one
- *   execution happens. With no launcher registered it returns `undefined` and the
- *   shim falls back to a normal `executeToolCall`.
+ *   `model-call-end`: it awaits the already-running promise if an earlier
+ *   trigger won the race, or starts the execution itself if it runs first.
+ *   Either way exactly one execution happens. With no launcher registered it
+ *   returns `undefined` and the shim falls back to a normal `executeToolCall`.
  *
  * The coordinator owns no execution logic — `executeToolCall` is unchanged.
  */

--- a/electron/src/main/llm/eager-tool-executor.ts
+++ b/electron/src/main/llm/eager-tool-executor.ts
@@ -33,11 +33,17 @@ import type { ToolExecutionResult } from '../../shared/types/tool-result';
 export type EagerToolLauncher = (
   toolCallId: string,
   input: unknown,
+  abortSignal?: AbortSignal,
 ) => Promise<ToolExecutionResult>;
+
+/** Validates a tool's parsed input before eager execution begins. */
+export type EagerToolValidator = (input: unknown) => boolean;
 
 export class EagerToolExecutor {
   /** Launchers keyed by internal tool name (MCP names are pre-normalized). */
   private readonly launchers = new Map<string, EagerToolLauncher>();
+  /** Input validators keyed by internal tool name (optional). */
+  private readonly validators = new Map<string, EagerToolValidator>();
   /** In-flight executions keyed by toolCallId. */
   private readonly inflight = new Map<string, Promise<ToolExecutionResult>>();
 
@@ -46,12 +52,22 @@ export class EagerToolExecutor {
     this.launchers.set(internalToolName, launcher);
   }
 
+  /** Register an input validator for one internal tool name (last wins). */
+  registerValidator(internalToolName: string, validator: EagerToolValidator): void {
+    this.validators.set(internalToolName, validator);
+  }
+
   /**
    * Begin executing a tool call from the stream loop (fire-and-forget). Delegates
    * to `getOrStart`, so a later `execute` shim call awaits the same run.
    */
-  start(toolCallId: string, internalToolName: string, input: unknown): void {
-    this.getOrStart(toolCallId, internalToolName, input);
+  start(
+    toolCallId: string,
+    internalToolName: string,
+    input: unknown,
+    abortSignal?: AbortSignal,
+  ): void {
+    this.getOrStart(toolCallId, internalToolName, input, abortSignal);
   }
 
   /**
@@ -60,27 +76,46 @@ export class EagerToolExecutor {
    * `execute` shim call this, so whichever runs first owns the execution and the
    * other awaits it — guaranteeing exactly one run regardless of their ordering.
    *
-   * Returns `undefined` when no launcher is registered (unknown or
-   * provider-executed tool), signalling the caller to fall back to a direct
-   * `executeToolCall`. Synchronous launcher failures are captured as a rejected
-   * promise so they surface through the SDK's normal error path.
+   * Returns `undefined` (caller falls back to a direct `executeToolCall`) when:
+   * - no launcher is registered (unknown or provider-executed tool), or
+   * - a registered validator rejects the input. The delta path reconstructs input
+   *   before the SDK's validation verdict, so this gate prevents eagerly running a
+   *   handler the SDK will reject with `tool-input-error`.
+   *
+   * Synchronous launcher failures are captured as a rejected promise so they
+   * surface through the SDK's normal error path.
    */
   getOrStart(
     toolCallId: string,
     internalToolName: string,
     input: unknown,
+    abortSignal?: AbortSignal,
   ): Promise<ToolExecutionResult> | undefined {
     const existing = this.inflight.get(toolCallId);
     if (existing) return existing;
     const launcher = this.launchers.get(internalToolName);
     if (!launcher) return undefined;
+    const validator = this.validators.get(internalToolName);
+    if (validator && !validator(input)) return undefined;
     let promise: Promise<ToolExecutionResult>;
     try {
-      promise = launcher(toolCallId, input);
+      promise = launcher(toolCallId, input, abortSignal);
     } catch (error) {
       promise = Promise.reject(error);
     }
     this.inflight.set(toolCallId, promise);
     return promise;
+  }
+
+  /**
+   * Drop the in-flight entry once it is no longer needed. Called after the SDK
+   * emits the tool's output (the `execute` shim has run and will not run again for
+   * this id), bounding the map to genuinely in-flight tools. Deleting earlier
+   * (e.g. on read) would be unsafe: the stream loop and the shim both call
+   * `getOrStart` for the same id, so a deleted entry would be re-created and the
+   * tool would execute twice.
+   */
+  forget(toolCallId: string): void {
+    this.inflight.delete(toolCallId);
   }
 }

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -551,12 +551,16 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
     const pendingToolResults: PendingToolResult[] = [];
     const seenToolCallIds = new Set<string>();
     const seenToolResultIds = new Set<string>();
-    // Eager execution from streamed tool-input deltas. The AI SDK withholds the
-    // validated `tool-call` part until the step finishes (batched), so we
-    // reconstruct "input complete" ourselves: accumulate `tool-input-delta` text
-    // per tool and launch the tool when `tool-input-end` fires (or when the next
-    // tool / text begins, as a backstop). `eagerExecutor.start` is idempotent, so
-    // the SDK's later batched `tool-call` is a no-op for already-started tools.
+    // Eager execution. The AI SDK emits each tool's input parts
+    // (tool-input-start/delta/end, then the validated tool-input-available)
+    // incrementally as the model streams, but defers actually RUNNING the tool
+    // until model-call-end (Promise.all). To overlap execution with the
+    // generation of subsequent tool calls, we reconstruct "input complete"
+    // ourselves: accumulate tool-input-delta text per tool and launch it when
+    // tool-input-end fires (or when the next tool / text begins, as a backstop).
+    // The tool-input-available case below also eager-starts via the same
+    // idempotent getOrStart, so whichever signal arrives first wins and the
+    // SDK's deferred execute becomes a no-op await for already-started tools.
     const pendingToolInputs = new Map<string, { toolName: string; text: string }>();
     let activeToolInputId: string | null = null;
     // Early UI events for eagerly-started tools, drained into the stream so the

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -551,6 +551,73 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
     const pendingToolResults: PendingToolResult[] = [];
     const seenToolCallIds = new Set<string>();
     const seenToolResultIds = new Set<string>();
+    // Eager execution from streamed tool-input deltas. The AI SDK withholds the
+    // validated `tool-call` part until the step finishes (batched), so we
+    // reconstruct "input complete" ourselves: accumulate `tool-input-delta` text
+    // per tool and launch the tool when `tool-input-end` fires (or when the next
+    // tool / text begins, as a backstop). `eagerExecutor.start` is idempotent, so
+    // the SDK's later batched `tool-call` is a no-op for already-started tools.
+    const pendingToolInputs = new Map<string, { toolName: string; text: string }>();
+    let activeToolInputId: string | null = null;
+    // Early UI events for eagerly-started tools, drained into the stream so the
+    // renderer sees `running` / `completed` transitions as they actually happen
+    // rather than in the SDK's batched step-end burst.
+    const eagerStarts: Array<{ toolCallId: string; toolName: string; args: string }> = [];
+    const eagerCompletions: Array<{ toolCallId: string; execution: ToolExecutionResult }> = [];
+    const finalizeToolInput = (toolCallId: string): void => {
+      const pending = pendingToolInputs.get(toolCallId);
+      if (!pending) return;
+      pendingToolInputs.delete(toolCallId);
+      if (activeToolInputId === toolCallId) activeToolInputId = null;
+      let input: unknown;
+      try {
+        input = JSON.parse(pending.text);
+      } catch {
+        // Incomplete/invalid JSON — the SDK's `tool-call` path will handle it.
+        return;
+      }
+      const promise = eagerExecutor.getOrStart(toolCallId, pending.toolName, input);
+      if (!promise) return; // no launcher (provider-executed/unknown) — SDK handles it
+      eagerStarts.push({
+        toolCallId,
+        toolName: pending.toolName,
+        args: stringifyToolInput(input),
+      });
+      promise
+        .then((execution) => {
+          eagerCompletions.push({ toolCallId, execution });
+        })
+        .catch(() => {
+          // executeToolCall resolves to terminal executions rather than rejecting.
+        });
+    };
+    const drainEagerStarts = function* (): Generator<StreamEvent> {
+      while (eagerStarts.length > 0) {
+        const start = eagerStarts.shift()!;
+        if (seenToolCallIds.has(start.toolCallId)) continue;
+        seenToolCallIds.add(start.toolCallId);
+        deliveredAny = true;
+        yield {
+          type: 'tool_call',
+          toolCallId: start.toolCallId,
+          toolName: start.toolName,
+          args: start.args,
+        };
+      }
+    };
+    const drainEagerCompletions = function* (): Generator<StreamEvent> {
+      while (eagerCompletions.length > 0) {
+        const completion = eagerCompletions.shift()!;
+        if (seenToolResultIds.has(completion.toolCallId)) continue;
+        seenToolResultIds.add(completion.toolCallId);
+        deliveredAny = true;
+        yield {
+          type: 'tool_result',
+          toolCallId: completion.toolCallId,
+          ...streamResultFields(completion.execution),
+        };
+      }
+    };
     const pendingUsageEvents: Usage[] = [];
     let currentStepMessages: readonly ModelMessage[] = coreMessages;
     let stepIndex = 0;
@@ -680,6 +747,8 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
             }
 
             case 'finish-step': {
+              // Backstop: finalize any tool still pending at step end.
+              if (activeToolInputId) finalizeToolInput(activeToolInputId);
               yield {
                 type: 'usage',
                 usage: buildStepUsage(
@@ -702,6 +771,8 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
 
             case 'text-delta': {
               armIdleTimer();
+              // Model resumed text after tool inputs → finalize any pending tool.
+              if (activeToolInputId) finalizeToolInput(activeToolInputId);
               const text =
                 typeof part.text === 'string'
                   ? part.text
@@ -722,7 +793,18 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
                 typeof part.toolName === 'string' ? part.toolName : 'unknown',
                 mcpManager,
               );
+              // The model moved to a new tool → the previously streaming tool's
+              // input is complete (backstop for providers without tool-input-end).
+              if (activeToolInputId && activeToolInputId !== toolCallId) {
+                finalizeToolInput(activeToolInputId);
+              }
+              // Surface the finalized tool's `running` state BEFORE announcing the
+              // new generating tool, so the single streamingToolCall slot settles
+              // on the tool that is actually still generating.
+              yield* drainEagerStarts();
               if (toolCallId) {
+                pendingToolInputs.set(toolCallId, { toolName, text: '' });
+                activeToolInputId = toolCallId;
                 deliveredAny = true;
                 yield { type: 'tool_call_start', toolCallId, toolName };
               }
@@ -739,9 +821,19 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
                     ? part.delta
                     : '';
               if (toolCallId && argsDelta) {
+                const pending = pendingToolInputs.get(toolCallId);
+                if (pending) pending.text += argsDelta;
                 deliveredAny = true;
                 yield { type: 'tool_call_delta', toolCallId, argsDelta };
               }
+              break;
+            }
+
+            case 'tool-input-end': {
+              // This tool's input finished streaming — launch it now, before the
+              // SDK emits the batched `tool-call` at step end.
+              const toolCallId = streamToolCallId(part);
+              if (toolCallId) finalizeToolInput(toolCallId);
               break;
             }
 
@@ -842,6 +934,7 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
             case 'reasoning-delta':
             case 'reasoning': {
               armIdleTimer();
+              if (activeToolInputId) finalizeToolInput(activeToolInputId);
               const text =
                 typeof part.text === 'string'
                   ? part.text
@@ -866,6 +959,11 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
               break;
           }
 
+          // Surface eagerly-started tools and their early completions to the UI
+          // stream as soon as they happen (deduped against the SDK's batched
+          // `tool-call` / `tool-output-available` via the seen-id sets).
+          yield* drainEagerStarts();
+          yield* drainEagerCompletions();
           yield* drainPendingToolEvents(
             pendingToolCalls,
             pendingToolResults,
@@ -926,6 +1024,10 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
 
       const finishReason = await result.finishReason;
 
+      // Flush any eager tool starts/completions that settled during the final
+      // await (e.g. the last tool in a step) before emitting `finish`.
+      yield* drainEagerStarts();
+      yield* drainEagerCompletions();
       yield* drainPendingToolEvents(
         pendingToolCalls,
         pendingToolResults,

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -580,8 +580,23 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
         // Incomplete/invalid JSON — the SDK's `tool-call` path will handle it.
         return;
       }
-      const promise = eagerExecutor.getOrStart(toolCallId, pending.toolName, input);
-      if (!promise) return; // no launcher (provider-executed/unknown) — SDK handles it
+      // Pass the per-attempt combined (user + idle) abort signal so an idle
+      // timeout or turn death aborts the eagerly-running tool, matching the
+      // SDK `execute` path (which derives its per-call signal from the same
+      // combined signal).
+      const promise = eagerExecutor.getOrStart(
+        toolCallId,
+        pending.toolName,
+        input,
+        combinedAbort,
+      );
+      if (!promise) return; // no launcher / invalid input — the SDK path handles it
+      // The eager tool is now running: pause the idle watchdog for its duration
+      // so a quiet model tail can't spuriously abort a legitimately-running tool
+      // (the SDK only pauses idle at model-call-end, which the delta path beats).
+      // The matching resume fires when the run settles, independent of the
+      // seenToolResultIds UI dedup below.
+      pauseIdleForTool();
       eagerStarts.push({
         toolCallId,
         toolName: pending.toolName,
@@ -593,7 +608,12 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
         })
         .catch(() => {
           // executeToolCall resolves to terminal executions rather than rejecting.
-        });
+        })
+        .finally(() => resumeIdleAfterTool());
+    };
+    /** Finalize the currently-streaming tool when an input boundary is reached. */
+    const flushActiveToolInput = (): void => {
+      if (activeToolInputId) finalizeToolInput(activeToolInputId);
     };
     const drainEagerStarts = function* (): Generator<StreamEvent> {
       while (eagerStarts.length > 0) {
@@ -752,7 +772,7 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
 
             case 'finish-step': {
               // Backstop: finalize any tool still pending at step end.
-              if (activeToolInputId) finalizeToolInput(activeToolInputId);
+              flushActiveToolInput();
               yield {
                 type: 'usage',
                 usage: buildStepUsage(
@@ -776,7 +796,7 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
             case 'text-delta': {
               armIdleTimer();
               // Model resumed text after tool inputs → finalize any pending tool.
-              if (activeToolInputId) finalizeToolInput(activeToolInputId);
+              flushActiveToolInput();
               const text =
                 typeof part.text === 'string'
                   ? part.text
@@ -855,9 +875,17 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
                 seenToolCallIds.add(toolCallId);
                 deliveredAny = true;
                 // Start executing now, while the model keeps generating other
-                // tool calls. Provider-executed tools run remotely — skip them.
-                if (part.providerExecuted !== true) {
-                  eagerExecutor.start(toolCallId, toolName, part.input ?? part.args);
+                // tool calls. Skip provider-executed tools (the provider owns
+                // them) and SDK-invalid calls (the SDK will emit tool-input-error;
+                // running them eagerly would commit a handler the model is told
+                // failed).
+                if (part.providerExecuted !== true && part.invalid !== true) {
+                  eagerExecutor.start(
+                    toolCallId,
+                    toolName,
+                    part.input ?? part.args,
+                    combinedAbort,
+                  );
                 }
                 yield { type: 'tool_call', toolCallId, toolName, args };
               }
@@ -868,6 +896,10 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
             case 'tool-result': {
               resumeIdleAfterTool();
               const toolCallId = streamToolCallId(part);
+              // The SDK has the result, so the execute shim has run and will not
+              // run again for this id — release the in-flight memo (bounds the
+              // map to genuinely in-flight tools).
+              if (toolCallId) eagerExecutor.forget(toolCallId);
               const raw = part.output ?? part.result ?? '';
               const toolName = toInternalToolName(
                 typeof part.toolName === 'string' ? part.toolName : 'unknown',
@@ -890,6 +922,7 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
             case 'tool-error': {
               resumeIdleAfterTool();
               const toolCallId = streamToolCallId(part);
+              if (toolCallId) eagerExecutor.forget(toolCallId);
               const execution = sdkPreExecutionError(part, mcpManager);
               if (toolCallId && !seenToolResultIds.has(toolCallId)) {
                 seenToolResultIds.add(toolCallId);
@@ -907,6 +940,9 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
               // Args never became valid — no execute, keep/reset idle
               armIdleTimer();
               const toolCallId = streamToolCallId(part);
+              // Release any eager memo (the delta path may have started this tool
+              // before the SDK's validation verdict); the SDK owns the error path.
+              if (toolCallId) eagerExecutor.forget(toolCallId);
               const execution = sdkPreExecutionError(part, mcpManager);
               if (toolCallId) {
                 const toolName = toInternalToolName(
@@ -938,7 +974,7 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
             case 'reasoning-delta':
             case 'reasoning': {
               armIdleTimer();
-              if (activeToolInputId) finalizeToolInput(activeToolInputId);
+              flushActiveToolInput();
               const text =
                 typeof part.text === 'string'
                   ? part.text
@@ -1100,6 +1136,81 @@ export interface BuildToolMapSkillOptions {
   allowedSkills?: readonly string[];
 }
 
+/** Everything needed to wire one tool (registry, skill, or MCP) for eager execution. */
+interface EagerToolWiring {
+  eager?: EagerToolExecutor;
+  /** Internal tool name (MCP names are pre-normalized); keys the launcher/validator. */
+  internalName: string;
+  /** Registry that owns this tool's handler. */
+  registry: ToolRegistry;
+  dispatchOptions: ToolDispatchOptions;
+  /** Zod input schema, used to gate eager execution on valid input. */
+  inputSchema: unknown;
+}
+
+/**
+ * Register a tool's eager launcher and input validator (no-op without `eager`).
+ * The launcher routes through the unchanged `executeToolCall`, overriding only the
+ * abort signal with the per-attempt signal supplied at start time.
+ */
+function registerEagerTool(wiring: EagerToolWiring): void {
+  const { eager, internalName, registry, dispatchOptions, inputSchema } = wiring;
+  if (!eager) return;
+  eager.registerLauncher(internalName, (toolCallId, input, abortSignal) =>
+    executeToolCall(
+      { id: toolCallId, name: internalName, args: input },
+      registry,
+      abortSignal ? { ...dispatchOptions, abortSignal } : dispatchOptions,
+    ),
+  );
+  const schema = inputSchema as { safeParse?: (input: unknown) => { success: boolean } } | undefined;
+  if (typeof schema?.safeParse === 'function') {
+    eager.registerValidator(internalName, (input) => schema.safeParse!(input).success);
+  }
+}
+
+/**
+ * Build the SDK-facing `execute` shim: await the eager run if one was started
+ * (or start it if the shim wins the race), otherwise fall back to a direct
+ * dispatch. Exactly one execution happens either way.
+ */
+function makeEagerExecute(
+  wiring: EagerToolWiring,
+): (
+  args: unknown,
+  executionOptions: { toolCallId: string; abortSignal?: AbortSignal },
+) => Promise<ToolExecutionResult> {
+  const { eager, internalName, registry, dispatchOptions } = wiring;
+  return async (args, executionOptions) => {
+    const opts = withSdkAbortSignal(dispatchOptions, executionOptions.abortSignal);
+    const inflight = eager?.getOrStart(
+      executionOptions.toolCallId,
+      internalName,
+      args,
+      opts.abortSignal,
+    );
+    if (inflight) return inflight;
+    return executeToolCall(
+      { id: executionOptions.toolCallId, name: internalName, args },
+      registry,
+      opts,
+    );
+  };
+}
+
+/** Build the `toModelOutput` mapper from an execution result schema. */
+function makeToModelOutput(outputSchema: {
+  parse: (output: unknown) => unknown;
+}): ({ output }: { output: unknown }) => { type: string; value: string } {
+  return ({ output }: { output: unknown }) => {
+    const execution = outputSchema.parse(output) as ToolExecutionResult;
+    return {
+      type: execution.canonical.status === 'error' ? 'error-text' : 'text',
+      value: execution.agentProjection.content,
+    };
+  };
+}
+
 /**
  * Build a tool map for AI SDK from the registry, filtered by agent's allowed tools.
  *
@@ -1139,40 +1250,20 @@ export function buildToolMap(
     if (!outputSchema) {
       throw new TypeError(`No execution schema registered for tool '${definition.name}'`);
     }
-    eager?.registerLauncher(definition.name, (toolCallId, input) =>
-      executeToolCall(
-        { id: toolCallId, name: definition.name, args: input },
-        registry,
-        dispatchOptions,
-      ),
-    );
+    const wiring: EagerToolWiring = {
+      eager,
+      internalName: definition.name,
+      registry,
+      dispatchOptions,
+      inputSchema: definition.inputSchema,
+    };
+    registerEagerTool(wiring);
     toolMap[definition.name] = {
       description: definition.description,
       inputSchema: definition.inputSchema,
       outputSchema,
-      execute: async (
-        args: unknown,
-        executionOptions: { toolCallId: string; abortSignal?: AbortSignal },
-      ) => {
-        const inflight = eager?.getOrStart(executionOptions.toolCallId, definition.name, args);
-        if (inflight) return inflight;
-        return executeToolCall(
-          {
-            id: executionOptions.toolCallId,
-            name: definition.name,
-            args,
-          },
-          registry,
-          withSdkAbortSignal(dispatchOptions, executionOptions.abortSignal),
-        );
-      },
-      toModelOutput: ({ output }: { output: unknown }) => {
-        const execution = outputSchema.parse(output) as ToolExecutionResult;
-        return {
-          type: execution.canonical.status === 'error' ? 'error-text' : 'text',
-          value: execution.agentProjection.content,
-        };
-      },
+      execute: makeEagerExecute(wiring),
+      toModelOutput: makeToModelOutput(outputSchema),
     };
   }
 
@@ -1190,40 +1281,20 @@ export function buildToolMap(
     if (!outputSchema) {
       throw new TypeError(`No execution schema registered for tool '${definition.name}'`);
     }
-    eager?.registerLauncher(definition.name, (toolCallId, input) =>
-      executeToolCall(
-        { id: toolCallId, name: definition.name, args: input },
-        skillRegistry,
-        dispatchOptions,
-      ),
-    );
+    const skillWiring: EagerToolWiring = {
+      eager,
+      internalName: definition.name,
+      registry: skillRegistry,
+      dispatchOptions,
+      inputSchema: definition.inputSchema,
+    };
+    registerEagerTool(skillWiring);
     toolMap.skill = {
       description: definition.description,
       inputSchema: definition.inputSchema,
       outputSchema,
-      execute: async (
-        args: unknown,
-        executionOptions: { toolCallId: string; abortSignal?: AbortSignal },
-      ) => {
-        const inflight = eager?.getOrStart(executionOptions.toolCallId, definition.name, args);
-        if (inflight) return inflight;
-        return executeToolCall(
-          {
-            id: executionOptions.toolCallId,
-            name: definition.name,
-            args,
-          },
-          skillRegistry,
-          withSdkAbortSignal(dispatchOptions, executionOptions.abortSignal),
-        );
-      },
-      toModelOutput: ({ output }: { output: unknown }) => {
-        const execution = outputSchema.parse(output) as ToolExecutionResult;
-        return {
-          type: execution.canonical.status === 'error' ? 'error-text' : 'text',
-          value: execution.agentProjection.content,
-        };
-      },
+      execute: makeEagerExecute(skillWiring),
+      toModelOutput: makeToModelOutput(outputSchema),
     };
   }
 
@@ -1256,44 +1327,28 @@ export function buildToolMap(
         throw new TypeError(`No execution schema registered for MCP tool '${internalName}'`);
       }
 
-      eager?.registerLauncher(internalName, (toolCallId, input) =>
-        executeToolCall(
-          { id: toolCallId, name: internalName, args: input },
-          dynamicRegistry,
-          dispatchOptions,
-        ),
-      );
+      const mcpWiring: EagerToolWiring = {
+        eager,
+        internalName,
+        registry: dynamicRegistry,
+        dispatchOptions,
+        inputSchema: definition.inputSchema,
+      };
+      registerEagerTool(mcpWiring);
+      const mcpExecute = makeEagerExecute(mcpWiring);
       toolMap[providerName] = {
         description: definition.description,
         inputSchema: definition.rawInputJsonSchema
           ? jsonSchema(definition.rawInputJsonSchema as Parameters<typeof jsonSchema>[0])
           : definition.inputSchema,
         outputSchema,
-        execute: async (
+        execute: (
           args: unknown,
           executionOptions: { toolCallId: string; abortSignal?: AbortSignal } = {
             toolCallId: crypto.randomUUID(),
           },
-        ) => {
-          const inflight = eager?.getOrStart(executionOptions.toolCallId, internalName, args);
-          if (inflight) return inflight;
-          return executeToolCall(
-            {
-              id: executionOptions.toolCallId,
-              name: internalName,
-              args,
-            },
-            dynamicRegistry,
-            withSdkAbortSignal(dispatchOptions, executionOptions.abortSignal),
-          );
-        },
-        toModelOutput: ({ output }: { output: unknown }) => {
-          const execution = outputSchema.parse(output) as ToolExecutionResult;
-          return {
-            type: execution.canonical.status === 'error' ? 'error-text' : 'text',
-            value: execution.agentProjection.content,
-          };
-        },
+        ) => mcpExecute(args, executionOptions),
+        toModelOutput: makeToModelOutput(outputSchema),
       };
     }
   }

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -45,6 +45,7 @@ import {
   executeToolCall,
   type ToolDispatchOptions,
 } from './tool-dispatch';
+import { EagerToolExecutor } from './eager-tool-executor';
 import {
   finalizeToolExecutionResult,
   genericAgentProjector,
@@ -462,6 +463,10 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
     ? lastUserMessage.content
     : '';
 
+  // Eager execution: tools start as soon as their input is streamed, before the
+  // model finishes the step. The executor lives across idle-retry attempts;
+  // toolCallIds are unique, so stale in-flight entries never collide.
+  const eagerExecutor = new EagerToolExecutor();
   const tools = buildToolMap(agent.allowed_tools, registry, mcpManager, {
     sessionId,
     windowId,
@@ -476,7 +481,7 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
       ? new Map(projectRuntime.skills)
       : getSkillsRegistry(),
     allowedSkills: agent.allowed_skills,
-  });
+  }, eagerExecutor);
   const buildUsageContext = createContextSnapshotBuilder(fullSystemPrompt, tools);
 
   // ── Compose middleware ──
@@ -753,6 +758,11 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
               if (toolCallId && !seenToolCallIds.has(toolCallId)) {
                 seenToolCallIds.add(toolCallId);
                 deliveredAny = true;
+                // Start executing now, while the model keeps generating other
+                // tool calls. Provider-executed tools run remotely — skip them.
+                if (part.providerExecuted !== true) {
+                  eagerExecutor.start(toolCallId, toolName, part.input ?? part.args);
+                }
                 yield { type: 'tool_call', toolCallId, toolName, args };
               }
               break;
@@ -993,6 +1003,12 @@ export interface BuildToolMapSkillOptions {
  * When `skillOptions.skills` is provided and `skill` is in the map, the skill
  * tool is rebuilt with `allowedSkills` so restricted agents cannot load skills
  * outside their allowlist.
+ *
+ * When `eager` is provided, each tool registers a launcher (bound to its own
+ * registry and the frozen `dispatchOptions`) and its `execute` becomes a shim
+ * that awaits the pre-started in-flight promise. This lets a tool begin
+ * executing as soon as its input is streamed, before the model finishes the
+ * step. Without `eager`, `execute` runs `executeToolCall` directly as before.
  */
 export function buildToolMap(
   allowedTools: readonly string[],
@@ -1000,6 +1016,7 @@ export function buildToolMap(
   mcpManager: MCPManager | null,
   dispatchOptions: ToolDispatchOptions,
   skillOptions?: BuildToolMapSkillOptions,
+  eager?: EagerToolExecutor,
 ): Record<string, Tool> {
   // Use a loose record internally to avoid TS2589 (excessively deep
   // instantiation) from Tool's conditional generic types, then assert to
@@ -1016,6 +1033,13 @@ export function buildToolMap(
     if (!outputSchema) {
       throw new TypeError(`No execution schema registered for tool '${definition.name}'`);
     }
+    eager?.registerLauncher(definition.name, (toolCallId, input) =>
+      executeToolCall(
+        { id: toolCallId, name: definition.name, args: input },
+        registry,
+        dispatchOptions,
+      ),
+    );
     toolMap[definition.name] = {
       description: definition.description,
       inputSchema: definition.inputSchema,
@@ -1024,6 +1048,8 @@ export function buildToolMap(
         args: unknown,
         executionOptions: { toolCallId: string; abortSignal?: AbortSignal },
       ) => {
+        const inflight = eager?.getOrStart(executionOptions.toolCallId, definition.name, args);
+        if (inflight) return inflight;
         return executeToolCall(
           {
             id: executionOptions.toolCallId,
@@ -1058,6 +1084,13 @@ export function buildToolMap(
     if (!outputSchema) {
       throw new TypeError(`No execution schema registered for tool '${definition.name}'`);
     }
+    eager?.registerLauncher(definition.name, (toolCallId, input) =>
+      executeToolCall(
+        { id: toolCallId, name: definition.name, args: input },
+        skillRegistry,
+        dispatchOptions,
+      ),
+    );
     toolMap.skill = {
       description: definition.description,
       inputSchema: definition.inputSchema,
@@ -1066,6 +1099,8 @@ export function buildToolMap(
         args: unknown,
         executionOptions: { toolCallId: string; abortSignal?: AbortSignal },
       ) => {
+        const inflight = eager?.getOrStart(executionOptions.toolCallId, definition.name, args);
+        if (inflight) return inflight;
         return executeToolCall(
           {
             id: executionOptions.toolCallId,
@@ -1115,6 +1150,13 @@ export function buildToolMap(
         throw new TypeError(`No execution schema registered for MCP tool '${internalName}'`);
       }
 
+      eager?.registerLauncher(internalName, (toolCallId, input) =>
+        executeToolCall(
+          { id: toolCallId, name: internalName, args: input },
+          dynamicRegistry,
+          dispatchOptions,
+        ),
+      );
       toolMap[providerName] = {
         description: definition.description,
         inputSchema: definition.rawInputJsonSchema
@@ -1127,6 +1169,8 @@ export function buildToolMap(
             toolCallId: crypto.randomUUID(),
           },
         ) => {
+          const inflight = eager?.getOrStart(executionOptions.toolCallId, internalName, args);
+          if (inflight) return inflight;
           return executeToolCall(
             {
               id: executionOptions.toolCallId,

--- a/electron/tests/integration/eager-tool-execution-stream.test.ts
+++ b/electron/tests/integration/eager-tool-execution-stream.test.ts
@@ -265,4 +265,238 @@ describe('eager tool execution through streamChat', () => {
     expect(slowHandler).not.toHaveBeenCalled();
     expect(fastHandler).toHaveBeenCalledOnce();
   });
+
+  function installGatedFakeAiSdk(
+    beforeGate: Array<Record<string, unknown>>,
+    afterGate: Array<Record<string, unknown>>,
+    gate: Promise<void>,
+  ): void {
+    async function* fakeFullStream(): AsyncGenerator<Record<string, unknown>> {
+      for (const part of beforeGate) yield part;
+      await gate;
+      for (const part of afterGate) yield part;
+      yield { type: 'finish-step', usage: {}, finishReason: 'tool-calls' };
+    }
+    const fakeAi = {
+      streamText: vi.fn(() => ({
+        fullStream: fakeFullStream(),
+        finishReason: Promise.resolve('tool-calls'),
+      })),
+      wrapLanguageModel: ({ model }: { model: unknown }) => model,
+      isStepCount: () => () => false,
+    };
+    vi.mocked(importESM).mockResolvedValue(fakeAi as never);
+  }
+
+  it('emits exactly one tool_call and one tool_result when the delta path and the SDK batched signal both fire for the same id', async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((res) => {
+      releaseGate = res;
+    });
+    installGatedFakeAiSdk(
+      [
+        { type: 'tool-input-start', toolCallId: 'call-A', toolName: 'slow' },
+        { type: 'tool-input-delta', toolCallId: 'call-A', inputTextDelta: '{"x":1}' },
+        // Delta path eager-starts A here.
+        { type: 'tool-input-end', toolCallId: 'call-A' },
+      ],
+      [
+        // The SDK's batched validated signal + result for the SAME id arrive later.
+        { type: 'tool-input-available', toolCallId: 'call-A', toolName: 'slow', input: { x: 1 } },
+        { type: 'tool-output-available', toolCallId: 'call-A', toolName: 'slow', output: {} },
+      ],
+      gate,
+    );
+
+    const registry = new ToolRegistry();
+    registerTool(registry, 'slow', slowHandler);
+
+    const controller = new AbortController();
+    const gen = streamChat({
+      messages: [],
+      agent,
+      systemPrompt: '',
+      context: { cwd },
+      config: defaults(),
+      registry,
+      mcpManager: null,
+      abortSignal: controller.signal,
+      modelInstance: {} as never,
+    });
+
+    const events: StreamEvent[] = [];
+    // Drive until the delta path announces A (tool_call from the eager drain),
+    // then let the SDK batched signal + result through.
+    let sawCallA = false;
+    while (!sawCallA) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+      if (value.type === 'tool_call' && id(value) === 'call-A') sawCallA = true;
+    }
+    expect(sawCallA).toBe(true);
+    await vi.waitFor(() => expect(slowHandler).toHaveBeenCalledOnce());
+
+    releaseGate();
+    while (true) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+    }
+
+    // Exactly one running + one completed event for A, deduped across both paths.
+    const toolCalls = events.filter((e) => e.type === 'tool_call' && id(e) === 'call-A');
+    const toolResults = events.filter((e) => e.type === 'tool_result' && id(e) === 'call-A');
+    expect(toolCalls).toHaveLength(1);
+    expect(toolResults).toHaveLength(1);
+    // The eager (complete) result won, not the SDK output's generic fallback.
+    const result = toolResults[0] as { execution: { canonical: { status: string } } };
+    expect(result.execution.canonical.status).toBe('complete');
+    // And the handler ran exactly once across both triggers.
+    expect(slowHandler).toHaveBeenCalledOnce();
+  });
+
+  it('cancelling the turn aborts an eagerly-started tool (settles to cancelled)', async () => {
+    let releaseHandler!: () => void;
+    const handlerGate = new Promise<void>((res) => {
+      releaseHandler = res;
+    });
+    let capturedSignal: AbortSignal | undefined;
+    const gatingHandler = vi.fn(async (_args: unknown, ctx: { abortSignal?: AbortSignal }) => {
+      capturedSignal = ctx.abortSignal;
+      await handlerGate;
+      return { status: 'complete' as const, data: { value: 'should-be-cancelled' } };
+    });
+    let releaseModel!: () => void;
+    const modelGate = new Promise<void>((res) => {
+      releaseModel = res;
+    });
+    installGatedFakeAiSdk(
+      [
+        { type: 'tool-input-start', toolCallId: 'call-A', toolName: 'slow' },
+        { type: 'tool-input-delta', toolCallId: 'call-A', inputTextDelta: '{"x":1}' },
+        { type: 'tool-input-end', toolCallId: 'call-A' },
+      ],
+      [],
+      modelGate,
+    );
+
+    const registry = new ToolRegistry();
+    registerTool(registry, 'slow', gatingHandler);
+
+    const controller = new AbortController();
+    const gen = streamChat({
+      messages: [],
+      agent,
+      systemPrompt: '',
+      context: { cwd },
+      config: defaults(),
+      registry,
+      mcpManager: null,
+      abortSignal: controller.signal,
+      modelInstance: {} as never,
+    });
+
+    const events: StreamEvent[] = [];
+    let sawCallA = false;
+    while (!sawCallA) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+      if (value.type === 'tool_call' && id(value) === 'call-A') sawCallA = true;
+    }
+    await vi.waitFor(() => expect(gatingHandler).toHaveBeenCalledOnce());
+
+    // The eager execution received an abort signal derived from the turn signal.
+    expect(capturedSignal).toBeDefined();
+    controller.abort();
+    expect(capturedSignal!.aborted).toBe(true);
+
+    // Let the handler unwind; executeToolCall sees the aborted parent → cancelled.
+    releaseHandler();
+    releaseModel();
+    while (true) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+    }
+
+    const resultA = events.find(
+      (e) => e.type === 'tool_result' && id(e) === 'call-A',
+    ) as { execution: { canonical: { status: string } } } | undefined;
+    expect(resultA).toBeDefined();
+    expect(resultA!.execution.canonical.status).toBe('cancelled');
+  });
+
+  it('idle watchdog does not abort a legitimately-running delta-path eager tool', async () => {
+    let releaseHandler!: () => void;
+    const handlerGate = new Promise<void>((res) => {
+      releaseHandler = res;
+    });
+    const gatingHandler = vi.fn(async () => {
+      await handlerGate;
+      return { status: 'complete' as const, data: { value: 'ok' } };
+    });
+
+    // Quiet period (300ms) longer than the idle timeout (100ms); a real stream
+    // aborts here if the idle watchdog fires, so this is abort-aware.
+    async function* fakeFullStream(signal?: AbortSignal): AsyncGenerator<Record<string, unknown>> {
+      yield { type: 'tool-input-start', toolCallId: 'call-A', toolName: 'slow' };
+      yield { type: 'tool-input-delta', toolCallId: 'call-A', inputTextDelta: '{"x":1}' };
+      yield { type: 'tool-input-end', toolCallId: 'call-A' };
+      await new Promise<void>((resolve, reject) => {
+        const t = setTimeout(resolve, 300);
+        signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(t);
+            reject(new Error('aborted'));
+          },
+          { once: true },
+        );
+      });
+      yield { type: 'finish-step', usage: {}, finishReason: 'tool-calls' };
+    }
+    const fakeAi = {
+      streamText: vi.fn((opts: { abortSignal?: AbortSignal }) => ({
+        fullStream: fakeFullStream(opts.abortSignal),
+        finishReason: Promise.resolve('tool-calls'),
+      })),
+      wrapLanguageModel: ({ model }: { model: unknown }) => model,
+      isStepCount: () => () => false,
+    };
+    vi.mocked(importESM).mockResolvedValue(fakeAi as never);
+
+    const registry = new ToolRegistry();
+    registerTool(registry, 'slow', gatingHandler);
+
+    const controller = new AbortController();
+    const gen = streamChat({
+      messages: [],
+      agent,
+      systemPrompt: '',
+      context: { cwd },
+      // 0.1s idle timeout; the tool runs (gated) through a 300ms quiet model tail.
+      config: { ...defaults(), llm_stream_idle_timeout: 0.1 },
+      registry,
+      mcpManager: null,
+      abortSignal: controller.signal,
+      modelInstance: {} as never,
+    });
+
+    const events: StreamEvent[] = [];
+    while (true) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+    }
+    releaseHandler();
+
+    expect(gatingHandler).toHaveBeenCalledOnce();
+    // The stream completed normally — the idle watchdog did NOT abort the in-flight tool.
+    expect(events.some((e) => e.type === 'finish')).toBe(true);
+    expect(
+      events.some((e) => e.type === 'error' && (e as { title: string }).title === 'Stream idle timeout'),
+    ).toBe(false);
+  });
 });

--- a/electron/tests/integration/eager-tool-execution-stream.test.ts
+++ b/electron/tests/integration/eager-tool-execution-stream.test.ts
@@ -145,4 +145,124 @@ describe('eager tool execution through streamChat', () => {
     expect(order).toEqual(['call-A', 'call-B']);
     expect(events.some((e) => e.type === 'finish')).toBe(true);
   });
+
+  function installDeltaFakeAiSdk(script: Array<Record<string, unknown>>): void {
+    async function* fakeFullStream(): AsyncGenerator<Record<string, unknown>> {
+      for (const part of script) yield part;
+      yield { type: 'finish-step', usage: {}, finishReason: 'tool-calls' };
+    }
+    const fakeAi = {
+      streamText: vi.fn(() => ({
+        fullStream: fakeFullStream(),
+        finishReason: Promise.resolve('tool-calls'),
+      })),
+      wrapLanguageModel: ({ model }: { model: unknown }) => model,
+      isStepCount: () => () => false,
+    };
+    vi.mocked(importESM).mockResolvedValue(fakeAi as never);
+  }
+
+  const id = (e: StreamEvent): string => (e as { toolCallId: string }).toolCallId;
+
+  it('executes tools from streamed deltas and emits running/completed before step end', async () => {
+    // No `tool-input-available`/`tool-call` parts here — execution and UI events
+    // must come entirely from the streamed-delta finalization path.
+    installDeltaFakeAiSdk([
+      { type: 'tool-input-start', toolCallId: 'call-A', toolName: 'slow' },
+      { type: 'tool-input-delta', toolCallId: 'call-A', inputTextDelta: '{"x":' },
+      { type: 'tool-input-delta', toolCallId: 'call-A', inputTextDelta: '1}' },
+      // Model moves on to B → A's input is complete → A launches early (backstop).
+      { type: 'tool-input-start', toolCallId: 'call-B', toolName: 'fast' },
+      { type: 'tool-input-delta', toolCallId: 'call-B', inputTextDelta: '{"x":2}' },
+      // B's input ends → B launches.
+      { type: 'tool-input-end', toolCallId: 'call-B' },
+    ]);
+
+    const registry = new ToolRegistry();
+    registerTool(registry, 'slow', slowHandler);
+    registerTool(registry, 'fast', fastHandler);
+
+    const controller = new AbortController();
+    const gen = streamChat({
+      messages: [],
+      agent,
+      systemPrompt: '',
+      context: { cwd },
+      config: defaults(),
+      registry,
+      mcpManager: null,
+      abortSignal: controller.signal,
+      modelInstance: {} as never,
+    });
+
+    const events: StreamEvent[] = [];
+    while (true) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+    }
+    await vi.waitFor(() => expect(slowHandler).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(fastHandler).toHaveBeenCalledOnce());
+
+    // Both tools executed exactly once via the delta path.
+    expect(slowHandler).toHaveBeenCalledOnce();
+    expect(fastHandler).toHaveBeenCalledOnce();
+
+    // `running` and `completed` events were emitted for each tool.
+    const toolCalls = events.filter((e) => e.type === 'tool_call').map(id).sort();
+    const toolResults = events.filter((e) => e.type === 'tool_result').map(id).sort();
+    expect(toolCalls).toEqual(['call-A', 'call-B']);
+    expect(toolResults).toEqual(['call-A', 'call-B']);
+
+    // Ordering fix: A's `running` event precedes B's generation start.
+    const idxCallA = events.findIndex((e) => e.type === 'tool_call' && id(e) === 'call-A');
+    const idxStartB = events.findIndex((e) => e.type === 'tool_call_start' && id(e) === 'call-B');
+    expect(idxCallA).toBeGreaterThanOrEqual(0);
+    expect(idxStartB).toBeGreaterThan(idxCallA);
+
+    // `completed` lands before the stream finishes (emitted during streaming).
+    const idxResultA = events.findIndex((e) => e.type === 'tool_result' && id(e) === 'call-A');
+    const idxFinish = events.findIndex((e) => e.type === 'finish');
+    expect(idxResultA).toBeGreaterThanOrEqual(0);
+    expect(idxResultA).toBeLessThan(idxFinish);
+  });
+
+  it('does not execute a tool whose streamed input is incomplete/invalid JSON', async () => {
+    installDeltaFakeAiSdk([
+      { type: 'tool-input-start', toolCallId: 'call-A', toolName: 'slow' },
+      { type: 'tool-input-delta', toolCallId: 'call-A', inputTextDelta: '{"x":' },
+      // B starts → A finalizes, but A's accumulated text is not valid JSON.
+      { type: 'tool-input-start', toolCallId: 'call-B', toolName: 'fast' },
+      { type: 'tool-input-delta', toolCallId: 'call-B', inputTextDelta: '{"x":2}' },
+      { type: 'tool-input-end', toolCallId: 'call-B' },
+    ]);
+
+    const registry = new ToolRegistry();
+    registerTool(registry, 'slow', slowHandler);
+    registerTool(registry, 'fast', fastHandler);
+
+    const controller = new AbortController();
+    const gen = streamChat({
+      messages: [],
+      agent,
+      systemPrompt: '',
+      context: { cwd },
+      config: defaults(),
+      registry,
+      mcpManager: null,
+      abortSignal: controller.signal,
+      modelInstance: {} as never,
+    });
+
+    while (true) {
+      const { done } = await gen.next();
+      if (done) break;
+    }
+    await vi.waitFor(() => expect(fastHandler).toHaveBeenCalledOnce());
+
+    // A's invalid input was skipped by the delta path (no crash, no execution);
+    // B (valid) still executed.
+    expect(slowHandler).not.toHaveBeenCalled();
+    expect(fastHandler).toHaveBeenCalledOnce();
+  });
 });

--- a/electron/tests/integration/eager-tool-execution-stream.test.ts
+++ b/electron/tests/integration/eager-tool-execution-stream.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Eager tool execution — end-to-end through streamChat (R11 headline test).
+ *
+ * Mocks the AI SDK (`importESM('ai')`) with a controllable `streamText` whose
+ * fullStream emits two tool calls separated by a "model still generating" gate.
+ * Proves the orchestrator starts the first tool executing on `tool-input-available`
+ * — while the model is still generating the second tool call — rather than
+ * waiting for the whole step to finish.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { importESM } from '../../src/main/utils/esm-import';
+import { streamChat, type StreamEvent } from '../../src/main/llm/orchestrator';
+import { ToolRegistry } from '../../src/main/tools/registry';
+import { defaults } from '../../src/main/config';
+import { genericToolResultDataSchema } from '../../src/shared/types/tool-result';
+import type { Agent } from '../../src/shared/types/agent';
+import type { ToolHandler } from '../../src/main/tools/types';
+
+vi.mock('../../src/main/utils/esm-import', () => ({
+  importESM: vi.fn(),
+}));
+
+const agent: Agent = {
+  name: 'eager-test',
+  type: 'custom' as never,
+  tier: 'bloom' as never,
+  description: 'test agent',
+  system_prompt: '',
+  allowed_tools: ['slow', 'fast'],
+  allowed_skills: [],
+};
+
+describe('eager tool execution through streamChat', () => {
+  let cwd: string;
+  let slowHandler: ReturnType<typeof vi.fn>;
+  let fastHandler: ReturnType<typeof vi.fn>;
+  let releaseModel!: () => void;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-eager-stream-'));
+    slowHandler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'slow' } }));
+    fastHandler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'fast' } }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function registerTool(registry: ToolRegistry, name: string, handler: ToolHandler): void {
+    registry.register(
+      {
+        name,
+        description: `test tool ${name}`,
+        inputSchema: z.object({ x: z.number().optional() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'search',
+        riskClass: 'read',
+      },
+      handler,
+    );
+  }
+
+  function installFakeAiSdk(): void {
+    const modelGate = new Promise<void>((res) => {
+      releaseModel = res;
+    });
+    async function* fakeFullStream(): AsyncGenerator<Record<string, unknown>> {
+      yield { type: 'tool-input-available', toolCallId: 'call-A', toolName: 'slow', input: { x: 1 } };
+      // The model is still generating the next tool call until the test releases.
+      await modelGate;
+      yield { type: 'tool-input-available', toolCallId: 'call-B', toolName: 'fast', input: { x: 2 } };
+      yield { type: 'finish-step', usage: {}, finishReason: 'tool-calls' };
+    }
+    const fakeAi = {
+      streamText: vi.fn(() => ({
+        fullStream: fakeFullStream(),
+        finishReason: Promise.resolve('tool-calls'),
+      })),
+      wrapLanguageModel: ({ model }: { model: unknown }) => model,
+      isStepCount: () => () => false,
+    };
+    vi.mocked(importESM).mockResolvedValue(fakeAi as never);
+  }
+
+  it('starts tool A executing before the model finishes generating tool B', async () => {
+    installFakeAiSdk();
+
+    const registry = new ToolRegistry();
+    registerTool(registry, 'slow', slowHandler);
+    registerTool(registry, 'fast', fastHandler);
+
+    const controller = new AbortController();
+    const gen = streamChat({
+      messages: [],
+      agent,
+      systemPrompt: '',
+      context: { cwd },
+      config: defaults(),
+      registry,
+      mcpManager: null,
+      abortSignal: controller.signal,
+      modelInstance: {} as never,
+    });
+
+    const events: StreamEvent[] = [];
+    // Drive the generator manually (not for-await…break, which would close it).
+    // Pull until tool call A is delivered, then pause — the model gate is still
+    // held, so tool call B has not been generated yet.
+    let sawA = false;
+    while (!sawA) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+      if (value.type === 'tool_call' && value.toolCallId === 'call-A') sawA = true;
+    }
+    expect(sawA).toBe(true);
+
+    // Tool A began executing from its tool-input-available chunk alone (flush the
+    // permission-gate microtask), while the model is still generating tool B.
+    await vi.waitFor(() => expect(slowHandler).toHaveBeenCalledOnce());
+    expect(fastHandler).not.toHaveBeenCalled();
+    expect(events.some((e) => e.type === 'tool_call' && e.toolCallId === 'call-B')).toBe(false);
+
+    // Let the model finish generating tool B and drain the rest of the stream.
+    releaseModel();
+    while (true) {
+      const { value, done } = await gen.next();
+      if (done) break;
+      events.push(value);
+    }
+
+    await vi.waitFor(() => expect(fastHandler).toHaveBeenCalledOnce());
+    // Each tool executed exactly once (eager start, no double-run).
+    expect(slowHandler).toHaveBeenCalledOnce();
+
+    const toolCallEvents = events.filter((e) => e.type === 'tool_call');
+    const order = toolCallEvents.map((e) => (e as { toolCallId: string }).toolCallId);
+    expect(order).toEqual(['call-A', 'call-B']);
+    expect(events.some((e) => e.type === 'finish')).toBe(true);
+  });
+});

--- a/electron/tests/unit/eager-tool-execution.test.ts
+++ b/electron/tests/unit/eager-tool-execution.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Eager tool execution — buildToolMap integration tests (U2/U3 contract).
+ *
+ * Exercises the real launcher → executeToolCall → handler path and the
+ * `execute` shim that awaits the pre-started in-flight promise. Proves:
+ *  - a tool begins executing at `start()` time (mid-stream), not at step end;
+ *  - the SDK's later `execute` call awaits the same run (no double execution);
+ *  - without a pre-start, `execute` falls back to running the tool normally;
+ *  - handler errors surface through the shim as normal terminal results.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { buildToolMap } from '../../src/main/llm/orchestrator';
+import { EagerToolExecutor } from '../../src/main/llm/eager-tool-executor';
+import { ToolRegistry } from '../../src/main/tools/registry';
+import { genericToolResultDataSchema } from '../../src/shared/types/tool-result';
+import type { ToolHandler } from '../../src/main/tools/types';
+
+type ExecFn = (
+  args: unknown,
+  opts: { toolCallId: string; abortSignal?: AbortSignal },
+) => Promise<unknown>;
+
+describe('eager tool execution via buildToolMap', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-eager-exec-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function registerTool(registry: ToolRegistry, name: string, handler: ToolHandler): void {
+    registry.register(
+      {
+        name,
+        description: `test tool ${name}`,
+        inputSchema: z.object({ x: z.number().optional() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'search',
+        riskClass: 'read',
+      },
+      handler,
+    );
+  }
+
+  function buildMap(handler: ToolHandler, eager?: EagerToolExecutor) {
+    const registry = new ToolRegistry();
+    registerTool(registry, 'slow', handler);
+    const tools = buildToolMap(
+      ['slow'],
+      registry,
+      null,
+      { cwd, timeoutSeconds: 30 },
+      undefined,
+      eager,
+    );
+    return tools;
+  }
+
+  it('starts the handler at start() time and the execute shim awaits the same run', async () => {
+    const eager = new EagerToolExecutor();
+    let release!: () => void;
+    const gate = new Promise<void>((res) => {
+      release = res;
+    });
+    let started = false;
+    const handler = vi.fn(async () => {
+      started = true;
+      await gate;
+      return { status: 'complete' as const, data: { value: 'done' } };
+    });
+    const tools = buildMap(handler, eager);
+
+    // Mimic the stream loop on `tool-input-available`: start before step end.
+    eager.start('call-1', 'slow', { x: 1 });
+    expect(eager.getOrStart('call-1', 'slow', { x: 1 })).toBeInstanceOf(Promise);
+
+    // Execution began from `start()` alone — flush the permission-gate microtask
+    // so the handler runs up to the gate. The gate keeps it in-flight, proving
+    // it started before any `execute` call (i.e. before model-call-end).
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    expect(started).toBe(true);
+
+    // The SDK now calls execute at step end; it must await the in-flight run.
+    const execPromise = (tools.slow.execute as unknown as ExecFn)({ x: 1 }, { toolCallId: 'call-1' });
+    release();
+    const result = (await execPromise) as { canonical: { status: string } };
+
+    expect(result.canonical.status).toBe('complete');
+    // Exactly one execution total — the shim did not re-run the handler.
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('execute falls back to running the tool when it was not pre-started', async () => {
+    const eager = new EagerToolExecutor();
+    const handler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'fallback' } }));
+    const tools = buildMap(handler, eager);
+
+    const result = (await (tools.slow.execute as unknown as ExecFn)(
+      { x: 2 },
+      { toolCallId: 'never-started' },
+    )) as { canonical: { status: string } };
+
+    expect(result.canonical.status).toBe('complete');
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('works with no eager executor at all (pure fallback path)', async () => {
+    const handler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'plain' } }));
+    const tools = buildMap(handler, undefined);
+
+    const result = (await (tools.slow.execute as unknown as ExecFn)(
+      { x: 3 },
+      { toolCallId: 'plain-call' },
+    )) as { canonical: { status: string } };
+
+    expect(result.canonical.status).toBe('complete');
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces a handler error through the shim as a terminal error result', async () => {
+    const eager = new EagerToolExecutor();
+    const handler = vi.fn(async () => {
+      throw new Error('handler boom');
+    });
+    const tools = buildMap(handler, eager);
+
+    eager.start('call-err', 'slow', { x: 1 });
+    const result = (await (tools.slow.execute as unknown as ExecFn)(
+      { x: 1 },
+      { toolCallId: 'call-err' },
+    )) as { canonical: { status: string } };
+
+    expect(result.canonical.status).toBe('error');
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('start() for an unregistered tool is a no-op; execute still falls back', async () => {
+    const eager = new EagerToolExecutor();
+    const handler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'ok' } }));
+    const tools = buildMap(handler, eager);
+
+    // No launcher for 'unknown' — start does nothing.
+    eager.start('call-x', 'unknown', {});
+    expect(eager.getOrStart('call-x', 'unknown', {})).toBeUndefined();
+
+    const result = (await (tools.slow.execute as unknown as ExecFn)(
+      { x: 9 },
+      { toolCallId: 'call-x' },
+    )) as { canonical: { status: string } };
+    expect(result.canonical.status).toBe('complete');
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('executes exactly once when the execute shim runs before the stream loop starts the tool', async () => {
+    const eager = new EagerToolExecutor();
+    const handler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'shim-first' } }));
+    const tools = buildMap(handler, eager);
+
+    // Race case: the SDK calls execute (shim) before the stream loop's start().
+    const execPromise = (tools.slow.execute as unknown as ExecFn)({ x: 5 }, { toolCallId: 'call-race' });
+    // The stream loop's later start() must not launch a second execution.
+    eager.start('call-race', 'slow', { x: 5 });
+
+    const result = (await execPromise) as { canonical: { status: string } };
+    expect(result.canonical.status).toBe('complete');
+    // Exactly one execution — the memoized promise is shared, no double-run.
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});

--- a/electron/tests/unit/eager-tool-execution.test.ts
+++ b/electron/tests/unit/eager-tool-execution.test.ts
@@ -19,6 +19,9 @@ import { EagerToolExecutor } from '../../src/main/llm/eager-tool-executor';
 import { ToolRegistry } from '../../src/main/tools/registry';
 import { genericToolResultDataSchema } from '../../src/shared/types/tool-result';
 import type { ToolHandler } from '../../src/main/tools/types';
+import type { MCPManager } from '../../src/main/mcp/manager';
+import type { Skill } from '../../src/shared/types/skill';
+import { sessionPermissionOverrides } from '../../src/main/ipc/permission';
 
 type ExecFn = (
   args: unknown,
@@ -175,5 +178,102 @@ describe('eager tool execution via buildToolMap', () => {
     expect(result.canonical.status).toBe('complete');
     // Exactly one execution — the memoized promise is shared, no double-run.
     expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('MCP tools: launcher keyed by internal name, execute under the mangled provider name awaits the eager run (KTD-3)', async () => {
+    // mcp::* tools are always-ask; allow via session override so no dialog is needed.
+    const sessionId = `eager-mcp-${Date.now()}`;
+    sessionPermissionOverrides.set(sessionId, 'allow');
+    try {
+      const eager = new EagerToolExecutor();
+      const mcpHandler = vi.fn(async () => ({ status: 'complete' as const, data: { value: 'mcp-ok' } }));
+      const internalName = 'mcp::srv::do_thing';
+      const mcpDefinition = {
+        name: internalName,
+        description: 'mcp test tool',
+        inputSchema: z.object({ x: z.number().optional() }),
+        resultFamily: 'generic',
+        outputDataSchema: genericToolResultDataSchema,
+        category: 'search',
+        riskClass: 'read',
+      };
+      const mcpManager = {
+        getTools: () => [{ definition: mcpDefinition, handler: mcpHandler }],
+      } as unknown as MCPManager;
+
+      const registry = new ToolRegistry();
+      registerTool(registry, 'slow', vi.fn(async () => ({ status: 'complete' as const, data: {} })));
+      const tools = buildToolMap(
+        [internalName],
+        registry,
+        mcpManager,
+        { cwd, timeoutSeconds: 30, sessionId },
+        undefined,
+        eager,
+      );
+
+      // The MCP tool is exposed under a mangled provider name, not the internal name.
+      const providerName = Object.keys(tools).find((k) => k !== 'slow')!;
+      expect(providerName).toBeDefined();
+      expect(providerName).not.toBe(internalName);
+
+      // Eager start uses the INTERNAL name; the execute shim lives under the provider name.
+      eager.start('call-mcp', internalName, { x: 1 });
+      await vi.waitFor(() => expect(mcpHandler).toHaveBeenCalledOnce());
+
+      const result = (await (tools[providerName].execute as unknown as ExecFn)(
+        { x: 1 },
+        { toolCallId: 'call-mcp' },
+      )) as { canonical: { status: string } };
+      expect(result.canonical.status).toBe('complete');
+      // Exactly one execution — the shim awaited the eager run keyed by toolCallId.
+      expect(mcpHandler).toHaveBeenCalledOnce();
+
+      // Fallback: a fresh toolCallId runs the tool normally.
+      const fallback = (await (tools[providerName].execute as unknown as ExecFn)(
+        { x: 2 },
+        { toolCallId: 'mcp-fresh' },
+      )) as { canonical: { status: string } };
+      expect(fallback.canonical.status).toBe('complete');
+      expect(mcpHandler).toHaveBeenCalledTimes(2);
+    } finally {
+      sessionPermissionOverrides.delete(sessionId);
+    }
+  });
+
+  it('skill tool: eager launcher is registered and the execute shim awaits the eager run', async () => {
+    const eager = new EagerToolExecutor();
+    const skill: Skill = {
+      name: 'test-skill',
+      description: 'a test skill',
+      requires: [],
+      resources: [],
+      content: 'test-skill body',
+    };
+    // A dummy 'skill' registry entry so buildToolMap enters the skill-rebuild branch.
+    const registry = new ToolRegistry();
+    registerTool(registry, 'skill', vi.fn(async () => ({ status: 'complete' as const, data: {} })));
+    const tools = buildToolMap(
+      ['skill'],
+      registry,
+      null,
+      { cwd, timeoutSeconds: 30 },
+      { skills: new Map([['test-skill', skill]]) },
+      eager,
+    );
+    expect(tools.skill).toBeDefined();
+
+    // Eagerly start the real skill handler.
+    eager.start('call-skill', 'skill', { name: 'test-skill' });
+    const eagerPromise = eager.getOrStart('call-skill', 'skill', { name: 'test-skill' });
+    expect(eagerPromise).toBeInstanceOf(Promise); // launcher registered for 'skill'
+
+    // The shim must await the eager run: its result is the same resolved object as
+    // the eager promise (a fresh fallback execution would produce a different one).
+    const shimResult = await (tools.skill.execute as unknown as ExecFn)(
+      { name: 'test-skill' },
+      { toolCallId: 'call-skill' },
+    );
+    expect(shimResult).toBe(await eagerPromise);
   });
 });

--- a/electron/tests/unit/eager-tool-executor.test.ts
+++ b/electron/tests/unit/eager-tool-executor.test.ts
@@ -35,7 +35,7 @@ describe('EagerToolExecutor', () => {
     const second = executor.getOrStart('call-1', 'read', { file_path: 'a.ts' });
 
     expect(launcher).toHaveBeenCalledOnce();
-    expect(launcher).toHaveBeenCalledWith('call-1', { file_path: 'a.ts' });
+    expect(launcher).toHaveBeenCalledWith('call-1', { file_path: 'a.ts' }, undefined);
     expect(first).toBeInstanceOf(Promise);
     expect(second).toBe(first);
   });
@@ -130,5 +130,60 @@ describe('EagerToolExecutor', () => {
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledOnce();
+  });
+
+  it('validator gate blocks invalid input without invoking the launcher', () => {
+    const executor = new EagerToolExecutor();
+    const launcher = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('tool', launcher);
+    executor.registerValidator('tool', (input) => (input as { ok?: boolean })?.ok === true);
+
+    expect(executor.getOrStart('call-bad', 'tool', { ok: false })).toBeUndefined();
+    expect(launcher).not.toHaveBeenCalled();
+
+    const good = executor.getOrStart('call-good', 'tool', { ok: true });
+    expect(good).toBeInstanceOf(Promise);
+    expect(launcher).toHaveBeenCalledOnce();
+  });
+
+  it('launches for any input when no validator is registered', () => {
+    const executor = new EagerToolExecutor();
+    const launcher = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('tool', launcher);
+
+    const result = executor.getOrStart('call-1', 'tool', { anything: 1 });
+
+    expect(result).toBeInstanceOf(Promise);
+    expect(launcher).toHaveBeenCalledOnce();
+  });
+
+  it('forget() releases the memo so the next getOrStart re-executes', () => {
+    const executor = new EagerToolExecutor();
+    const launcher = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('read', launcher);
+
+    const p1 = executor.getOrStart('call-1', 'read', {});
+    expect(launcher).toHaveBeenCalledOnce();
+
+    executor.forget('call-1');
+
+    const p2 = executor.getOrStart('call-1', 'read', {});
+    expect(launcher).toHaveBeenCalledTimes(2);
+    expect(p2).not.toBe(p1);
+
+    expect(() => executor.forget('never-seen')).not.toThrow();
+  });
+
+  it('threads the abortSignal through to the launcher', () => {
+    const executor = new EagerToolExecutor();
+    const signal = new AbortController().signal;
+    const launcher = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('tool', launcher);
+
+    executor.getOrStart('call-1', 'tool', { x: 1 }, signal);
+    expect(launcher).toHaveBeenCalledWith('call-1', { x: 1 }, signal);
+
+    executor.start('call-2', 'tool', { x: 2 }, signal);
+    expect(launcher).toHaveBeenCalledWith('call-2', { x: 2 }, signal);
   });
 });

--- a/electron/tests/unit/eager-tool-executor.test.ts
+++ b/electron/tests/unit/eager-tool-executor.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Eager tool execution coordinator tests (U1).
+ *
+ * Covers the pure coordination logic: launcher registration, single memoized
+ * execution per toolCallId regardless of whether `start` (stream loop) or
+ * `getOrStart` (execute shim) runs first, undefined for unregistered tools,
+ * synchronous-failure capture, and per-tool isolation. The coordinator never
+ * inspects the result value, so a sentinel stands in for a ToolExecutionResult.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { EagerToolExecutor } from '../../src/main/llm/eager-tool-executor';
+import type { ToolExecutionResult } from '../../src/shared/types/tool-result';
+
+const sentinel = { canonical: { status: 'success' } } as unknown as ToolExecutionResult;
+
+function deferred(): {
+  promise: Promise<ToolExecutionResult>;
+  resolve: (value: ToolExecutionResult) => void;
+} {
+  let resolve!: (value: ToolExecutionResult) => void;
+  const promise = new Promise<ToolExecutionResult>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('EagerToolExecutor', () => {
+  it('getOrStart creates the execution on first call and memoizes it', () => {
+    const executor = new EagerToolExecutor();
+    const launcher = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('read', launcher);
+
+    const first = executor.getOrStart('call-1', 'read', { file_path: 'a.ts' });
+    const second = executor.getOrStart('call-1', 'read', { file_path: 'a.ts' });
+
+    expect(launcher).toHaveBeenCalledOnce();
+    expect(launcher).toHaveBeenCalledWith('call-1', { file_path: 'a.ts' });
+    expect(first).toBeInstanceOf(Promise);
+    expect(second).toBe(first);
+  });
+
+  it('getOrStart returns undefined and stores nothing when no launcher is registered', () => {
+    const executor = new EagerToolExecutor();
+    expect(executor.getOrStart('call-1', 'unregistered', {})).toBeUndefined();
+    // A later launcher registration does not retroactively pick up the old id.
+    executor.registerLauncher('unregistered', vi.fn().mockResolvedValue(sentinel));
+    expect(executor.getOrStart('call-1', 'unregistered', {})).toBeInstanceOf(Promise);
+  });
+
+  it('start() and getOrStart() share one execution (stream-loop first)', async () => {
+    const executor = new EagerToolExecutor();
+    const { promise, resolve } = deferred();
+    const launcher = vi.fn(() => promise);
+    executor.registerLauncher('grep', launcher);
+
+    executor.start('call-1', 'grep', { pattern: 'x' });
+    const fromShim = executor.getOrStart('call-1', 'grep', { pattern: 'x' });
+
+    expect(launcher).toHaveBeenCalledOnce();
+    expect(fromShim).toBe(promise);
+    resolve(sentinel);
+    await expect(fromShim).resolves.toBe(sentinel);
+  });
+
+  it('runs exactly once when the execute shim (getOrStart) beats start()', () => {
+    const executor = new EagerToolExecutor();
+    const launcher = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('edit', launcher);
+
+    // Shim path wins the race and starts the execution…
+    const fromShim = executor.getOrStart('call-1', 'edit', {});
+    // …then the stream loop's start() must be a no-op.
+    executor.start('call-1', 'edit', {});
+
+    expect(launcher).toHaveBeenCalledOnce();
+    expect(fromShim).toBeInstanceOf(Promise);
+  });
+
+  it('is idempotent per toolCallId across repeated start() calls', () => {
+    const executor = new EagerToolExecutor();
+    const launcher = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('grep', launcher);
+
+    executor.start('call-1', 'grep', { pattern: 'x' });
+    executor.start('call-1', 'grep', { pattern: 'x' });
+
+    expect(launcher).toHaveBeenCalledOnce();
+  });
+
+  it('captures a synchronous launcher throw as a rejected memoized promise', async () => {
+    const executor = new EagerToolExecutor();
+    const boom = new Error('launcher exploded');
+    executor.registerLauncher('edit', () => {
+      throw boom;
+    });
+
+    const first = executor.getOrStart('call-1', 'edit', {});
+    const second = executor.getOrStart('call-1', 'edit', {});
+
+    expect(first).toBe(second);
+    await expect(first).rejects.toBe(boom);
+  });
+
+  it('tracks multiple tool calls independently', async () => {
+    const executor = new EagerToolExecutor();
+    const a = deferred();
+    const b = deferred();
+    executor.registerLauncher('read', () => a.promise);
+    executor.registerLauncher('grep', () => b.promise);
+
+    const inflightA = executor.getOrStart('call-a', 'read', {})!;
+    const inflightB = executor.getOrStart('call-b', 'grep', {})!;
+    expect(inflightA).not.toBe(inflightB);
+
+    a.resolve(sentinel);
+    b.resolve(sentinel);
+    await expect(inflightA).resolves.toBe(sentinel);
+    await expect(inflightB).resolves.toBe(sentinel);
+  });
+
+  it('last launcher registration wins for a tool name', () => {
+    const executor = new EagerToolExecutor();
+    const first = vi.fn().mockResolvedValue(sentinel);
+    const second = vi.fn().mockResolvedValue(sentinel);
+    executor.registerLauncher('read', first);
+    executor.registerLauncher('read', second);
+
+    executor.start('call-1', 'read', {});
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools now begin executing as soon as their streamed inputs are complete, reducing wait time during model responses.
  * Tool execution remains consistent across standard, skill, and MCP tools, with duplicate executions prevented.
  * Improved cancellation handling and preservation of tool results during streamed responses.

* **Bug Fixes**
  * Prevented valid, long-running tools from being incorrectly terminated by idle timeouts.
  * Invalid streamed inputs are safely skipped without blocking subsequent valid tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->