### PR TITLE
feat(providers): merge pricing overrides into the model editor and re…

### DIFF
--- a/electron/assets/providers/catalog.json
+++ b/electron/assets/providers/catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "catalogVersion": 1,
-  "issuedAt": "2026-07-13T22:49:29.519Z",
+  "catalogVersion": 2,
+  "issuedAt": "2026-08-12T23:25:21.000Z",
   "expiresAt": "2027-01-01T00:00:00.000Z",
   "compatibleApp": {
     "minimum": "0.1.0"
@@ -9,8 +9,8 @@
   "provenance": {
     "source": "models.dev",
     "sourceUrl": "https://models.dev/api.json",
-    "capturedAt": "2026-07-13T22:49:29.519Z",
-    "contentHash": "sha256:e79e3f1b9f62a01d9f74f785aa749caf5e712b74d406bc117bb8136b027dd9e4"
+    "capturedAt": "2026-08-12T23:25:21.000Z",
+    "contentHash": "sha256:aeb0ae23586f2b6dbc874747e42246539a8b6c36d2b9fe21ddce065a75ae514d"
   },
   "providers": [
     {
@@ -27,7 +27,7 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
         {
@@ -48,10 +48,10 @@
             "contextTokens": 16385,
             "outputTokens": 4096
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.5",
@@ -71,12 +71,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -97,10 +97,10 @@
             "contextTokens": 8192,
             "outputTokens": 8192
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "30",
@@ -115,12 +115,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -142,10 +142,10 @@
             "contextTokens": 128000,
             "outputTokens": 4096
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "10",
@@ -160,12 +160,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -191,7 +191,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2",
@@ -211,12 +211,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -242,7 +242,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.4",
@@ -262,12 +262,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -289,10 +289,10 @@
             "contextTokens": 1047576,
             "outputTokens": 32768
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.1",
@@ -312,12 +312,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -343,7 +343,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2.5",
@@ -363,12 +363,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -390,10 +390,10 @@
             "contextTokens": 128000,
             "outputTokens": 4096
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -408,12 +408,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -438,7 +438,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2.5",
@@ -458,12 +458,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -488,7 +488,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2.5",
@@ -508,12 +508,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -539,7 +539,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.15",
@@ -559,12 +559,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -582,6 +582,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -589,7 +596,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -609,112 +616,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gpt-5-chat-latest",
-          "displayName": "GPT-5 Chat (latest)",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": false,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 400000,
-            "outputTokens": 128000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "1.25",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "10",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.125",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gpt-5-codex",
-          "displayName": "GPT-5-Codex",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 400000,
-            "outputTokens": 128000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "1.25",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "10",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.125",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -732,6 +639,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -739,7 +653,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.25",
@@ -759,12 +673,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -782,6 +696,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -789,7 +710,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.05",
@@ -809,12 +730,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -832,6 +753,10 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "high"
+          ],
+          "reasoningDefault": "high",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 272000
@@ -839,7 +764,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "15",
@@ -854,12 +779,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -877,6 +802,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -884,7 +816,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -904,212 +836,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gpt-5.1-chat-latest",
-          "displayName": "GPT-5.1 Chat",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 128000,
-            "outputTokens": 16384
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "1.25",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "10",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.125",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gpt-5.1-codex",
-          "displayName": "GPT-5.1 Codex",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 400000,
-            "outputTokens": 128000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "1.25",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "10",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.125",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gpt-5.1-codex-max",
-          "displayName": "GPT-5.1 Codex Max",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 400000,
-            "outputTokens": 128000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "1.25",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "10",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.125",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gpt-5.1-codex-mini",
-          "displayName": "GPT-5.1 Codex mini",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 400000,
-            "outputTokens": 128000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "0.25",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "2",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.025",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1127,6 +859,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -1134,7 +874,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.75",
@@ -1154,12 +894,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1177,6 +917,10 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "medium"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 128000,
             "outputTokens": 16384
@@ -1184,7 +928,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.75",
@@ -1204,63 +948,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gpt-5.2-codex",
-          "displayName": "GPT-5.2 Codex",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 400000,
-            "outputTokens": 128000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "1.75",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "14",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.175",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1278,6 +971,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -1285,7 +984,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "21",
@@ -1300,12 +999,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1330,7 +1029,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.75",
@@ -1350,12 +1049,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1374,6 +1073,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -1381,7 +1088,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.75",
@@ -1401,12 +1108,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1425,6 +1132,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 128000,
             "outputTokens": 32000
@@ -1432,7 +1147,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.75",
@@ -1452,12 +1167,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1476,6 +1191,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1483,7 +1206,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2.5",
@@ -1503,12 +1226,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1526,6 +1249,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -1533,7 +1264,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.75",
@@ -1553,12 +1284,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1576,6 +1307,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 400000,
             "outputTokens": 128000
@@ -1583,7 +1322,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.2",
@@ -1603,12 +1342,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1626,6 +1365,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1633,7 +1378,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "30",
@@ -1648,12 +1393,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1672,6 +1417,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1679,7 +1432,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -1699,12 +1452,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1723,6 +1476,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1730,7 +1489,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "30",
@@ -1745,12 +1504,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1769,6 +1528,15 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1776,7 +1544,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -1801,12 +1569,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1825,6 +1593,15 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1832,37 +1609,37 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
-                "amount": "1",
+                "amount": "0.2",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "output": {
-                "amount": "6",
+                "amount": "1.2",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "cacheRead": {
-                "amount": "0.1",
+                "amount": "0.02",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "cacheWrite": {
-                "amount": "1.25",
+                "amount": "0.25",
                 "per": 1000000,
                 "unit": "tokens"
               }
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1881,6 +1658,15 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1888,7 +1674,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -1913,12 +1699,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1937,6 +1723,15 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1050000,
             "outputTokens": 128000
@@ -1944,37 +1739,37 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
-                "amount": "2.5",
+                "amount": "2",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "output": {
-                "amount": "15",
+                "amount": "12",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "cacheRead": {
-                "amount": "0.25",
+                "amount": "0.2",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "cacheWrite": {
-                "amount": "3.125",
+                "amount": "2.5",
                 "per": 1000000,
                 "unit": "tokens"
               }
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -1993,14 +1788,20 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 100000
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "15",
@@ -2020,12 +1821,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2043,14 +1844,20 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 100000
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "150",
@@ -2065,12 +1872,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2089,6 +1896,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 100000
@@ -2096,7 +1909,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2",
@@ -2116,62 +1929,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "o3-deep-research",
-          "displayName": "o3-deep-research",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 200000,
-            "outputTokens": 100000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "10",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "40",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "2.5",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2188,14 +1951,20 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 100000
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.1",
@@ -2215,12 +1984,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2238,6 +2007,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 100000
@@ -2245,7 +2020,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "20",
@@ -2260,12 +2035,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2283,14 +2058,20 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 100000
           },
-          "lifecycle": "active",
+          "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.1",
@@ -2310,62 +2091,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "o4-mini-deep-research",
-          "displayName": "o4-mini-deep-research",
-          "protocol": "openai-compatible",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 200000,
-            "outputTokens": 100000
-          },
-          "lifecycle": "active",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "2",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "8",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.5",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2377,7 +2108,7 @@
               "text"
             ],
             "outputModalities": [
-              "embedding"
+              "text"
             ],
             "tools": false,
             "reasoning": false
@@ -2389,7 +2120,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.13",
@@ -2404,12 +2135,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2421,7 +2152,7 @@
               "text"
             ],
             "outputModalities": [
-              "embedding"
+              "text"
             ],
             "tools": false,
             "reasoning": false
@@ -2433,7 +2164,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.02",
@@ -2448,12 +2179,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2465,7 +2196,7 @@
               "text"
             ],
             "outputModalities": [
-              "embedding"
+              "text"
             ],
             "tools": false,
             "reasoning": false
@@ -2477,7 +2208,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.1",
@@ -2492,12 +2223,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -2516,7 +2247,7 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
         {
@@ -2535,6 +2266,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 128000
@@ -2542,7 +2281,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "10",
@@ -2567,12 +2306,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2598,7 +2337,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1",
@@ -2623,12 +2362,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2654,7 +2393,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1",
@@ -2679,124 +2418,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "claude-opus-4-1",
-          "displayName": "Claude Opus 4.1 (latest)",
-          "protocol": "anthropic-messages",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 200000,
-            "outputTokens": 32000
-          },
-          "lifecycle": "deprecated",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "15",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "75",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "1.5",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheWrite": {
-                "amount": "18.75",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "claude-opus-4-1-20250805",
-          "displayName": "Claude Opus 4.1",
-          "protocol": "anthropic-messages",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image",
-              "pdf"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 200000,
-            "outputTokens": 32000
-          },
-          "lifecycle": "deprecated",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "15",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "75",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "1.5",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheWrite": {
-                "amount": "18.75",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2815,6 +2442,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 64000
@@ -2822,7 +2455,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -2847,12 +2480,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2871,6 +2504,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 200000,
             "outputTokens": 64000
@@ -2878,7 +2517,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -2903,12 +2542,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2927,6 +2566,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 128000
@@ -2934,7 +2580,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -2959,12 +2605,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -2983,6 +2629,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 128000
@@ -2990,7 +2644,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -3015,12 +2669,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3039,6 +2693,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 128000
@@ -3046,7 +2708,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "5",
@@ -3071,12 +2733,76 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "claude-opus-5",
+          "displayName": "Claude Opus 5",
+          "protocol": "anthropic-messages",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
+          "limits": {
+            "contextTokens": 1000000,
+            "outputTokens": 128000
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "5",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "25",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.5",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheWrite": {
+                "amount": "6.25",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3102,7 +2828,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "3",
@@ -3127,12 +2853,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3158,7 +2884,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "3",
@@ -3183,12 +2909,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3207,6 +2933,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 128000
@@ -3214,7 +2947,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "3",
@@ -3239,12 +2972,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3263,6 +2996,14 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 128000
@@ -3270,7 +3011,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2",
@@ -3295,12 +3036,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -3319,108 +3060,52 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
         {
-          "id": "gemini-2.0-flash",
-          "displayName": "Gemini 2.0 Flash",
+          "id": "gemini-2.5-computer-use-preview-10-2025",
+          "displayName": "Gemini 2.5 Computer Use Preview 10-2025",
           "protocol": "google-generative-ai",
           "capabilities": {
             "inputModalities": [
               "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
+              "image"
             ],
             "outputModalities": [
               "text"
             ],
             "tools": true,
-            "reasoning": false
+            "reasoning": true
           },
           "limits": {
-            "contextTokens": 1048576,
-            "outputTokens": 8192
+            "contextTokens": 131072,
+            "outputTokens": 65536
           },
-          "lifecycle": "deprecated",
+          "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
-                "amount": "0.1",
+                "amount": "1.25",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "output": {
-                "amount": "0.4",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.025",
+                "amount": "10",
                 "per": 1000000,
                 "unit": "tokens"
               }
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gemini-2.0-flash-lite",
-          "displayName": "Gemini 2.0 Flash-Lite",
-          "protocol": "google-generative-ai",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image",
-              "audio",
-              "video",
-              "pdf"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": false
-          },
-          "limits": {
-            "contextTokens": 1048576,
-            "outputTokens": 8192
-          },
-          "lifecycle": "deprecated",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "0.075",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "0.3",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3448,7 +3133,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.3",
@@ -3468,12 +3153,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3501,7 +3186,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.1",
@@ -3521,12 +3206,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3554,7 +3239,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -3574,12 +3259,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3600,6 +3285,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -3607,7 +3299,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.5",
@@ -3627,65 +3319,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
-          }
-        },
-        {
-          "id": "gemini-3-pro-preview",
-          "displayName": "Gemini 3 Pro Preview",
-          "protocol": "google-generative-ai",
-          "capabilities": {
-            "inputModalities": [
-              "text",
-              "image",
-              "video",
-              "audio",
-              "pdf"
-            ],
-            "outputModalities": [
-              "text"
-            ],
-            "tools": true,
-            "reasoning": true
-          },
-          "limits": {
-            "contextTokens": 1048576,
-            "outputTokens": 65536
-          },
-          "lifecycle": "deprecated",
-          "pricing": {
-            "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
-            "rates": {
-              "input": {
-                "amount": "2",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "output": {
-                "amount": "12",
-                "per": 1000000,
-                "unit": "tokens"
-              },
-              "cacheRead": {
-                "amount": "0.2",
-                "per": 1000000,
-                "unit": "tokens"
-              }
-            },
-            "provenance": {
-              "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
-            }
-          },
-          "provenance": {
-            "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3706,6 +3345,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -3713,7 +3359,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.25",
@@ -3733,12 +3379,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3759,6 +3405,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -3766,7 +3419,7 @@
           "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.25",
@@ -3786,12 +3439,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3812,6 +3465,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -3819,7 +3478,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2",
@@ -3839,12 +3498,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3865,6 +3524,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -3872,7 +3537,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2",
@@ -3892,12 +3557,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3918,6 +3583,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -3925,7 +3597,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.5",
@@ -3945,12 +3617,132 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "gemini-3.5-flash-lite",
+          "displayName": "Gemini 3.5 Flash Lite",
+          "protocol": "google-generative-ai",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
+          "limits": {
+            "contextTokens": 1048576,
+            "outputTokens": 65536
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "0.3",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "2.5",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.03",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "gemini-3.6-flash",
+          "displayName": "Gemini 3.6 Flash",
+          "protocol": "google-generative-ai",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "video",
+              "audio",
+              "pdf"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
+          "limits": {
+            "contextTokens": 1048576,
+            "outputTokens": 65536
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "1.5",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "7.5",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.15",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -3962,7 +3754,7 @@
               "text"
             ],
             "outputModalities": [
-              "embedding"
+              "text"
             ],
             "tools": false,
             "reasoning": false
@@ -3974,7 +3766,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.15",
@@ -3989,12 +3781,60 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "gemini-embedding-2",
+          "displayName": "Gemini Embedding 2",
+          "protocol": "google-generative-ai",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": false,
+            "reasoning": false
+          },
+          "limits": {
+            "contextTokens": 8192,
+            "outputTokens": 1
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "0.2",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "0",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4005,8 +3845,8 @@
             "inputModalities": [
               "text",
               "image",
-              "audio",
               "video",
+              "audio",
               "pdf"
             ],
             "outputModalities": [
@@ -4015,6 +3855,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -4022,32 +3869,32 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
-                "amount": "0.3",
+                "amount": "1.5",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "output": {
-                "amount": "2.5",
+                "amount": "9",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "cacheRead": {
-                "amount": "0.075",
+                "amount": "0.15",
                 "per": 1000000,
                 "unit": "tokens"
               }
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4058,8 +3905,8 @@
             "inputModalities": [
               "text",
               "image",
-              "audio",
               "video",
+              "audio",
               "pdf"
             ],
             "outputModalities": [
@@ -4068,6 +3915,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048576,
             "outputTokens": 65536
@@ -4075,15 +3929,15 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
-                "amount": "0.1",
+                "amount": "0.25",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "output": {
-                "amount": "0.4",
+                "amount": "1.5",
                 "per": 1000000,
                 "unit": "tokens"
               },
@@ -4095,12 +3949,59 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "gemini-robotics-er-1.6-preview",
+          "displayName": "Gemini Robotics-ER 1.6 Preview",
+          "protocol": "google-generative-ai",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "video",
+              "audio"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "limits": {
+            "contextTokens": 131072,
+            "outputTokens": 65536
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "1",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "5",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4125,16 +4026,16 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {},
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4159,16 +4060,16 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {},
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -4187,7 +4088,7 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
         {
@@ -4213,7 +4114,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -4233,12 +4134,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4264,7 +4165,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -4284,12 +4185,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4308,6 +4209,13 @@
             "tools": false,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 30000
@@ -4315,7 +4223,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -4335,12 +4243,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4359,6 +4267,13 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 30000
@@ -4366,7 +4281,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -4386,12 +4301,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4410,6 +4325,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 500000,
             "outputTokens": 500000
@@ -4417,7 +4338,65 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "2",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "6",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.3",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "grok-4.6",
+          "displayName": "Grok 4.6",
+          "protocol": "xai",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoningDefault": "medium",
+          "limits": {
+            "contextTokens": 500000,
+            "outputTokens": 500000
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2",
@@ -4437,12 +4416,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4468,7 +4447,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1",
@@ -4488,12 +4467,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -4512,12 +4491,12 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
         {
           "id": "deepseek-v4-flash",
-          "displayName": "DeepSeek V4 Flash",
+          "displayName": "DeepSeek V4 Flash (2x usage)",
           "protocol": "openai-compatible",
           "capabilities": {
             "inputModalities": [
@@ -4529,6 +4508,12 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "low",
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "high",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 384000
@@ -4536,37 +4521,37 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
+                "amount": "0.07",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
                 "amount": "0.14",
                 "per": 1000000,
                 "unit": "tokens"
               },
-              "output": {
-                "amount": "0.28",
-                "per": 1000000,
-                "unit": "tokens"
-              },
               "cacheRead": {
-                "amount": "0.0028",
+                "amount": "0.0014",
                 "per": 1000000,
                 "unit": "tokens"
               }
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
           "id": "deepseek-v4-pro",
-          "displayName": "DeepSeek V4 Pro",
+          "displayName": "DeepSeek V4 Pro (New)",
           "protocol": "openai-compatible",
           "capabilities": {
             "inputModalities": [
@@ -4578,6 +4563,11 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "max",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 384000
@@ -4585,32 +4575,32 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
-                "amount": "1.74",
+                "amount": "0.435",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "output": {
-                "amount": "3.48",
+                "amount": "0.87",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "cacheRead": {
-                "amount": "0.0145",
+                "amount": "0.003625",
                 "per": 1000000,
                 "unit": "tokens"
               }
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4634,7 +4624,7 @@
           "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1",
@@ -4654,12 +4644,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4683,7 +4673,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.4",
@@ -4703,12 +4693,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4725,6 +4715,11 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "max",
           "limits": {
             "contextTokens": 1000000,
             "outputTokens": 131072
@@ -4732,7 +4727,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.4",
@@ -4752,12 +4747,188 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "gpt-5.6-luna",
+          "displayName": "GPT-5.6 Luna (2x usage)",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
+          "limits": {
+            "contextTokens": 1050000,
+            "outputTokens": 128000
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "0.1",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "0.6",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.01",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheWrite": {
+                "amount": "0.125",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "grok-4.5",
+          "displayName": "Grok 4.5",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "reasoningDefault": "medium",
+          "limits": {
+            "contextTokens": 500000,
+            "outputTokens": 500000
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "2",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "6",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.5",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "hy3",
+          "displayName": "Hy3",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "none",
+            "low",
+            "high"
+          ],
+          "reasoningDefault": "low",
+          "limits": {
+            "contextTokens": 256000,
+            "outputTokens": 64000
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "0.14",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "0.58",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.035",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4783,7 +4954,7 @@
           "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.6",
@@ -4803,12 +4974,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4834,7 +5005,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.95",
@@ -4854,12 +5025,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4885,7 +5056,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.95",
@@ -4905,12 +5076,67 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "kimi-k3",
+          "displayName": "Kimi K3",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "video"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "max"
+          ],
+          "reasoningDefault": "max",
+          "limits": {
+            "contextTokens": 1048576,
+            "outputTokens": 131072
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "3",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "15",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.3",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4937,7 +5163,7 @@
           "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.4",
@@ -4957,12 +5183,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -4986,7 +5212,7 @@
           "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1",
@@ -5006,12 +5232,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5038,7 +5264,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.14",
@@ -5058,12 +5284,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5087,32 +5313,32 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
-                "amount": "1.74",
+                "amount": "0.435",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "output": {
-                "amount": "3.48",
+                "amount": "0.87",
                 "per": 1000000,
                 "unit": "tokens"
               },
               "cacheRead": {
-                "amount": "0.0145",
+                "amount": "0.003625",
                 "per": 1000000,
                 "unit": "tokens"
               }
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5136,7 +5362,7 @@
           "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.3",
@@ -5156,12 +5382,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5185,7 +5411,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.3",
@@ -5205,12 +5431,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5236,7 +5462,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.3",
@@ -5256,12 +5482,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5287,7 +5513,7 @@
           "lifecycle": "deprecated",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.2",
@@ -5312,12 +5538,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5343,7 +5569,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.5",
@@ -5368,12 +5594,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5397,7 +5623,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "2.5",
@@ -5422,12 +5648,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5453,7 +5679,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.4",
@@ -5478,12 +5704,68 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "qwen3.8-max",
+          "displayName": "Qwen3.8 Max",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image",
+              "video"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "limits": {
+            "contextTokens": 1000000,
+            "outputTokens": 131072
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "2",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "6",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.25",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheWrite": {
+                "amount": "2.5",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -5502,7 +5784,7 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
         {
@@ -5528,7 +5810,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.11",
@@ -5543,12 +5825,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5574,7 +5856,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.28",
@@ -5594,12 +5876,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5624,7 +5906,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.7",
@@ -5644,12 +5926,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5666,6 +5948,11 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "max",
           "limits": {
             "contextTokens": 524288,
             "outputTokens": 524288
@@ -5673,7 +5960,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.9",
@@ -5693,12 +5980,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -5717,9 +6004,113 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
+        {
+          "id": "deepseek-v4-flash",
+          "displayName": "DeepSeek V4 Flash",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "max",
+          "limits": {
+            "contextTokens": 1048560,
+            "outputTokens": 65536
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "0.104",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "0.207",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.026",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "gemma-4-31b",
+          "displayName": "Gemma 4 31B",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "limits": {
+            "contextTokens": 262128,
+            "outputTokens": 16384
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "0.144",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "0.42",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.036",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
         {
           "id": "glm-5.2",
           "displayName": "GLM 5.2",
@@ -5734,6 +6125,16 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048560,
             "outputTokens": 1048560
@@ -5741,7 +6142,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.45",
@@ -5761,12 +6162,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5790,7 +6191,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.45",
@@ -5810,12 +6211,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5832,6 +6233,16 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 1048560,
             "outputTokens": 1048560
@@ -5839,7 +6250,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.725",
@@ -5859,12 +6270,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5881,6 +6292,16 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 199984,
             "outputTokens": 199984
@@ -5888,7 +6309,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.45",
@@ -5908,12 +6329,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5937,7 +6358,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.45",
@@ -5957,12 +6378,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -5986,7 +6407,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.725",
@@ -6006,12 +6427,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6028,6 +6449,16 @@
             "tools": true,
             "reasoning": true
           },
+          "reasoningLevels": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoningDefault": "medium",
           "limits": {
             "contextTokens": 199984,
             "outputTokens": 199984
@@ -6035,7 +6466,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.725",
@@ -6055,12 +6486,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6085,7 +6516,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.52",
@@ -6105,12 +6536,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6135,7 +6566,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.69",
@@ -6155,12 +6586,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6185,7 +6616,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.345",
@@ -6205,12 +6636,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6235,7 +6666,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.475",
@@ -6255,12 +6686,118 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "kimi-k3",
+          "displayName": "Kimi K3",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": true
+          },
+          "reasoningLevels": [
+            "low",
+            "high",
+            "max"
+          ],
+          "reasoningDefault": "high",
+          "limits": {
+            "contextTokens": 1048560,
+            "outputTokens": 1048560
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "3",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "15",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.3",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
+          }
+        },
+        {
+          "id": "kimi-k3-fast",
+          "displayName": "Kimi K3 Fast",
+          "protocol": "openai-compatible",
+          "capabilities": {
+            "inputModalities": [
+              "text",
+              "image"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "tools": true,
+            "reasoning": false
+          },
+          "limits": {
+            "contextTokens": 1048560,
+            "outputTokens": 1048560
+          },
+          "lifecycle": "active",
+          "pricing": {
+            "currency": "USD",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
+            "rates": {
+              "input": {
+                "amount": "3",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "output": {
+                "amount": "15",
+                "per": 1000000,
+                "unit": "tokens"
+              },
+              "cacheRead": {
+                "amount": "0.3",
+                "per": 1000000,
+                "unit": "tokens"
+              }
+            },
+            "provenance": {
+              "source": "models.dev",
+              "observedAt": "2026-08-12T23:25:21.000Z"
+            }
+          },
+          "provenance": {
+            "source": "models.dev",
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6285,7 +6822,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.52",
@@ -6305,12 +6842,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6335,7 +6872,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.69",
@@ -6355,12 +6892,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6385,7 +6922,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.95",
@@ -6405,12 +6942,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6434,7 +6971,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.69",
@@ -6454,12 +6991,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6484,7 +7021,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.29",
@@ -6504,12 +7041,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6533,7 +7070,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.69",
@@ -6553,12 +7090,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6583,7 +7120,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-07-13T22:49:29.519Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.29",
@@ -6603,12 +7140,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-07-13T22:49:29.519Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-07-13T22:49:29.519Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -6627,7 +7164,7 @@
       "lifecycle": "active",
       "provenance": {
         "source": "models.dev",
-        "observedAt": "2026-08-12T03:40:23.755Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": [
         {
@@ -6662,7 +7199,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-08-12T03:40:23.755Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -6682,12 +7219,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-08-12T03:40:23.755Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-08-12T03:40:23.755Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6723,7 +7260,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-08-12T03:40:23.755Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "1.25",
@@ -6743,12 +7280,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-08-12T03:40:23.755Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-08-12T03:40:23.755Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         },
         {
@@ -6784,7 +7321,7 @@
           "lifecycle": "active",
           "pricing": {
             "currency": "USD",
-            "effectiveAt": "2026-08-12T03:40:23.755Z",
+            "effectiveAt": "2026-08-12T23:25:21.000Z",
             "rates": {
               "input": {
                 "amount": "0.1",
@@ -6804,12 +7341,12 @@
             },
             "provenance": {
               "source": "models.dev",
-              "observedAt": "2026-08-12T03:40:23.755Z"
+              "observedAt": "2026-08-12T23:25:21.000Z"
             }
           },
           "provenance": {
             "source": "models.dev",
-            "observedAt": "2026-08-12T03:40:23.755Z"
+            "observedAt": "2026-08-12T23:25:21.000Z"
           }
         }
       ]
@@ -6829,7 +7366,7 @@
       "lifecycle": "active",
       "provenance": {
         "source": "catalog",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": []
     },
@@ -6848,7 +7385,7 @@
       "lifecycle": "active",
       "provenance": {
         "source": "catalog",
-        "observedAt": "2026-07-13T22:49:29.519Z"
+        "observedAt": "2026-08-12T23:25:21.000Z"
       },
       "models": []
     }

--- a/electron/src/main/ipc/provider-models.ts
+++ b/electron/src/main/ipc/provider-models.ts
@@ -28,6 +28,7 @@ import {
   connectionIdSchema,
   connectionView,
   modelView,
+  pricingView,
   readApiKeyForTrustedStatus,
   requireConnection,
   runConnectionDiscovery,
@@ -57,11 +58,20 @@ async function modelOptions(
     throw new Error(`Unknown provider connection '${connectionId}'`);
   }
   const options: ProviderModelOption[] = [];
+  const catalogSnapshot = current.catalog.load();
+  const catalogPricingByProviderId = new Map<string, ReadonlyMap<string, import('../providers/catalog/schema').CatalogPricing>>();
+  for (const provider of catalogSnapshot.catalog.providers) {
+    catalogPricingByProviderId.set(
+      provider.id,
+      new Map(provider.models.map((model) => [model.id, model.pricing])),
+    );
+  }
   for (const connection of selectedConnections) {
     const definition = definitions.find((item) => item.id === connection.providerId);
     if (!definition) continue;
     const driver = current.registry.get(definition.id);
     const tierMechanism = driver?.tierMechanism;
+    const providerCatalogPricing = catalogPricingByProviderId.get(connection.providerId);
     const { rows, variantTiersByBase } = groupTierVariantRows(
       listConnectionModelRows(connection, definition),
       tierMechanism?.kind === 'model-name-variants' ? tierMechanism : undefined,
@@ -104,12 +114,19 @@ async function modelOptions(
           }
         : undefined;
       const pricingOverride = connection.pricingOverrides?.[row.model.id];
+      const catalogPricing = row.source === 'catalog'
+        ? providerCatalogPricing?.get(row.model.id)
+        : undefined;
       options.push({
         selection,
         connectionName: connection.name,
         providerId: connection.providerId,
         providerDisplayName: definition.displayName,
-        model: modelView(row.model, row.source),
+        model: modelView(
+          row.model,
+          row.source,
+          catalogPricing ? pricingView(catalogPricing) : undefined,
+        ),
         enabled: row.enabled,
         customized: row.customized,
         discoveredAt: row.discoveredAt,

--- a/electron/src/main/ipc/providers.ts
+++ b/electron/src/main/ipc/providers.ts
@@ -13,12 +13,14 @@ import type {
   ProviderDeleteConnectionResult,
   ProviderConnectionView,
   ProviderDefinitionView,
+  ProviderModelPricingView,
   ProviderModelView,
   ProviderMutationResult,
   ProviderOverview,
   ProviderStatusView,
 } from '../../shared/types/ipc';
 import { pricingRateFieldsSchema, providerQuotaSchema } from '../../shared/types/provider-facets';
+import type { CatalogPricing } from '../providers/catalog/schema';
 import {
   customConnectionModelSchema,
   environmentVariableSchema,
@@ -264,9 +266,23 @@ function unavailableProviderReason(
   return null;
 }
 
+/** Renderer-safe view of one signed-catalog rate card; provenance never leaves main. */
+export function pricingView(pricing: CatalogPricing): ProviderModelPricingView {
+  return {
+    currency: pricing.currency,
+    ...(pricing.currencyUnit ? { currencyUnit: pricing.currencyUnit } : {}),
+    effectiveAt: pricing.effectiveAt,
+    rates: pricing.rates,
+    ...(pricing.contextTiers && pricing.contextTiers.length > 0
+      ? { contextTiers: pricing.contextTiers }
+      : {}),
+  };
+}
+
 export function modelView(
   model: ProviderModelDefinition,
   source: 'catalog' | 'provider' | 'user',
+  pricing?: ProviderModelPricingView,
 ): ProviderModelView {
   return {
     id: model.id,
@@ -288,12 +304,14 @@ export function modelView(
           outputTokens: model.limits.outputTokens,
         }
       : null,
+    ...(pricing ? { pricing } : {}),
   };
 }
 
 function definitionView(
   definition: ProviderDefinition,
   registry: ProviderDriverRegistry,
+  pricingByModelId?: ReadonlyMap<string, CatalogPricing>,
 ): ProviderDefinitionView {
   const unavailableReason = unavailableProviderReason(definition, registry);
   return {
@@ -307,7 +325,10 @@ function definitionView(
     unavailableReason,
     supportsDiscovery: Boolean(registry.get(definition.id)?.discoveryFacet),
     supportsQuota: Boolean(registry.get(definition.id)?.quotaFacet),
-    models: definition.models.map((model) => modelView(model, 'catalog')),
+    models: definition.models.map((model) => {
+      const pricing = pricingByModelId?.get(model.id);
+      return modelView(model, 'catalog', pricing ? pricingView(pricing) : undefined);
+    }),
   };
 }
 
@@ -389,8 +410,20 @@ async function overview(): Promise<ProviderOverview> {
     .filter((observation) => observation.connectionId === undefined
       || connectionProviderIds.get(observation.connectionId) === observation.providerId)
     .map(statusView);
+  const catalogSnapshot = current.catalog.load();
+  const pricingByProviderId = new Map<string, ReadonlyMap<string, CatalogPricing>>();
+  for (const provider of catalogSnapshot.catalog.providers) {
+    pricingByProviderId.set(
+      provider.id,
+      new Map(provider.models.map((model) => [model.id, model.pricing])),
+    );
+  }
   return {
-    definitions: definitions.map((definition) => definitionView(definition, current.registry)),
+    definitions: definitions.map((definition) => definitionView(
+      definition,
+      current.registry,
+      pricingByProviderId.get(definition.id),
+    )),
     connections: connections.map((connection) =>
       connectionView(connection, definitions, activeTurnCounts.get(connection.id) ?? 0),
     ),

--- a/electron/src/renderer/components/Providers/ConnectionModelsDialog.tsx
+++ b/electron/src/renderer/components/Providers/ConnectionModelsDialog.tsx
@@ -288,9 +288,7 @@ export function ConnectionModelsEditor({
   const [editingCustomModelId, setEditingCustomModelId] = useState<string | null>(null);
   const [customForm, setCustomForm] = useState<CustomModelForm>(EMPTY_CUSTOM_MODEL);
   const [reasoningDraft, setReasoningDraft] = useState<ReasoningModelConfig>(EMPTY_REASONING_CONFIG);
-  const [pricingEditingModelId, setPricingEditingModelId] = useState<string | null>(null);
   const [pricingDraft, setPricingDraft] = useState(EMPTY_PRICING_DRAFT);
-  const [pricingError, setPricingError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -400,8 +398,8 @@ export function ConnectionModelsEditor({
   );
 
   useEffect(() => {
-    onEditingChange?.(editingCustomModelId !== null || pricingEditingModelId !== null);
-  }, [editingCustomModelId, pricingEditingModelId, onEditingChange]);
+    onEditingChange?.(editingCustomModelId !== null);
+  }, [editingCustomModelId, onEditingChange]);
 
   const toggleModel = (modelId: string) => {
     onSelectedModelIdsChange(selectedModelIds.includes(modelId)
@@ -425,6 +423,7 @@ export function ConnectionModelsEditor({
     setEditingCustomModelId(NEW_CUSTOM_MODEL);
     setCustomForm(EMPTY_CUSTOM_MODEL);
     setReasoningDraft(EMPTY_REASONING_CONFIG);
+    setPricingDraft(EMPTY_PRICING_DRAFT);
     setError(null);
   };
 
@@ -434,6 +433,9 @@ export function ConnectionModelsEditor({
     setEditingCustomModelId(row.view.id);
     setCustomForm(formForCustomModel(editable));
     setReasoningDraft(reasoningConfig[row.view.id] ?? EMPTY_REASONING_CONFIG);
+    // Seed the override draft from the saved override, or the signed-catalog
+    // rate card when no override exists, so the current rate is always visible.
+    setPricingDraft(pricingDraftFor(pricingOverrides[row.view.id] ?? row.view.pricing?.rates));
     setError(null);
   };
 
@@ -441,44 +443,8 @@ export function ConnectionModelsEditor({
     setEditingCustomModelId(null);
     setCustomForm(EMPTY_CUSTOM_MODEL);
     setReasoningDraft(EMPTY_REASONING_CONFIG);
+    setPricingDraft(EMPTY_PRICING_DRAFT);
     setError(null);
-  };
-
-  const startEditingPricing = (modelId: string) => {
-    setPricingEditingModelId(modelId);
-    setPricingDraft(pricingDraftFor(pricingOverrides[modelId]));
-    setPricingError(null);
-  };
-
-  const cancelPricingEditing = () => {
-    setPricingEditingModelId(null);
-    setPricingDraft(EMPTY_PRICING_DRAFT);
-    setPricingError(null);
-  };
-
-  const savePricingOverride = () => {
-    if (!pricingEditingModelId) return;
-    for (const field of PRICING_RATE_FIELDS) {
-      if (invalidPricingAmount(pricingDraft[field.key])) {
-        setPricingError(`Enter a non-negative decimal amount for ${field.label.toLowerCase()}.`);
-        return;
-      }
-    }
-    const next = { ...pricingOverrides };
-    const override = pricingOverrideFromDraft(pricingDraft);
-    if (Object.keys(override).length === 0) delete next[pricingEditingModelId];
-    else {
-      // Preserve dimensions this minimal form does not edit (energy, TTL-keyed
-      // cache writes) so saving one field never silently drops another.
-      const existing = pricingOverrides[pricingEditingModelId];
-      if (existing?.energy) override.energy = existing.energy;
-      if (existing?.cacheWriteByTtl) override.cacheWriteByTtl = existing.cacheWriteByTtl;
-      next[pricingEditingModelId] = override;
-    }
-    onPricingOverridesChange?.(next);
-    setPricingEditingModelId(null);
-    setPricingDraft(EMPTY_PRICING_DRAFT);
-    setPricingError(null);
   };
 
   const clearPricingOverride = (modelId: string) => {
@@ -486,7 +452,10 @@ export function ConnectionModelsEditor({
     const next = { ...pricingOverrides };
     delete next[modelId];
     onPricingOverridesChange?.(next);
-    if (pricingEditingModelId === modelId) cancelPricingEditing();
+    // Return the form to the underlying catalog rates as the visible base.
+    const row = rows.find((candidate) => candidate.view.id === modelId);
+    setPricingDraft(pricingDraftFor(row?.view.pricing?.rates));
+    setError(null);
   };
 
   const toggleModality = (
@@ -506,6 +475,12 @@ export function ConnectionModelsEditor({
 
   const saveCustomModel = () => {
     if (!editingCustomModelId) return;
+    for (const field of PRICING_RATE_FIELDS) {
+      if (invalidPricingAmount(pricingDraft[field.key])) {
+        setError(`Enter a non-negative decimal amount for ${field.label.toLowerCase()}.`);
+        return;
+      }
+    }
     const fixedId = editingCustomModelId !== NEW_CUSTOM_MODEL
       && (catalogModelIds.has(editingCustomModelId) || discoveredRowIds.has(editingCustomModelId));
     const catalogModel = catalogModels.find((model) => model.id === editingCustomModelId);
@@ -581,9 +556,27 @@ export function ConnectionModelsEditor({
     }
     onReasoningConfigChange(nextReasoningConfig);
 
+    // The override lives on the same form as the model: saving the model
+    // persists the rate override too, migrating its key on a rename.
+    const override = pricingOverrideFromDraft(pricingDraft);
+    const nextPricingOverrides = { ...pricingOverrides };
+    if (existing && existing.id !== id) delete nextPricingOverrides[existing.id];
+    if (Object.keys(override).length === 0) {
+      delete nextPricingOverrides[id];
+    } else {
+      // Preserve dimensions this minimal form does not edit (energy, TTL-keyed
+      // cache writes) so saving one field never silently drops another.
+      const prior = pricingOverrides[existing?.id ?? id] ?? pricingOverrides[id];
+      if (prior?.energy) override.energy = prior.energy;
+      if (prior?.cacheWriteByTtl) override.cacheWriteByTtl = prior.cacheWriteByTtl;
+      nextPricingOverrides[id] = override;
+    }
+    onPricingOverridesChange?.(nextPricingOverrides);
+
     setEditingCustomModelId(null);
     setCustomForm(EMPTY_CUSTOM_MODEL);
     setReasoningDraft(EMPTY_REASONING_CONFIG);
+    setPricingDraft(EMPTY_PRICING_DRAFT);
     setError(null);
   };
 
@@ -644,7 +637,7 @@ export function ConnectionModelsEditor({
                         variant="ghost"
                         size="sm"
                         onClick={() => void discoverModels()}
-                        disabled={disabled || discovering || editingCustomModelId !== null || pricingEditingModelId !== null}
+                        disabled={disabled || discovering || editingCustomModelId !== null}
                       >
                         <Icon name="refresh" size={14} />
                         {discovering ? 'Fetching…' : 'Fetch models'}
@@ -654,7 +647,7 @@ export function ConnectionModelsEditor({
                       variant="ghost"
                       size="sm"
                       onClick={toggleAllModels}
-                      disabled={disabled || editingCustomModelId !== null || pricingEditingModelId !== null || selectableModelIds.length === 0}
+                      disabled={disabled || editingCustomModelId !== null || selectableModelIds.length === 0}
                       aria-pressed={allModelsSelected}
                     >
                       {allModelsSelected ? 'Deselect all models' : 'Select all models'}
@@ -663,7 +656,7 @@ export function ConnectionModelsEditor({
                       <Button
                         size="sm"
                         onClick={startAddingCustomModel}
-                        disabled={disabled || pricingEditingModelId !== null}
+                        disabled={disabled}
                       >
                         <Icon name="plus" size={14} />
                         Add custom model
@@ -704,7 +697,7 @@ export function ConnectionModelsEditor({
                             checked={selected}
                             onChange={() => toggleModel(row.view.id)}
                             aria-label={`Use ${row.view.displayName}`}
-                            disabled={disabled || editingCustomModelId !== null || pricingEditingModelId !== null}
+                            disabled={disabled || editingCustomModelId !== null}
                           />
                           <div className="min-w-0">
                             <div className="flex flex-wrap items-center gap-2">
@@ -747,7 +740,7 @@ export function ConnectionModelsEditor({
                                   size="xs"
                                   className="rounded-md"
                                   value={tierSelections[row.view.id] ?? row.tierOptions.selected ?? ''}
-                                  disabled={disabled || editingCustomModelId !== null || pricingEditingModelId !== null}
+                                  disabled={disabled || editingCustomModelId !== null}
                                   onChange={(event) => selectTier(row.view.id, event.target.value)}
                                   onClick={(event) => event.stopPropagation()}
                                 >
@@ -766,22 +759,11 @@ export function ConnectionModelsEditor({
                           <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => startEditingPricing(row.view.id)}
-                            aria-label={`Edit pricing for ${row.view.displayName}`}
-                            title="Edit per-model rate override"
-                            disabled={disabled || editingCustomModelId !== null || pricingEditingModelId !== null}
-                          >
-                            <Icon name="sliders" size={14} />
-                            Pricing
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
                             shape="square"
                             onClick={() => startEditingRow(row)}
                             aria-label={`Edit ${row.view.displayName}`}
-                            title={`Edit ${row.view.displayName}`}
-                            disabled={disabled || editingCustomModelId !== null || pricingEditingModelId !== null}
+                            title={`Edit ${row.view.displayName} metadata and pricing`}
+                            disabled={disabled || editingCustomModelId !== null}
                           >
                             <Icon name="edit" size={14} />
                           </Button>
@@ -791,7 +773,7 @@ export function ConnectionModelsEditor({
                               size="sm"
                               onClick={() => resetModelOverride(row.view.id)}
                               title="Reset to the underlying metadata"
-                              disabled={disabled || editingCustomModelId !== null || pricingEditingModelId !== null}
+                              disabled={disabled || editingCustomModelId !== null}
                             >
                               Reset
                             </Button>
@@ -805,7 +787,7 @@ export function ConnectionModelsEditor({
                               onClick={() => removeCustomModel(row.view.id)}
                               aria-label={`Remove ${row.view.displayName}`}
                               title={`Remove ${row.view.displayName}`}
-                              disabled={disabled || editingCustomModelId !== null || pricingEditingModelId !== null}
+                              disabled={disabled || editingCustomModelId !== null}
                             >
                               <Icon name="trash" size={14} />
                             </Button>
@@ -976,6 +958,54 @@ export function ConnectionModelsEditor({
                       />
                     </div>
                   )}
+                  <div className="mt-4 rounded-box border border-base-300 bg-base-100/60 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <h4 className="text-sm font-semibold">Pricing override</h4>
+                        <p className="mt-0.5 text-xs text-base-content/60">
+                          Set field-level rates that win over the catalog, provider, and discovered
+                          pricing rungs for this model. Empty fields keep the underlying rate.
+                        </p>
+                      </div>
+                      {pricingOverrides[editingCustomModelId] && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-error"
+                          onClick={() => clearPricingOverride(editingCustomModelId)}
+                          disabled={disabled}
+                        >
+                          Clear override
+                        </Button>
+                      )}
+                    </div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2">
+                      {PRICING_RATE_FIELDS.map((field) => (
+                        <div key={field.key}>
+                          <label
+                            className="label"
+                            htmlFor={`pricing-${field.key}-${editingCustomModelId}`}
+                          >
+                            {field.label}
+                          </label>
+                          <TextInput
+                            id={`pricing-${field.key}-${editingCustomModelId}`}
+                            bordered={false}
+                            className="w-full"
+                            inputMode="decimal"
+                            value={pricingDraft[field.key]}
+                            onChange={(event) => setPricingDraft({ ...pricingDraft, [field.key]: event.target.value })}
+                            placeholder={field.placeholder}
+                            disabled={disabled}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <p className="label mt-2">
+                      Token rates are per 1,000,000 tokens; the per-request fee is charged once per
+                      request. Fields pre-fill from the catalog rate card as a starting point.
+                    </p>
+                  </div>
                   <div className="mt-4 flex justify-end gap-2">
                     <Button
                       variant="ghost"
@@ -991,75 +1021,6 @@ export function ConnectionModelsEditor({
                       disabled={disabled}
                     >
                       {editingCustomModelId === NEW_CUSTOM_MODEL ? 'Add model' : 'Save model'}
-                    </Button>
-                  </div>
-                </div>
-              )}
-
-              {pricingEditingModelId !== null && (
-                <div className="rounded-box border border-base-300 bg-base-200/40 p-4">
-                  <h3 className="text-sm font-semibold">Pricing override</h3>
-                  <p className="mt-0.5 break-all font-mono text-xs text-base-content/60">
-                    {pricingEditingModelId}
-                  </p>
-                  <p className="mt-1 text-xs text-base-content/60">
-                    Set field-level rates that win over the catalog, provider, and discovered
-                    pricing rungs for this model. Empty fields keep the underlying rate.
-                  </p>
-                  <div className="mt-3 grid gap-3 md:grid-cols-2">
-                    {PRICING_RATE_FIELDS.map((field) => (
-                      <div key={field.key}>
-                        <label
-                          className="label"
-                          htmlFor={`pricing-${field.key}-${pricingEditingModelId}`}
-                        >
-                          {field.label}
-                        </label>
-                        <TextInput
-                          id={`pricing-${field.key}-${pricingEditingModelId}`}
-                          bordered={false}
-                          className="w-full"
-                          inputMode="decimal"
-                          value={pricingDraft[field.key]}
-                          onChange={(event) => setPricingDraft({ ...pricingDraft, [field.key]: event.target.value })}
-                          placeholder={field.placeholder}
-                          disabled={disabled}
-                        />
-                      </div>
-                    ))}
-                  </div>
-                  <p className="label mt-2">
-                    Token rates are per 1,000,000 tokens; the per-request fee is charged once per request.
-                  </p>
-                  {pricingError && (
-                    <Alert tone="error" icon="alertCircle" aria-live="assertive">{pricingError}</Alert>
-                  )}
-                  <div className="mt-4 flex justify-end gap-2">
-                    {pricingOverrides[pricingEditingModelId] && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-error"
-                        onClick={() => clearPricingOverride(pricingEditingModelId)}
-                        disabled={disabled}
-                      >
-                        Clear override
-                      </Button>
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={cancelPricingEditing}
-                      disabled={disabled}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      size="sm"
-                      onClick={savePricingOverride}
-                      disabled={disabled}
-                    >
-                      Save pricing override
                     </Button>
                   </div>
                 </div>

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -545,6 +545,18 @@ export interface ProjectConfigSaveMessage {
 // ── Provider API ─────────────────────────────────────────────────────────────
 
 /**
+ * Renderer-safe catalog pricing for one model: the rate fields plus the
+ * billing-unit context needed to label them. Provenance stays in main.
+ */
+export interface ProviderModelPricingView {
+  currency: string;
+  currencyUnit?: import('./provider-facets').CurrencyUnit;
+  effectiveAt: string;
+  rates: import('./provider-facets').PricingRateFields;
+  contextTiers?: readonly import('./provider-facets').PricingContextTier[];
+}
+
+/**
  * Renderer-safe provider model metadata. Driver origins, pricing internals,
  * and catalog signatures stay in the main process.
  */
@@ -565,6 +577,8 @@ export interface ProviderModelView {
     contextTokens: number | null;
     outputTokens: number | null;
   } | null;
+  /** Signed-catalog rate card for catalog rows; absent for other origins. */
+  pricing?: ProviderModelPricingView;
 }
 
 /** A catalog preset rendered by onboarding and settings. */

--- a/electron/tests/integration/provider-catalog-tools.test.ts
+++ b/electron/tests/integration/provider-catalog-tools.test.ts
@@ -56,7 +56,10 @@ describe('provider catalog operator tools', () => {
     expect(bundledModels.every((model) => (
       model.capabilities.outputModalities.every((modality) => modality === 'text' || modality === 'embedding')
     ))).toBe(true);
-    expect(bundledModels.some((model) => model.capabilities.outputModalities.includes('embedding'))).toBe(true);
+    // Upstream models.dev no longer publishes embedding-output models; the
+    // seed path that retains embedding-only models is covered by the fixture
+    // capture below. The bundle must still ship usable text-generation models.
+    expect(bundledModels.some((model) => model.capabilities.outputModalities.includes('text'))).toBe(true);
     expect(result.catalog.providers.find((provider) => provider.id === 'lilac')?.models)
       .toEqual(expect.arrayContaining([
         expect.objectContaining({

--- a/electron/tests/unit/connection-models-editor.test.tsx
+++ b/electron/tests/unit/connection-models-editor.test.tsx
@@ -29,6 +29,14 @@ function definition(overrides: Partial<ProviderDefinitionView> = {}): ProviderDe
       source: 'catalog',
       capabilities: { inputModalities: ['text'], outputModalities: ['text'], tools: true, reasoning: true },
       limits: { contextTokens: 1000, outputTokens: 100 },
+      pricing: {
+        currency: 'USD',
+        effectiveAt: '2026-08-01T00:00:00.000Z',
+        rates: {
+          input: { amount: '0.5', per: 1_000_000, unit: 'tokens' },
+          output: { amount: '1.5', per: 1_000_000, unit: 'tokens' },
+        },
+      },
     }],
     ...overrides,
   };
@@ -208,50 +216,56 @@ describe('connection models unified listing', () => {
     expect(screen.queryByRole('button', { name: /fetch models/i })).toBeNull();
   });
 
-  it('renders the per-model pricing override form and clears an existing override', () => {
+  it('pre-fills the pricing section from the signed-catalog rate card when no override is set', () => {
+    renderEditor();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit NW Base' }));
+    expect(screen.getByRole('heading', { name: 'Pricing override' })).toBeDefined();
+    expect(screen.getByLabelText('Input rate')).toBeDefined();
+    expect(screen.getByDisplayValue('0.5')).toBeDefined();
+    expect(screen.getByDisplayValue('1.5')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Clear override' })).toBeNull();
+  });
+
+  it('shows an existing override in the model form and clears it back to catalog rates', () => {
     const override = {
       input: { amount: '1.25', per: 1_000_000, unit: 'tokens' as const },
       output: { amount: '5.00', per: 1_000_000, unit: 'tokens' as const },
     };
     const onPricingOverridesChange = vi.fn();
     renderEditor({
-      unifiedModels: [
-        option('nw-base', { enabled: true, pricingOverrides: override, model: { displayName: 'NW Base' } }),
-      ],
       pricingOverrides: { 'nw-base': override },
       onPricingOverridesChange,
     });
 
     expect(screen.getByText('NW Base').closest('li')?.textContent).toContain('Pricing override');
-    fireEvent.click(screen.getByRole('button', { name: 'Edit pricing for NW Base' }));
-    expect(screen.getByRole('heading', { name: 'Pricing override' })).toBeDefined();
-    expect(screen.getByLabelText('Input rate')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit NW Base' }));
     expect(screen.getByDisplayValue('1.25')).toBeDefined();
     expect(screen.getByDisplayValue('5.00')).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear override' }));
     expect(onPricingOverridesChange).toHaveBeenCalledWith({});
-    expect(screen.queryByRole('button', { name: 'Clear override' })).toBeNull();
+    // The form falls back to the catalog rate card as the visible base.
+    expect(screen.getByDisplayValue('0.5')).toBeDefined();
   });
 
-  it('saves a per-model pricing override from the form fields', () => {
+  it('saves a per-model pricing override together with the model from the edit form', () => {
     const onPricingOverridesChange = vi.fn();
     renderEditor({
-      unifiedModels: [
-        option('nw-base', { enabled: true, model: { displayName: 'NW Base' } }),
-      ],
       pricingOverrides: {},
+      reasoningConfig: { 'nw-base': { levels: ['low'], default: 'low' } },
       onPricingOverridesChange,
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit pricing for NW Base' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit NW Base' }));
     fireEvent.change(screen.getByLabelText('Input rate'), { target: { value: '1.5' } });
     fireEvent.change(screen.getByLabelText('Per-request fee'), { target: { value: '0.02' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save pricing override' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save model' }));
 
     expect(onPricingOverridesChange).toHaveBeenCalledWith({
       'nw-base': {
         input: { amount: '1.5', per: 1_000_000, unit: 'tokens' },
+        output: { amount: '1.5', per: 1_000_000, unit: 'tokens' },
         perRequest: { amount: '0.02', per: 1, unit: 'requests' },
       },
     });


### PR DESCRIPTION
…fresh the catalog

Pricing overrides previously lived on a separate per-row form and the renderer never received signed-catalog rate cards, so the editor could not show the current rate when setting an override. The rate fields now live inside the add/edit model form and save together with the model (renames migrate the override key); ProviderModelView carries a renderer-safe pricing view so catalog rows pre-fill their current rates.

Refresh the bundled catalog from models.dev (version 2, captured 2026-08-12) with updated models, rates, and lifecycle states, and drop the integration assertion that upstream still publishes embedding models.