### PR TITLE
fix(agents): hydrate stored subagents on session open

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - Interface may prevent some changes while streaming (Such as model and reasoning level) but the command pallete still allows to execute
 - Interrupted subagents are being marked as complete - possibly after starting a new chain it is not preserved? - but only on some places (subagent view is correct, main agent context and main chat/session UI appears to not be)
 - replace_symbol can left trailing remnants
-- crashed / closed app can make the agent lose context (Subagents - on the interface they still appear, for the main againt they do not - IDs not found)
 
 ## Agent quality
 

--- a/electron/src/main/ipc/session.ts
+++ b/electron/src/main/ipc/session.ts
@@ -213,6 +213,26 @@ function emitWorkspaceChanged(
   sender.send(IPC_CHANNELS.SESSION_WORKSPACE_CHANGED, { workspace });
 }
 
+/**
+ * Materialize a session's persisted subagent chains back into the runtime
+ * manager so the main agent regains its subagent context after an app restart
+ * (records live only in memory for the current launch). No-op when the records
+ * are already live or the project runtime is unresolvable. Session open must
+ * not fail because hydration could not run, so errors are contained.
+ */
+async function hydrateOpenedSessionSubagents(
+  sessionId: string,
+  windowId: string,
+): Promise<void> {
+  try {
+    const { getSubagentManager } = await import('../tools/index.js');
+    const { hydrateSessionSubagents } = await import('../tools/subagent/hydrate.js');
+    await hydrateSessionSubagents(getSubagentManager(), sessionId, { windowId });
+  } catch (error) {
+    console.warn(`[subagents] session-open hydration failed for ${sessionId}:`, error);
+  }
+}
+
 // ── IPC registration ─────────────────────────────────────────────────────────
 
 export function registerSessionIPC(): void {
@@ -250,6 +270,9 @@ export function registerSessionIPC(): void {
       // Hydrate the in-memory permission gate map from the persisted session
       // record so the override survives restarts.
       hydrateSessionPermissionOverride(session.id, session.permissionMode);
+      // Restore the runtime subagent records (prompt context + wait/interrupt)
+      // after a restart; the renderer already renders the stored rows.
+      await hydrateOpenedSessionSubagents(session.id, windowId);
     } else {
       // Drop ghost tabs when the session cannot be loaded (missing/corrupt).
       workingSetRemove(id, windowId);
@@ -301,6 +324,9 @@ export function registerSessionIPC(): void {
     if (session) {
       workingSetOpenOrFocus(session.id, windowId);
       hydrateSessionPermissionOverride(session.id, session.permissionMode);
+      // Restore the runtime subagent records (prompt context + wait/interrupt)
+      // after a restart; the renderer already renders the stored rows.
+      await hydrateOpenedSessionSubagents(session.id, windowId);
     } else {
       // Drop ghost tabs when the session cannot be loaded (missing/corrupt).
       workingSetRemove(id, windowId);

--- a/electron/src/main/tools/subagent/hydrate.ts
+++ b/electron/src/main/tools/subagent/hydrate.ts
@@ -1,5 +1,6 @@
 /**
- * Tool-side hydration helper for the close/follow-up subagent tools (U3).
+ * Hydration helpers for the close/follow-up subagent tools (U3) and for
+ * session open (R9).
  *
  * Records whose full form lives only in `session.subagentChains` — evicted lean
  * summaries and everything persisted before the current app launch — are
@@ -12,6 +13,7 @@
 import type { Agent } from '../../../shared/types/agent';
 import type { SubagentRecord as DomainSubagentRecord } from '../../../shared/types/subagent';
 import type { HydrateSpec, SubagentManager } from '../../agents/manager';
+import type { ProjectRuntime } from '../../project/runtime';
 import type { ToolExecutionContext } from '../types';
 
 export interface HydrateSubagentRecordsResult {
@@ -19,6 +21,13 @@ export interface HydrateSubagentRecordsResult {
   hydrated: string[];
   /** Ids whose stored agent definition is no longer in the project registry. */
   agentMissing: string[];
+}
+
+/** Runtime resolution inputs shared by the tool and session-open paths. */
+export interface HydrateSubagentDeps {
+  projectRuntime?: ProjectRuntime | null;
+  windowId?: string | null;
+  cwd?: string | null;
 }
 
 /**
@@ -31,11 +40,11 @@ export interface HydrateSubagentRecordsResult {
  * reported in `agentMissing` and not hydrated (synthesizing a permissive
  * fallback agent would grant tools the original definition may not have allowed).
  */
-export async function hydrateSubagentRecords(
+async function hydrateStoredRecords(
   manager: SubagentManager,
   sessionId: string,
   ids: string[],
-  ctx: ToolExecutionContext,
+  deps: HydrateSubagentDeps,
 ): Promise<HydrateSubagentRecordsResult> {
   const hydrated: string[] = [];
   const agentMissing: string[] = [];
@@ -64,7 +73,7 @@ export async function hydrateSubagentRecords(
     storedById.set(record.id, record);
   }
 
-  const agents: ReadonlyMap<string, Agent> = ctx.projectRuntime?.agents ?? new Map();
+  const agents: ReadonlyMap<string, Agent> = deps.projectRuntime?.agents ?? new Map();
   const specs: HydrateSpec[] = [];
   for (const id of needsHydration) {
     const domain = storedById.get(id);
@@ -79,9 +88,9 @@ export async function hydrateSubagentRecords(
       agent,
       domain,
       sessionId,
-      windowId: ctx.windowId ?? null,
-      cwd: session.cwd ?? ctx.cwd ?? null,
-      projectRuntime: ctx.projectRuntime,
+      windowId: deps.windowId ?? null,
+      cwd: session.cwd ?? deps.cwd ?? null,
+      projectRuntime: deps.projectRuntime ?? undefined,
     });
   }
 
@@ -96,4 +105,69 @@ export async function hydrateSubagentRecords(
   }
 
   return { hydrated, agentMissing };
+}
+
+/**
+ * Tool-path entry: hydrate the given ids from durable storage, resolving the
+ * project definitions from the frozen per-turn runtime.
+ */
+export async function hydrateSubagentRecords(
+  manager: SubagentManager,
+  sessionId: string,
+  ids: string[],
+  ctx: ToolExecutionContext,
+): Promise<HydrateSubagentRecordsResult> {
+  return hydrateStoredRecords(manager, sessionId, ids, {
+    projectRuntime: ctx.projectRuntime,
+    windowId: ctx.windowId,
+    cwd: ctx.cwd,
+  });
+}
+
+/**
+ * Session-open entry: materialize every stored subagent chain of one session
+ * back into the runtime manager, so the main agent regains its subagent context
+ * after an app restart. The UI already renders stored rows; the dynamic system
+ * prompt and the wait/interrupt/answer tools only see the manager, which starts
+ * empty each launch.
+ *
+ * Idempotent: live full records win and are never replaced, so repeated opens
+ * are no-ops. Records whose stored `agent_type` no longer resolves are left in
+ * storage (the tool path reports them as `agentMissing`). When the project
+ * runtime cannot be resolved (directory deleted/moved, runtime load failure)
+ * hydration is skipped entirely — the session is unusable without it.
+ */
+export async function hydrateSessionSubagents(
+  manager: SubagentManager,
+  sessionId: string,
+  deps: HydrateSubagentDeps = {},
+): Promise<HydrateSubagentRecordsResult> {
+  const { getSessionManager } = await import('../../session/singleton.js');
+  const session = getSessionManager().getSession(sessionId);
+  if (!session || session.subagentChains.length === 0) {
+    return { hydrated: [], agentMissing: [] };
+  }
+
+  let projectRuntime: ProjectRuntime | null = deps.projectRuntime ?? null;
+  const cwd = session.cwd ?? deps.cwd ?? null;
+  if (!projectRuntime && cwd) {
+    try {
+      const { getProjectRuntimeRegistry } = await import('../../project/runtime.js');
+      projectRuntime = getProjectRuntimeRegistry().get(cwd);
+    } catch {
+      // Project directory deleted/moved or runtime load failed; leave the
+      // records stored and visible in the UI.
+      projectRuntime = null;
+    }
+  }
+  if (!projectRuntime) {
+    return { hydrated: [], agentMissing: [] };
+  }
+
+  return hydrateStoredRecords(
+    manager,
+    sessionId,
+    session.subagentChains.map((record) => record.id),
+    { projectRuntime, windowId: deps.windowId, cwd },
+  );
 }

--- a/electron/tests/unit/subagent-tools.test.ts
+++ b/electron/tests/unit/subagent-tools.test.ts
@@ -25,7 +25,7 @@ import {
   subagentRecordToStorageDict,
 } from '../../src/shared/serialization/chain-subagent';
 import { persistSubagentChains } from '../../src/main/agents/persist-subagent-chains';
-import { hydrateSubagentRecords } from '../../src/main/tools/subagent/hydrate';
+import { hydrateSubagentRecords, hydrateSessionSubagents } from '../../src/main/tools/subagent/hydrate';
 import { recoverSubagentPersistence } from '../../src/main/agents/subagent-persistence-recovery';
 import type { StreamEvent } from '../../src/main/llm/orchestrator';
 import { buildDelegateTool as buildDelegateToolRaw } from '../../src/main/tools/subagent/delegate';
@@ -1455,6 +1455,139 @@ describe('hydrateSubagentRecords helper', () => {
     expect(writesAfter).toBe(writesBefore + 1);
   });
 
+});
+
+// ── hydrateSessionSubagents (R9 session-open) ────────────────────────────────
+
+describe('hydrateSessionSubagents', () => {
+  let manager: SubagentManager;
+  const sid = 'sess-session-open-hydrate';
+
+  beforeEach(() => {
+    manager = new SubagentManager();
+    sessionManagerHolder.current = null;
+  });
+
+  afterEach(() => {
+    sessionManagerHolder.current = null;
+  });
+
+  function makeSessionRuntime(agents: Map<string, Agent>) {
+    return {
+      projectDir: '/tmp',
+      config: defaults(),
+      agents,
+      skills: new Map(),
+      personalities: new Map(),
+    };
+  }
+
+  /** Build a durable domain record (in a side manager) for the helper to load. */
+  function storedRecord(label: string, agent: Agent) {
+    const source = new SubagentManager();
+    const original = source.spawn(label, 'task text', agent, { sessionId: sid });
+    source.markCompleted(original.id, 'stored result');
+    return {
+      id: original.id,
+      domain: subagentRecordFromStorageDict(subagentRecordToStorageDict(runtimeToDomain(original))),
+    };
+  }
+
+  function setSession(subagentChains: unknown[], opts: { cwd?: string | null } = {}) {
+    const session = { id: sid, cwd: opts.cwd ?? '/tmp/session', subagentChains };
+    sessionManagerHolder.current = {
+      getSession: (id: string) => (id === sid ? session : null),
+      getActive: () => null,
+    };
+    return session;
+  }
+
+  it('hydrates every stored record of the session (app-restart case)', async () => {
+    const agents = makeAgentMap();
+    const a = storedRecord('persisted-a', codeReviewerAgent);
+    const b = storedRecord('persisted-b', fileExplorerAgent);
+    setSession([a.domain, b.domain]);
+    expect(manager.getRecord(a.id)).toBeUndefined();
+    expect(manager.getRecord(b.id)).toBeUndefined();
+
+    const result = await hydrateSessionSubagents(manager, sid, {
+      projectRuntime: makeSessionRuntime(agents),
+    });
+
+    expect(result).toEqual({ hydrated: [a.id, b.id], agentMissing: [] });
+    const restored = manager.getRecord(a.id)!;
+    expect(restored.result).toBe('stored result');
+    expect(restored.state).toBe(SubagentState.COMPLETED);
+    expect(manager.isSummary(restored.id)).toBe(false);
+    expect(manager.getRecord(b.id)?.label).toBe('persisted-b');
+  });
+
+  it('is idempotent — live full records win and are never replaced', async () => {
+    const agents = makeAgentMap();
+    const { id, domain } = storedRecord('dup', codeReviewerAgent);
+    setSession([domain]);
+
+    await hydrateSessionSubagents(manager, sid, { projectRuntime: makeSessionRuntime(agents) });
+    expect(manager.getRecord(id)).toBeDefined();
+
+    // The live record is mutated after hydration; a re-open must keep it.
+    manager.close(id);
+    const before = manager.getRecord(id)!;
+    expect(before.closed).toBe(true);
+
+    const second = await hydrateSessionSubagents(manager, sid, {
+      projectRuntime: makeSessionRuntime(agents),
+    });
+
+    expect(second).toEqual({ hydrated: [], agentMissing: [] });
+    expect(manager.getRecord(id)!.closed).toBe(true);
+  });
+
+  it('returns empty when the session has no stored subagent chains', async () => {
+    setSession([]);
+
+    const result = await hydrateSessionSubagents(manager, sid, {
+      projectRuntime: makeSessionRuntime(makeAgentMap()),
+    });
+
+    expect(result).toEqual({ hydrated: [], agentMissing: [] });
+  });
+
+  it('skips hydration when the project runtime cannot be resolved', async () => {
+    const { id, domain } = storedRecord('orphan', codeReviewerAgent);
+    setSession([domain], { cwd: '/definitely/not/a/project' });
+
+    const result = await hydrateSessionSubagents(manager, sid);
+
+    expect(result).toEqual({ hydrated: [], agentMissing: [] });
+    expect(manager.getRecord(id)).toBeUndefined();
+  });
+
+  it('reports agentMissing for stored records whose agent definition is gone', async () => {
+    // Registry WITHOUT code-reviewer, which the stored record references.
+    const agents = new Map<string, Agent>();
+    agents.set(fileExplorerAgent.name, fileExplorerAgent);
+    const { id, domain } = storedRecord('orphan', codeReviewerAgent);
+    setSession([domain]);
+
+    const result = await hydrateSessionSubagents(manager, sid, {
+      projectRuntime: makeSessionRuntime(agents),
+    });
+
+    expect(result).toEqual({ hydrated: [], agentMissing: [id] });
+    expect(manager.getRecord(id)).toBeUndefined();
+  });
+
+  it('returns empty when the session is not found', async () => {
+    sessionManagerHolder.current = {
+      getSession: () => null,
+      getActive: () => null,
+    };
+
+    const result = await hydrateSessionSubagents(manager, sid);
+
+    expect(result).toEqual({ hydrated: [], agentMissing: [] });
+  });
 });
 
 // ── follow_up_subagent (U6) ──────────────────────────────────────────────────


### PR DESCRIPTION
SubagentManager is in-memory only and starts empty each launch, so after a crash/close the main agent lost its subagent context: the UI still rendered stored rows but wait/interrupt/answer reported IDs not found and the dynamic prompt's <subagents> section was empty.

Materialize a session's persisted subagent chains back into the manager when the session is opened (SESSION_OPEN and SESSION_LOAD with activate), reusing the existing tool-side hydration core (hydrateStoredRecords) via a new hydrateSessionSubagents entry. Idempotent — live full records win; skipped when the project runtime is unresolvable; errors contained so session open never fails.