### PR TITLE
fix: gate analytics quota panel on configured connections

### DIFF
--- a/electron/src/main/providers/accounting/analytics-queries.ts
+++ b/electron/src/main/providers/accounting/analytics-queries.ts
@@ -29,7 +29,7 @@ import type { SubagentAttributionRecord } from '../../../shared/types/accounting
 import type { QuotaOverviewEntry } from '../../../shared/types/analytics';
 import { providerQuotaSchema } from '../../../shared/types/provider-facets';
 import { getSessionNames } from '../../session/storage';
-import { getProviderStatusService } from '../runtime-context';
+import { getProviderConnectionStore, getProviderStatusService } from '../runtime-context';
 
 const DEFAULT_LIMIT = 1000;
 const CONTEXT_TOP_SESSIONS = 5;
@@ -159,12 +159,20 @@ function parseSnapshotModelDisplayName(snapshotJson: string): string | null {
  * Read the latest typed quota observations from the status cache (R24). These
  * render in native units and are informational only; the ledger is never joined
  * against them, and an unavailable status service yields an empty list.
+ *
+ * Entries are gated on configured connections: quota is only shown for a
+ * provider the user actually has a connection for. Without this gate, the
+ * credential-free provider-wide sources (e.g. Lilac, scheduled unconditionally)
+ * and persisted cache entries would surface quota for providers with no
+ * connection — information that is irrelevant to the user.
  */
 function getQuotaOverview(): QuotaOverviewEntry[] {
   try {
     const status = getProviderStatusService();
+    const connectedProviders = getProviderConnectionStore().listProviderIdsSync();
     const entries: QuotaOverviewEntry[] = [];
     for (const observation of status.list()) {
+      if (!connectedProviders.has(observation.providerId)) continue;
       const parsed = providerQuotaSchema.safeParse(observation.data['quota']);
       if (!parsed.success) continue;
       const quota = parsed.data;

--- a/electron/src/main/providers/connection-store.ts
+++ b/electron/src/main/providers/connection-store.ts
@@ -106,6 +106,15 @@ export class ConnectionStore {
     return readDocument(this.filePath).connections.map((connection) => ({ ...connection }));
   }
 
+  /**
+   * Synchronous read of the configured provider ids. The async surface stays
+   * authoritative for mutations; this read-only variant serves main-process
+   * consumers (analytics) that cannot await without rippling sync APIs.
+   */
+  listProviderIdsSync(): Set<string> {
+    return new Set(readDocument(this.filePath).connections.map((connection) => connection.providerId));
+  }
+
   async get(id: string): Promise<ProviderConnection | null> {
     const connection = readDocument(this.filePath).connections.find((item) => item.id === id);
     return connection ? { ...connection } : null;

--- a/electron/tests/integration/analytics-queries.test.ts
+++ b/electron/tests/integration/analytics-queries.test.ts
@@ -34,6 +34,14 @@ import {
   getContext,
 } from '../../src/main/providers/accounting/analytics-queries';
 import { _clearDbCache } from '../../src/main/session/storage';
+import type { ConnectionStore } from '../../src/main/providers/connection-store';
+import type { ProviderStatusObservation } from '../../src/main/providers/status/cache';
+import type { ProviderStatusService } from '../../src/main/providers/status/service';
+import {
+  resetProviderRuntimeContext,
+  setProviderConnectionStore,
+  setProviderStatusService,
+} from '../../src/main/providers/runtime-context';
 
 // ─── Shared state ─────────────────────────────────────────────────────────────
 
@@ -245,6 +253,7 @@ afterEach(() => {
   resetToolAttemptStore();
   resetContextSnapshotStore();
   resetSubagentAttributionStore();
+  resetProviderRuntimeContext();
   _clearDbCache();
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
@@ -459,6 +468,71 @@ describe('analytics-queries', () => {
         { providerId: 'anthropic', cost: '31' },
         { providerId: 'openai', cost: '5' },
       ]);
+    });
+  });
+
+  // ── Quota overview (connection gating) ─────────────────────────────────────
+
+  describe('quotaByProvider connection gating', () => {
+    function quotaObservation(providerId: string, connectionId?: string): ProviderStatusObservation {
+      return {
+        providerId,
+        ...(connectionId ? { connectionId } : {}),
+        observedAt: '2026-07-12T10:00:00.000Z',
+        providerUpdatedAt: null,
+        availability: 'available',
+        stale: false,
+        data: {
+          quota: {
+            observedAt: '2026-07-12T10:00:00.000Z',
+            balances: [{ label: 'Credits remaining', amount: '12.5', unit: 'USD' }],
+            subscription: null,
+            allowances: [{ label: 'API key', state: 'available' }],
+          },
+        },
+      };
+    }
+
+    function fakeStatusService(observations: readonly ProviderStatusObservation[]): ProviderStatusService {
+      return { list: () => observations } as unknown as ProviderStatusService;
+    }
+
+    function fakeConnectionStore(providerIds: readonly string[]): ConnectionStore {
+      return { listProviderIdsSync: () => new Set(providerIds) } as unknown as ConnectionStore;
+    }
+
+    it('hides cached quota for providers with no configured connection', () => {
+      setProviderStatusService(fakeStatusService([
+        quotaObservation('lilac'),
+        quotaObservation('neuralwatt', 'conn-1'),
+      ]));
+      setProviderConnectionStore(fakeConnectionStore(['neuralwatt']));
+
+      const result = getOverview();
+      expect(result.quotaByProvider).toHaveLength(1);
+      expect(result.quotaByProvider[0].providerId).toBe('neuralwatt');
+      expect(result.quotaByProvider[0].connectionId).toBe('conn-1');
+    });
+
+    it('shows no quota cards when no connections are configured', () => {
+      setProviderStatusService(fakeStatusService([
+        quotaObservation('lilac'),
+        quotaObservation('neuralwatt', 'conn-1'),
+      ]));
+      setProviderConnectionStore(fakeConnectionStore([]));
+
+      const result = getOverview();
+      expect(result.quotaByProvider).toHaveLength(0);
+    });
+
+    it('shows a provider-wide observation when a connection exists for that provider', () => {
+      setProviderStatusService(fakeStatusService([quotaObservation('lilac')]));
+      setProviderConnectionStore(fakeConnectionStore(['lilac']));
+
+      const result = getOverview();
+      expect(result.quotaByProvider).toHaveLength(1);
+      expect(result.quotaByProvider[0].providerId).toBe('lilac');
+      expect(result.quotaByProvider[0].connectionId).toBeNull();
     });
   });
 


### PR DESCRIPTION
Only show Provider Quota & Subscription cards for providers the user has an actual connection with. Without this gate, Lilac (scheduled unconditionally, credential-free) and persisted cache entries from deleted connections would surface quota for providers with no connection — irrelevant information.

- Add ConnectionStore.listProviderIdsSync() read-only sync accessor
- Filter getQuotaOverview() against configured provider ids
- Add 3 integration tests covering the gating behavior