### PR TITLE
fix(providers): streamline connection management feedback

### DIFF
--- a/electron/src/renderer/AppReady.tsx
+++ b/electron/src/renderer/AppReady.tsx
@@ -4,13 +4,17 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import { ChatView } from './components/ChatView';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
+import { Alert } from './components/ui/Alert';
+import { Button } from './components/ui/Button';
 import { StateMessage } from './components/ui/StateMessage';
 import { applyTheme, type ThemeName, THEME_NAMES } from './themes';
 import { onOrchidEvent } from './utils/events';
+import type { Notify, NotifySeverity } from './utils/notify';
 import type { Config } from '../shared/types/ipc-boundary';
 
 type SettingsTab = 'general' | 'providers' | 'mcp' | 'tier-models' | 'rag' | 'skills' | 'agents' | 'personalities';
@@ -22,6 +26,11 @@ const OnboardingScreen = lazy(() => import('./components/Onboarding/OnboardingSc
   default: module.OnboardingScreen,
 })));
 
+interface Toast {
+  message: string;
+  severity: NotifySeverity;
+}
+
 function AppReady() {
   const [theme, setThemeState] = useState<ThemeName>('default');
   const [configOpen, setConfigOpen] = useState(false);
@@ -29,6 +38,8 @@ function AppReady() {
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [onboardingChecked, setOnboardingChecked] = useState(false);
   const [bootstrapConfig, setBootstrapConfig] = useState<Config | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     applyTheme(theme);
@@ -71,6 +82,18 @@ function AppReady() {
     }
   }, []);
 
+  const notify: Notify = useCallback((message, severity = 'info') => {
+    console.log(`[${severity.toUpperCase()}] ${message}`);
+    if (severity === 'error') console.error(message);
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast({ message, severity });
+    toastTimer.current = setTimeout(() => setToast(null), 4500);
+  }, []);
+
+  useEffect(() => () => {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+  }, []);
+
   useEffect(() => onOrchidEvent('orchid:set-theme', (detail) => {
     const name = detail.theme as ThemeName | undefined;
     if (name && THEME_NAMES.includes(name)) {
@@ -88,15 +111,37 @@ function AppReady() {
   const chatVisible = !configOpen && !(onboardingOpen && onboardingChecked);
 
   return (
-    <div className="app-root h-screen min-h-0 overflow-hidden bg-base-100 text-base-content" data-theme={theme}>
+    <div className="app-root relative h-screen min-h-0 overflow-hidden bg-base-100 text-base-content" data-theme={theme}>
+      {toast && (
+        <Alert
+          tone={toast.severity}
+          variant="soft"
+          className={`command-toast command-toast-${toast.severity} orchid-state-enter py-2 text-sm`}
+          role="status"
+          aria-live="polite"
+          action={
+            <Button
+              variant="ghost"
+              size="xs"
+              shape="circle"
+              onClick={() => setToast(null)}
+              aria-label="Dismiss"
+            >
+              ×
+            </Button>
+          }
+        >
+          <span className="command-toast-message min-w-0 flex-1">{toast.message}</span>
+        </Alert>
+      )}
       {/* Keep ChatView mounted under Config so selection and draft state stay shared. */}
       <div className={chatVisible ? 'contents' : 'hidden'} aria-hidden={!chatVisible}>
-        <ChatView isVisible={chatVisible} bootstrapConfig={bootstrapConfig} />
+        <ChatView isVisible={chatVisible} bootstrapConfig={bootstrapConfig} onNotify={notify} />
       </div>
       {configOpen && (
         <ErrorBoundary title="Settings could not load">
           <Suspense fallback={<div className="flex h-screen min-h-0 items-center justify-center bg-base-100"><StateMessage kind="loading" title="Loading Settings…" role="status" aria-live="polite" /></div>}>
-            <ConfigView initialTab={settingsTab} onClose={() => setConfigOpen(false)} />
+            <ConfigView initialTab={settingsTab} onClose={() => setConfigOpen(false)} onNotify={notify} />
           </Suspense>
         </ErrorBoundary>
       )}

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -42,6 +42,7 @@ import type {
   RAGStoreStatus,
 } from '../../shared/types/ipc-boundary';
 import type { ProviderModelOption, SessionOpenResult } from '../../shared/types/ipc';
+import type { Notify } from '../utils/notify';
 import { ChatStream } from './ChatStream';
 import { DeferredSurface } from './deferred-surface';
 import { InputArea } from './InputArea';
@@ -53,7 +54,6 @@ import { CommandPalette } from './CommandPalette';
 import { ShortcutsHelp } from './ShortcutsHelp';
 import { SessionHeader } from './session-header';
 import { SessionTabBar } from './SessionTabBar';
-import { Alert, type AlertTone } from './ui/Alert';
 import { Button } from './ui/Button';
 import { StateMessage } from './ui/StateMessage';
 import type { SubagentOpenRequest } from './SubagentView';
@@ -65,20 +65,16 @@ const SubagentView = lazy(() => import('./SubagentView').then((module) => ({
   default: module.SubagentView,
 })));
 
-type ToastSeverity = 'info' | 'warning' | 'error';
-interface Toast {
-  message: string;
-  severity: ToastSeverity;
-}
-
 interface ChatViewProps {
   /** False while a full-window surface owns presentation. */
   isVisible?: boolean;
   /** App-owned effective configuration loaded once during renderer startup. */
   bootstrapConfig?: Config | null;
+  /** App-level notification surface shared by chat and settings. */
+  onNotify: Notify;
 }
 
-export function ChatView({ isVisible = true, bootstrapConfig = null }: ChatViewProps) {
+export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify }: ChatViewProps) {
   const session = useSession();
   const chat = useChat(session.activeSession?.id ?? null);
   const subagents = useSubagents(session.activeSession?.id ?? null);
@@ -120,13 +116,12 @@ export function ChatView({ isVisible = true, bootstrapConfig = null }: ChatViewP
   const [providerModelOptions, setProviderModelOptions] = useState<readonly ProviderModelOption[]>([]);
   const [maxContext, setMaxContext] = useState<number | null>(null);
   const [alwaysExpandToolGroups, setAlwaysExpandToolGroups] = useState(false);
-  const [toast, setToast] = useState<Toast | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
   const [contentMode, setContentMode] = useState<'chat' | 'subagents'>('chat');
   const [projectConfigDir, setProjectConfigDir] = useState<string | null>(null);
   const [subagentOpenRequest, setSubagentOpenRequest] = useState<SubagentOpenRequest>({ generation: 0, id: null });
   const chatContentRef = useRef<HTMLDivElement>(null);
-  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const notify = onNotify;
 
   useEffect(() => {
     const element = chatContentRef.current;
@@ -388,11 +383,8 @@ export function ChatView({ isVisible = true, bootstrapConfig = null }: ChatViewP
     const workspace = await session.setWorkspace(projectDir);
     if (!workspace?.cwd || gen !== sessionSwitchGen.current) return;
     await enterDraftMode({ clearComposer: true });
-    setToast({
-      severity: 'info',
-      message: `New chat in project: ${workspace.cwd}`,
-    });
-  }, [session, enterDraftMode]);
+    notify(`New chat in project: ${workspace.cwd}`, 'info');
+  }, [session, enterDraftMode, notify]);
 
   const handleProjectSelect = useCallback((projectDir: string) => {
     setProjectConfigDir(projectDir);
@@ -504,16 +496,6 @@ export function ChatView({ isVisible = true, bootstrapConfig = null }: ChatViewP
     [session, chat.setMessages, tabs.refresh, focusAfterWorkingSet],
   );
 
-  const notify = useCallback((message: string, severity: ToastSeverity = 'info') => {
-    console.log(`[${severity.toUpperCase()}] ${message}`);
-    if (severity === 'error') {
-      console.error(message);
-    }
-    if (toastTimer.current) clearTimeout(toastTimer.current);
-    setToast({ message, severity });
-    toastTimer.current = setTimeout(() => setToast(null), 4500);
-  }, []);
-
   const handleSessionRename = useCallback(
     async (id: string, name: string) => {
       try {
@@ -525,12 +507,6 @@ export function ChatView({ isVisible = true, bootstrapConfig = null }: ChatViewP
     },
     [session, notify],
   );
-
-  useEffect(() => {
-    return () => {
-      if (toastTimer.current) clearTimeout(toastTimer.current);
-    };
-  }, []);
 
   // null workspace = still loading; allow send (main process still gates).
   // unbound/missing = block in UI (R3).
@@ -1016,22 +992,6 @@ export function ChatView({ isVisible = true, bootstrapConfig = null }: ChatViewP
       </DeferredSurface>
 
       <main className="main-pane min-h-0 min-w-0 overflow-hidden">
-        {toast && (
-          <Alert
-            tone={toast.severity as AlertTone}
-            variant="soft"
-            className={`command-toast command-toast-${toast.severity} orchid-state-enter py-2 text-sm`}
-            role="status"
-            aria-live="polite"
-            action={
-              <Button variant="ghost" size="xs" shape="circle" onClick={() => setToast(null)} aria-label="Dismiss">
-                ×
-              </Button>
-            }
-          >
-            <span className="command-toast-message min-w-0 flex-1">{toast.message}</span>
-          </Alert>
-        )}
         {projectConfigDir ? (
           <Suspense
             fallback={(

--- a/electron/src/renderer/components/ConfigView.tsx
+++ b/electron/src/renderer/components/ConfigView.tsx
@@ -34,6 +34,7 @@ import {
 } from '../utils/config-save';
 import { withMapDeletionTombstones } from '../utils/config-tombstones';
 import { emitOrchidEvent } from '../utils/events';
+import type { Notify } from '../utils/notify';
 import { Keycaps } from './Keycaps';
 import { Alert } from './ui/Alert';
 import { Button } from './ui/Button';
@@ -143,6 +144,7 @@ const TABS: TabDef[] = [
 interface ConfigViewProps {
   onClose: () => void;
   initialTab?: TabId;
+  onNotify: Notify;
 }
 
 interface PermissionTabContext {
@@ -155,7 +157,7 @@ interface PermissionTabContext {
   updateDraft: (updates: ConfigPatch) => void;
 }
 
-export function ConfigView({ onClose, initialTab = 'general' }: ConfigViewProps) {
+export function ConfigView({ onClose, initialTab = 'general', onNotify }: ConfigViewProps) {
   const session = useSession();
   const providers = useProviders();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -689,6 +691,7 @@ export function ConfigView({ onClose, initialTab = 'general' }: ConfigViewProps)
                     ? updateProjectPermissionDraft
                     : updateDraft,
                 },
+                onNotify,
               )}
             </Suspense>
           ) : (
@@ -833,6 +836,7 @@ function renderTab(
     onScopeChange: () => {},
     updateDraft,
   },
+  onNotify: Notify = () => {},
 ) {
   switch (activeTab) {
     case 'general':
@@ -893,7 +897,7 @@ function renderTab(
         />
       );
     case 'providers':
-      return <ProvidersTab />;
+      return <ProvidersTab onNotify={onNotify} />;
     case 'mcp':
       return (
         <MCPServersTab

--- a/electron/src/renderer/components/Icon.tsx
+++ b/electron/src/renderer/components/Icon.tsx
@@ -122,6 +122,12 @@ interface IconProps extends Omit<SVGProps<SVGSVGElement>, 'name'> {
   label?: string;
 }
 
+const ICON_CENTERING: Partial<Record<IconName, string>> = {
+  // Trash2's lid polyline is asymmetric within its 24x24 viewBox (centered at x≈13
+  // instead of x=12), which makes the icon appear shifted right inside square buttons.
+  trash: '-translate-x-[4.5%]',
+};
+
 export function Icon({ name, size = 16, label, className = '', ...props }: IconProps) {
   const Component = ICONS[name];
 
@@ -129,7 +135,7 @@ export function Icon({ name, size = 16, label, className = '', ...props }: IconP
     <Component
       aria-hidden={label ? undefined : true}
       aria-label={label}
-      className={`shrink-0 ${className}`}
+      className={`shrink-0 ${ICON_CENTERING[name] ?? ''} ${className}`}
       focusable="false"
       size={size}
       strokeWidth={1.8}

--- a/electron/src/renderer/components/Preferences/ProvidersTab.tsx
+++ b/electron/src/renderer/components/Preferences/ProvidersTab.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import type { ProviderConnectionView } from '../../../shared/types/ipc';
 import { useProviders } from '../../hooks/useProviders';
 import { emitOrchidEvent } from '../../utils/events';
+import type { Notify } from '../../utils/notify';
 import {
   ConnectionWizard,
   type ProviderConnectionCompletion,
@@ -12,15 +13,19 @@ import { Alert } from '../ui/Alert';
 import { Button } from '../ui/Button';
 import { StateMessage } from '../ui/StateMessage';
 
-export function ProvidersTab() {
+export function ProvidersTab({ onNotify }: { readonly onNotify: Notify }) {
   const providers = useProviders();
   const [wizardOpen, setWizardOpen] = useState(false);
   const [connectionToEdit, setConnectionToEdit] = useState<ProviderConnectionView | null>(null);
-
   const completeConnection = async (result: ProviderConnectionCompletion) => {
     if (result.selection) {
       emitOrchidEvent('orchid:provider-selection-created', { selection: result.selection });
     }
+    onNotify(
+      result.message
+        ?? `${result.connection.health === 'ready' ? 'Ready' : 'Provider'} connection updated.`,
+      'info',
+    );
     await providers.refresh();
     setConnectionToEdit(null);
   };
@@ -76,6 +81,7 @@ export function ProvidersTab() {
         onEnable={providers.enableConnection}
         onDisconnect={providers.disconnectConnection}
         onDelete={providers.deleteConnection}
+        onNotify={onNotify}
         onRefreshStatus={providers.refreshStatus}
       />
 

--- a/electron/src/renderer/components/Providers/ConnectionList.tsx
+++ b/electron/src/renderer/components/Providers/ConnectionList.tsx
@@ -307,8 +307,9 @@ export function ConnectionList({
                       label="Edit connection"
                       icon="edit"
                       size="sm"
+                      shape="square"
                       iconSize={14}
-                      className="btn-square h-7 w-7"
+                      className="h-7 w-7"
                       onClick={() => onEditConnection(connection)}
                       disabled={isBusy}
                     />
@@ -376,8 +377,9 @@ export function ConnectionList({
                     icon="trash"
                     variant="error"
                     size="sm"
+                    shape="square"
                     iconSize={14}
-                    className="btn-square h-7 w-7"
+                    className="h-7 w-7"
                     onClick={(event) => {
                       deleteTriggerRef.current = event.currentTarget;
                       setConfirmDisconnectId(null);

--- a/electron/src/renderer/components/Providers/ConnectionList.tsx
+++ b/electron/src/renderer/components/Providers/ConnectionList.tsx
@@ -15,11 +15,13 @@ import {
   providerStatusForConnection,
   providerStatusIsConnectionScoped,
 } from '../../utils/provider-selection';
+import type { Notify } from '../../utils/notify';
 import { Icon } from '../Icon';
 import { Alert } from '../ui/Alert';
 import { Button } from '../ui/Button';
 import { ConfigCard } from '../ui/ConfigCard';
 import { DialogSurface } from '../ui/DialogSurface';
+import { IconButton } from '../ui/IconButton';
 import { Panel } from '../ui/Panel';
 import { SectionHeader } from '../ui/SectionHeader';
 import { StateMessage } from '../ui/StateMessage';
@@ -39,6 +41,7 @@ export interface ConnectionListProps {
   readonly onDelete?: (
     message: ProviderDeleteConnectionMessage,
   ) => Promise<ProviderDeleteConnectionResult>;
+  readonly onNotify?: Notify;
   readonly onRefreshStatus?: (
     message: ProviderStatusRefreshMessage,
   ) => Promise<ProviderStatusView | null>;
@@ -49,10 +52,6 @@ type ConnectionAction = 'validate' | 'disable' | 'enable' | 'disconnect' | 'dele
 interface ConnectionActionResult {
   readonly message: string | null;
   readonly connection?: ProviderConnectionView;
-}
-
-function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : 'The connection action could not be completed.';
 }
 
 function healthLabel(health: ProviderConnectionView['health']): string {
@@ -87,6 +86,25 @@ function healthBadgeTone(
   }
 }
 
+function modelDisplayNames(
+  connection: ProviderConnectionView,
+  definition: ProviderDefinitionView | undefined,
+): readonly string[] {
+  const displayNames = new Map(
+    (definition?.models ?? []).map((model) => [model.id, model.displayName]),
+  );
+  for (const model of connection.customModels) {
+    displayNames.set(model.id, model.displayName);
+  }
+  const modelIds = [
+    ...connection.modelIds,
+    ...connection.customModels
+      .map((model) => model.id)
+      .filter((modelId) => !connection.modelIds.includes(modelId)),
+  ];
+  return modelIds.map((modelId) => displayNames.get(modelId) ?? modelId);
+}
+
 /**
  * Each card represents a single account/endpoint. It never shows a credential
  * handle or token, and disconnect requires an explicit in-context confirmation.
@@ -102,13 +120,12 @@ export function ConnectionList({
   onEnable,
   onDisconnect,
   onDelete,
+  onNotify,
   onRefreshStatus,
 }: ConnectionListProps) {
   const [busy, setBusy] = useState<{ connectionId: string; action: ConnectionAction } | null>(null);
   const [confirmDisconnectId, setConfirmDisconnectId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const deletePermanentRef = useRef<HTMLButtonElement>(null);
   const deleteTriggerRef = useRef<HTMLButtonElement>(null);
 
@@ -119,19 +136,17 @@ export function ConnectionList({
   ) => {
     if (!operation) return;
     setBusy({ connectionId, action });
-    setError(null);
-    setMessage(null);
     try {
       const result = await operation();
-      setMessage(
+      onNotify?.(
         result.message ?? (result.connection
           ? `${healthLabel(result.connection.health)} connection updated.`
           : 'Connection updated.'),
       );
       if (action === 'disconnect') setConfirmDisconnectId(null);
       if (action === 'delete') setConfirmDeleteId(null);
-    } catch (actionError) {
-      setError(describeError(actionError));
+    } catch {
+      // useProviders surfaces action failures on the settings surface.
     } finally {
       setBusy(null);
     }
@@ -172,7 +187,6 @@ export function ConnectionList({
     >
       <SectionHeader
         title={<h2 id="provider-connections-title" className="text-sm font-semibold">Connections</h2>}
-        description="Each connection is a separate provider account or endpoint."
         actions={
           onAddConnection ? (
             <Button size="sm" onClick={onAddConnection}>
@@ -183,32 +197,20 @@ export function ConnectionList({
         }
       />
 
-      {message && (
-        <Alert tone="info" role="status" icon="alertCircle" aria-live="polite">{message}</Alert>
-      )}
-      {error && (
-        <Alert tone="error" icon="alertCircle" aria-live="assertive">{error}</Alert>
-      )}
-
       <div className="grid gap-3 xl:grid-cols-2">
         {connections.map((connection) => {
           const isBusy = busy?.connectionId === connection.id;
-          const modelNames = [
-            ...connection.modelIds,
-            ...connection.customModels
-              .map((model) => model.id)
-              .filter((modelId) => !connection.modelIds.includes(modelId)),
-          ];
           const canValidate =
             connection.health === 'draft' || connection.health === 'needs_attention';
           const definition = definitions.find((candidate) => candidate.id === connection.providerId);
+          const modelNames = modelDisplayNames(connection, definition);
           const status = providerStatusForConnection(connections, connection, statuses);
           const showsProviderStatus = status !== undefined
             || (providerStatusIsConnectionScoped(connection.providerId)
               && connection.credentialKind !== 'none');
           return (
-            <ConfigCard key={connection.id}>
-              <ConfigCard.Body className="flex flex-col gap-4">
+            <ConfigCard key={connection.id} className="h-full">
+              <ConfigCard.Body className="flex flex-1 flex-col gap-4">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <h3 className="config-card-title font-semibold">{connection.name}</h3>
@@ -240,11 +242,6 @@ export function ConnectionList({
                   <Alert tone="warning" icon="alert">
                     Reconnect or validate this connection before using it. Other connections are
                     unaffected.
-                  </Alert>
-                )}
-                {connection.health === 'disabled' && (
-                  <Alert tone="info" role="status" icon="alertCircle">
-                    New turns are disabled. A turn that already started can finish safely.
                   </Alert>
                 )}
                 {connection.activeTurnCount > 0 && (
@@ -304,16 +301,17 @@ export function ConnectionList({
                   </Alert>
                 )}
 
-                <div className="flex justify-end gap-2">
+                <div className="mt-auto flex flex-wrap justify-end gap-2 border-t border-base-300 pt-3">
                   {onEditConnection && (
-                    <Button
+                    <IconButton
+                      label="Edit connection"
+                      icon="edit"
                       size="sm"
+                      iconSize={14}
+                      className="btn-square h-7 w-7"
                       onClick={() => onEditConnection(connection)}
                       disabled={isBusy}
-                    >
-                      <Icon name="edit" size={14} />
-                      Edit connection
-                    </Button>
+                    />
                   )}
                   {canValidate && (
                     <Button
@@ -373,18 +371,20 @@ export function ConnectionList({
                         Disconnect
                       </Button>
                     )}
-                  <Button
+                  <IconButton
+                    label="Delete connection"
+                    icon="trash"
                     variant="error"
                     size="sm"
+                    iconSize={14}
+                    className="btn-square h-7 w-7"
                     onClick={(event) => {
                       deleteTriggerRef.current = event.currentTarget;
                       setConfirmDisconnectId(null);
                       setConfirmDeleteId(connection.id);
                     }}
                     disabled={isBusy || !onDelete}
-                  >
-                    Delete connection
-                  </Button>
+                  />
                 </div>
 
                 <DialogSurface

--- a/electron/src/renderer/components/Providers/ConnectionWizard.tsx
+++ b/electron/src/renderer/components/Providers/ConnectionWizard.tsx
@@ -45,6 +45,7 @@ import {
 export interface ProviderConnectionCompletion {
   readonly connection: ProviderConnectionView;
   readonly selection: ModelSelection | null;
+  readonly message: string | null;
 }
 
 export interface ConnectionWizardProps {
@@ -339,6 +340,7 @@ export function ConnectionWizard({
       selection: selectionModelId
         ? { connectionId: result.connection.id, modelId: selectionModelId }
         : null,
+      message: result.message,
     });
     close(true);
     return true;
@@ -346,7 +348,7 @@ export function ConnectionWizard({
 
   const finishExistingUpdate = async (result: ProviderMutationResult): Promise<void> => {
     setPendingConnection(result.connection);
-    await onComplete?.({ connection: result.connection, selection: null });
+    await onComplete?.({ connection: result.connection, selection: null, message: result.message });
     close(true);
   };
 

--- a/electron/src/renderer/components/ui/IconButton.tsx
+++ b/electron/src/renderer/components/ui/IconButton.tsx
@@ -3,6 +3,7 @@ import { Icon, type IconName } from '../Icon';
 
 export type IconButtonSize = 'xs' | 'sm' | 'md';
 export type IconButtonVariant = 'ghost' | 'primary' | 'error' | 'warning' | 'neutral';
+export type IconButtonShape = 'default' | 'square' | 'circle';
 
 export interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
   /** Accessible name — required for icon-only buttons. */
@@ -12,6 +13,7 @@ export interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonEle
   children?: ReactNode;
   size?: IconButtonSize;
   variant?: IconButtonVariant;
+  shape?: IconButtonShape;
   loading?: boolean;
   /** Tooltip; defaults to `label` for icon-only controls. */
   tooltip?: string;
@@ -32,6 +34,12 @@ const VARIANT_CLASS: Record<IconButtonVariant, string> = {
   neutral: '',
 };
 
+const SHAPE_CLASS: Record<IconButtonShape, string> = {
+  default: '',
+  square: 'btn-square',
+  circle: 'btn-circle',
+};
+
 const DEFAULT_ICON_SIZE: Record<IconButtonSize, number> = {
   xs: 12,
   sm: 14,
@@ -46,6 +54,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(functio
     children,
     size = 'sm',
     variant = 'ghost',
+    shape,
     loading = false,
     tooltip,
     iconSize,
@@ -61,9 +70,13 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(functio
   const resolvedIconSize = iconSize ?? DEFAULT_ICON_SIZE[size];
   const sizeClass = SIZE_CLASS[size];
   const variantClass = VARIANT_CLASS[variant];
-  // Prefer explicit square/circle from className; default icon-only to circle.
+  // Retain className compatibility while feature callers migrate to the shape prop.
   const hasShapeOverride = /\bbtn-(?:square|circle)\b/.test(className);
-  const shapeClass = isIconOnly && !hasShapeOverride ? 'btn-circle' : '';
+  const shapeClass = shape
+    ? SHAPE_CLASS[shape]
+    : isIconOnly && !hasShapeOverride
+      ? SHAPE_CLASS.circle
+      : '';
 
   return (
     <button

--- a/electron/src/renderer/utils/notify.ts
+++ b/electron/src/renderer/utils/notify.ts
@@ -1,0 +1,3 @@
+export type NotifySeverity = 'info' | 'warning' | 'error';
+
+export type Notify = (message: string, severity?: NotifySeverity) => void;

--- a/electron/tests/integration/provider-onboarding.test.ts
+++ b/electron/tests/integration/provider-onboarding.test.ts
@@ -222,6 +222,27 @@ describe('provider onboarding and disconnected UX', () => {
     expect(wizard).toContain('title="Authentication"');
   });
 
+  it('keeps connection cards compact and sends lifecycle feedback to the settings surface', () => {
+    const connections = source('components', 'Providers', 'ConnectionList.tsx');
+    const providersTab = source('components', 'Preferences', 'ProvidersTab.tsx');
+
+    expect(connections).not.toContain('Each connection is a separate provider account or endpoint.');
+    expect(connections).not.toContain('New turns are disabled. A turn that already started can finish safely.');
+    expect(connections).not.toContain('{message && (');
+    expect(connections).not.toContain('{error && (');
+    expect(connections).toContain('onNotify');
+    expect(connections).toContain('className="h-full"');
+    expect(connections).toContain('mt-auto flex flex-wrap');
+    expect(connections).toContain('model.displayName');
+    expect(connections).toContain('definition?.models');
+    expect(providersTab).toContain('onNotify');
+    expect(providersTab).toContain("'info'");
+    expect(providersTab).not.toContain('statusMessage');
+    expect(providersTab).not.toContain('statusTimer');
+    expect(providersTab).toContain('result.message');
+    expect(source('AppReady.tsx')).toContain('onNotify={notify}');
+  });
+
   it('matches the provider wizard shell and edits explicit input/output capabilities', () => {
     const modelEditor = source('components', 'Providers', 'ConnectionModelsDialog.tsx');
     const wizard = source('components', 'Providers', 'ConnectionWizard.tsx');

--- a/electron/tests/unit/renderer-ui-primitives.test.ts
+++ b/electron/tests/unit/renderer-ui-primitives.test.ts
@@ -50,6 +50,14 @@ describe('IconButton', () => {
     expect(html).not.toContain('btn-circle');
   });
 
+  it('supports square icon-only controls without feature-level button classes', () => {
+    const html = markup(
+      createElement(IconButton, { label: 'Edit connection', icon: 'edit', shape: 'square' }),
+    );
+    expect(html).toContain('btn-square');
+    expect(html).not.toContain('btn-circle');
+  });
+
   it('disables and marks busy while loading', () => {
     const html = markup(
       createElement(IconButton, { label: 'Refresh', icon: 'refresh', loading: true }),


### PR DESCRIPTION
Move provider lifecycle notifications to the app-level toast surface and compact connection cards so settings actions remain visible and consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized toast notifications for chat, configuration, and provider connection actions.
  * Notifications support informational, warning, and error messages and dismiss automatically.
  * Provider connection cards now show model names and status details in a more compact layout.
  * Added configurable icon button shapes, including square and circular styles.

* **Bug Fixes**
  * Improved feedback for successful and failed provider connection updates.
  * Improved alignment of delete icons and consistency of connection card controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->