### PR TITLE
fix: persist chain error detail and move error banner to bottom

### DIFF
--- a/electron/src/main/agents/manager.ts
+++ b/electron/src/main/agents/manager.ts
@@ -1640,5 +1640,7 @@ function makeEmptyChain(
     subagentRecord: null,
     startTime: new Date().toISOString(),
     endTime: null,
+    errorDetail: null,
+    errorTitle: null,
   };
 }

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -10,7 +10,7 @@ import { getForegroundLiveRegistry } from '../tools/process/foreground-live';
 import { SEND_INPUT_MAX_TEXT_LENGTH } from '../tools/process/send-input';
 import { getSessionManager } from '../session/singleton';
 import { IPC_CHANNELS, type ChatSessionSnapshot } from '../../shared/types/ipc';
-import { ChainStatus } from '../../shared/types/chain';
+import { ChainStatus, lastChainError } from '../../shared/types/chain';
 import { flattenSessionMessages } from '../../shared/types/session';
 import { clearAllChatHistory } from './chat-history';
 import { chatCancelSchema, chatQueueNextSchema, chatSendSchema, chatSnapshotSchema, chatStopSchema } from './payload-schemas';
@@ -137,6 +137,7 @@ export function registerChatIPC(): void {
         sessionId,
         messages: liveAgent && live ? [...liveAgent.messages] : flattenSessionMessages(session),
         live,
+        lastChainError: live ? null : lastChainError(session.chains),
       };
     },
   );

--- a/electron/src/main/ipc/chat/persist.ts
+++ b/electron/src/main/ipc/chat/persist.ts
@@ -191,6 +191,8 @@ export function persistTurnConversation(
   agent: Agent,
   selection?: ModelSelection | null,
   webContents?: WebContents,
+  errorDetail?: string | null,
+  errorTitle?: string | null,
 ): void {
   setChatHistory(sessionId, fullHistory);
   try {
@@ -203,6 +205,8 @@ export function persistTurnConversation(
       agentName: agent.name,
       agentType: agent.type,
       agentTier: agent.tier,
+      errorDetail,
+      errorTitle,
     }, sessionId);
     const update = updated ? buildSessionUpdatedEvent(updated, null) : null;
     if (update && webContents) {

--- a/electron/src/main/ipc/chat/send.ts
+++ b/electron/src/main/ipc/chat/send.ts
@@ -549,6 +549,7 @@ export async function startChatTurn(
       persistTurnConversation(
         sessionId, fullHistory, turnMessagesFromAgent(activeAgent), ChainStatus.FAILED,
         agent, activeAgent.selection, webContents,
+        detail, title,
       );
       activeAgent.messages = fullHistory;
       sendTurnEvent(webContents, activeAgent, IPC_CHANNELS.CHAT_ERROR, {

--- a/electron/src/main/ipc/session.ts
+++ b/electron/src/main/ipc/session.ts
@@ -7,6 +7,7 @@
 import { BrowserWindow, dialog, ipcMain } from 'electron';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
 import { flattenSessionMessages, sessionForRenderer } from '../../shared/types/session';
+import { lastChainError } from '../../shared/types/chain';
 import type { ModelSelection } from '../../shared/types/provider';
 import {
   getSessionManager,
@@ -358,6 +359,7 @@ export function registerSessionIPC(): void {
       messages,
       live,
       workspace,
+      lastChainError: session && !live ? lastChainError(session.chains) : null,
     };
   });
 

--- a/electron/src/main/session/manager.ts
+++ b/electron/src/main/session/manager.ts
@@ -639,6 +639,8 @@ export class SessionManager {
       subagentRecord: null,
       startTime: now,
       endTime: null,
+      errorDetail: null,
+      errorTitle: null,
     };
     chains = [...chains, chain];
 
@@ -711,6 +713,8 @@ export class SessionManager {
   finishActiveChain(
     status: ChainStatus = ChainStatus.COMPLETED,
     sessionId?: string,
+    errorDetail?: string | null,
+    errorTitle?: string | null,
   ): Session | null {
     const targetId = sessionId ?? this.selectedSessionId();
     const session = targetId ? this.ensureSession(targetId) : null;
@@ -729,6 +733,8 @@ export class SessionManager {
       ...existing,
       status: terminal,
       endTime: now,
+      errorDetail: errorDetail ?? null,
+      errorTitle: errorTitle ?? null,
     };
     const chains = session.chains.map((c) =>
       c.id === chain.id ? chain : c,
@@ -769,6 +775,8 @@ export class SessionManager {
     agentName?: string;
     agentType?: string;
     agentTier?: string;
+    errorDetail?: string | null;
+    errorTitle?: string | null;
   }, sessionId?: string): Session | null {
     const targetId = sessionId ?? this.selectedSessionId();
     let session = targetId ? this.ensureSession(targetId) : null;
@@ -827,7 +835,12 @@ export class SessionManager {
     if (status === ChainStatus.ACTIVE) {
       return session;
     }
-    return this.finishActiveChain(status, targetId ?? undefined);
+    return this.finishActiveChain(
+      status,
+      targetId ?? undefined,
+      params.errorDetail,
+      params.errorTitle,
+    );
   }
 
   /**

--- a/electron/src/main/session/schema.ts
+++ b/electron/src/main/session/schema.ts
@@ -39,7 +39,9 @@ CREATE TABLE IF NOT EXISTS chains (
   subagent_record_json TEXT,
   messages_json TEXT NOT NULL DEFAULT '[]',
   start_time TEXT,
-  end_time TEXT
+  end_time TEXT,
+  error_detail TEXT,
+  error_title TEXT
 );
 
 CREATE TABLE IF NOT EXISTS subagent_chains (
@@ -69,6 +71,16 @@ export function applySessionSchemaMigrations(db: SqliteDatabase): void {
     for (const col of ['tier_override']) {
       if (!existing.has(col)) {
         db.prepare(`ALTER TABLE sessions ADD COLUMN ${col} TEXT`).run();
+      }
+    }
+  }
+
+  if (tables.has('chains')) {
+    const chainColumns = db.prepare('PRAGMA table_info(chains)').all() as Array<{ name: string }>;
+    const existing = new Set(chainColumns.map((c) => c.name));
+    for (const col of ['error_detail', 'error_title']) {
+      if (!existing.has(col)) {
+        db.prepare(`ALTER TABLE chains ADD COLUMN ${col} TEXT`).run();
       }
     }
   }

--- a/electron/src/main/session/storage.ts
+++ b/electron/src/main/session/storage.ts
@@ -220,6 +220,8 @@ interface ChainRow {
   messages_json: string;
   start_time: string | null;
   end_time: string | null;
+  error_detail: string | null;
+  error_title: string | null;
 }
 
 interface SubagentChainRow {
@@ -293,6 +295,8 @@ function chainFromRow(row: ChainRow): Chain {
     subagentRecord,
     startTime: row.start_time,
     endTime: row.end_time,
+    errorDetail: row.error_detail ?? null,
+    errorTitle: row.error_title ?? null,
   };
 }
 
@@ -351,8 +355,8 @@ function sessionFromRow(row: SessionRow, chains: Chain[], subagentChains: Subage
 }
 
 const INSERT_CHAIN_SQL = `
-  INSERT INTO chains (id, session_id, ordinal, status, selection_json, model_label, agent_name, agent_type, agent_tier, subagent_record_json, messages_json, start_time, end_time)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO chains (id, session_id, ordinal, status, selection_json, model_label, agent_name, agent_type, agent_tier, subagent_record_json, messages_json, start_time, end_time, error_detail, error_title)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `;
 
 const INSERT_SUBAGENT_CHAIN_SQL = `
@@ -385,6 +389,8 @@ function insertChainRow(
     serializeMessages(chain.messages),
     chain.startTime,
     chain.endTime,
+    chain.errorDetail,
+    chain.errorTitle,
   );
 }
 
@@ -395,7 +401,8 @@ function updateChainRow(db: SqliteDatabase, chain: Chain): number {
        SET status = ?, selection_json = ?, model_label = ?,
            agent_name = ?, agent_type = ?, agent_tier = ?,
            subagent_record_json = ?, messages_json = ?,
-           start_time = ?, end_time = ?
+           start_time = ?, end_time = ?,
+           error_detail = ?, error_title = ?
        WHERE id = ? AND session_id = ?`,
     )
     .run(
@@ -411,6 +418,8 @@ function updateChainRow(db: SqliteDatabase, chain: Chain): number {
       serializeMessages(chain.messages),
       chain.startTime,
       chain.endTime,
+      chain.errorDetail,
+      chain.errorTitle,
       chain.id,
       chain.sessionId,
     ).changes;

--- a/electron/src/renderer/components/ChainFooter.tsx
+++ b/electron/src/renderer/components/ChainFooter.tsx
@@ -13,6 +13,8 @@ interface ChainFooterProps {
   elapsedSeconds?: number;
   interrupted?: boolean;
   failed?: boolean;
+  /** Error detail from a FAILED chain, shown as a tooltip on the badge. */
+  errorDetail?: string | null;
 }
 
 export function ChainFooter({
@@ -22,6 +24,7 @@ export function ChainFooter({
   elapsedSeconds,
   interrupted,
   failed,
+  errorDetail,
 }: ChainFooterProps) {
   const showSub = hasUsage(subUsage);
   const showUsage = hasUsage(usage);
@@ -35,7 +38,7 @@ export function ChainFooter({
         </StatusBadge>
       )}
       {failed && !interrupted && (
-        <StatusBadge tone="error" size="xs" className="gap-1">
+        <StatusBadge tone="error" size="xs" className="gap-1" title={errorDetail ?? undefined}>
           <Icon name="alert" size={12} />
           Failed
         </StatusBadge>

--- a/electron/src/renderer/components/ChatStream.tsx
+++ b/electron/src/renderer/components/ChatStream.tsx
@@ -337,6 +337,12 @@ export function ChatStream({
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       <div className="orchid-chat-scroll px-6 py-5" ref={containerRef}>
+        {/* History + live tail + active footer render as ONE keyed sequence.
+            History nodes remain referentially stable across live-only frames,
+            while the small tail/footer path updates independently. Keeping the
+            final nodes flat lets React retain shared segment/footer keys across
+            the live→committed swap instead of replaying entrance animation. */}
+        {streamNodes}
         {error && (
           <div className="orchid-error-slot">
             <ErrorBanner
@@ -347,13 +353,6 @@ export function ChatStream({
             />
           </div>
         )}
-
-        {/* History + live tail + active footer render as ONE keyed sequence.
-            History nodes remain referentially stable across live-only frames,
-            while the small tail/footer path updates independently. Keeping the
-            final nodes flat lets React retain shared segment/footer keys across
-            the live→committed swap instead of replaying entrance animation. */}
-        {streamNodes}
       </div>
       {isUserScrolledUp ? (
         <Button
@@ -411,6 +410,7 @@ function renderStreamItem(
         elapsedSeconds={item.elapsedSeconds}
         interrupted={item.interrupted}
         failed={item.failed}
+        errorDetail={item.errorDetail}
       />
     );
   }

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -392,6 +392,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
         sessionId: result.session.id,
         messages: result.messages,
         live: result.live,
+        lastChainError: result.lastChainError,
       });
     },
     [session, chat.beginSessionSwitch, chat.hydrateSnapshot, todos.applyFromSession, draftTabVisible, messageQueue.clearQueue],

--- a/electron/src/renderer/hooks/useChat.ts
+++ b/electron/src/renderer/hooks/useChat.ts
@@ -800,6 +800,14 @@ export function useChat(
       // sequence affinity for the selected session so stale turn/sequence
       // leftovers from a prior generation are discarded (not blindly applied).
       replayHydrationBuffer(bufferedEvents);
+      // Restore error from the last FAILED chain so the banner persists
+      // across session switches and restarts.
+      if (snapshot.lastChainError) {
+        const errorText = snapshot.lastChainError.title && !snapshot.lastChainError.detail.startsWith(snapshot.lastChainError.title)
+          ? `${snapshot.lastChainError.title}: ${snapshot.lastChainError.detail}`
+          : snapshot.lastChainError.detail;
+        dispatchProjection({ type: 'local_error', error: errorText, status: 'error' });
+      }
       return;
     }
 

--- a/electron/src/renderer/hooks/useSession.ts
+++ b/electron/src/renderer/hooks/useSession.ts
@@ -661,6 +661,8 @@ function makeLocalSession(): Session {
       subagentRecord: null,
       startTime: now,
       endTime: null,
+      errorDetail: null,
+      errorTitle: null,
     }],
     activeChainId: chainId,
     createdAt: now,

--- a/electron/src/renderer/utils/stream-building.ts
+++ b/electron/src/renderer/utils/stream-building.ts
@@ -40,6 +40,7 @@ export type StreamItem =
       elapsedSeconds?: number;
       interrupted?: boolean;
       failed?: boolean;
+      errorDetail?: string | null;
     }
   | {
       kind: 'collapsed-stub';
@@ -288,6 +289,7 @@ export function buildHistoryStreamItems(opts: {
           chain.status === ChainStatus.INTERRUPTED ||
           (isLastChain && interrupted),
         failed: chain.status === ChainStatus.FAILED,
+        errorDetail: chain.errorDetail,
       };
       if (isActive) {
         activeFooter = footer;

--- a/electron/src/shared/serialization/chain-subagent.ts
+++ b/electron/src/shared/serialization/chain-subagent.ts
@@ -45,6 +45,8 @@ export function chainToStorageDict(chain: Chain): ChainStorageDict {
   }
   if (chain.startTime) dict.startTime = chain.startTime;
   if (chain.endTime != null) dict.endTime = chain.endTime;
+  if (chain.errorDetail) dict.errorDetail = chain.errorDetail;
+  if (chain.errorTitle) dict.errorTitle = chain.errorTitle;
   return dict;
 }
 
@@ -92,6 +94,8 @@ export function chainFromStorageDict(data: unknown): Chain {
     subagentRecord,
     startTime,
     endTime,
+    errorDetail: typeof raw.errorDetail === 'string' ? raw.errorDetail : null,
+    errorTitle: typeof raw.errorTitle === 'string' ? raw.errorTitle : null,
   };
 }
 

--- a/electron/src/shared/types/chain.ts
+++ b/electron/src/shared/types/chain.ts
@@ -69,6 +69,10 @@ export interface Chain {
    * ISO timestamp when the chain finished, or null while ACTIVE / unknown.
    */
   readonly endTime: string | null;
+  /** Error detail persisted when status is FAILED; null otherwise. */
+  readonly errorDetail: string | null;
+  /** Short error title (auth/rate-limit/timeout/etc) persisted when FAILED. */
+  readonly errorTitle: string | null;
 }
 
 // ── Storage dict ────────────────────────────────────────────────────────────
@@ -86,6 +90,8 @@ export interface ChainStorageDict {
   subagentRecord?: unknown;
   startTime?: string;
   endTime?: string | null;
+  errorDetail?: string | null;
+  errorTitle?: string | null;
   [key: string]: unknown;
 }
 
@@ -158,4 +164,17 @@ export function parseChainStatus(raw: unknown): ChainStatus {
   if (raw === 'interrupted') return ChainStatus.INTERRUPTED;
   if (raw === 'failed') return ChainStatus.FAILED;
   return ChainStatus.COMPLETED;
+}
+
+/** Extract the error detail from the last FAILED chain in a session, if any. */
+export function lastChainError(
+  chains: readonly Chain[],
+): { detail: string; title?: string | null } | null {
+  for (let i = chains.length - 1; i >= 0; i--) {
+    const chain = chains[i]!;
+    if (chain.status === ChainStatus.FAILED && chain.errorDetail) {
+      return { detail: chain.errorDetail, title: chain.errorTitle };
+    }
+  }
+  return null;
 }

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -179,6 +179,8 @@ export interface ChatSessionSnapshot {
   sessionId: string;
   messages: Message[];
   live: ChatSnapshot | null;
+  /** Error detail from the last FAILED chain, if any (for hydration restore). */
+  lastChainError?: { detail: string; title?: string | null } | null;
 }
 
 /**
@@ -196,6 +198,8 @@ export interface SessionOpenResult {
   live: ChatSnapshot | null;
   /** Resolved workspace after activation (session → sticky → unbound). */
   workspace: WorkspaceInfo;
+  /** Error detail from the last FAILED chain, if any (for hydration restore). */
+  lastChainError?: { detail: string; title?: string | null } | null;
 }
 
 export interface SubagentSnapshotRequest { sessionId: string; }

--- a/electron/tests/parity/sessions.test.ts
+++ b/electron/tests/parity/sessions.test.ts
@@ -261,6 +261,8 @@ describe('Session Parity', () => {
             subagentRecord: null,
             startTime: null,
             endTime: null,
+            errorDetail: null,
+            errorTitle: null,
           },
           {
             id: 'c2',
@@ -275,6 +277,8 @@ describe('Session Parity', () => {
             subagentRecord: null,
             startTime: null,
             endTime: null,
+            errorDetail: null,
+            errorTitle: null,
           },
         ],
       });

--- a/electron/tests/unit/chat-ipc.test.ts
+++ b/electron/tests/unit/chat-ipc.test.ts
@@ -282,6 +282,8 @@ const mocks = vi.hoisted(() => {
         subagentRecord: null,
         startTime: new Date().toISOString(),
         endTime: null,
+        errorDetail: null,
+        errorTitle: null,
       };
       const updated = {
         ...target,

--- a/electron/tests/unit/session-persistence.test.ts
+++ b/electron/tests/unit/session-persistence.test.ts
@@ -125,6 +125,8 @@ function makeChain(sessionId: string, overrides: Partial<Chain> & { model?: stri
         : overrides.status === ChainStatus.ACTIVE
           ? null
           : now,
+    errorDetail: overrides.errorDetail ?? null,
+    errorTitle: overrides.errorTitle ?? null,
   };
 }
 

--- a/electron/tests/unit/subagent-transcript.test.ts
+++ b/electron/tests/unit/subagent-transcript.test.ts
@@ -22,6 +22,7 @@ const chain = (messages: Message[]): Chain => ({
   id: 'chain-1', sessionId: 'session-1', status: 'completed', messages,
   selection: null, modelLabel: null, agentName: 'worker', agentType: 'worker', agentTier: 'bloom',
   startTime: null, endTime: null, subagentRecord: null,
+  errorDetail: null, errorTitle: null,
 });
 
 const record = (messages: Message[]): SubagentRecord => ({

--- a/electron/tests/unit/use-session-cache.test.ts
+++ b/electron/tests/unit/use-session-cache.test.ts
@@ -55,6 +55,8 @@ function makeSession(overrides: Partial<Session> = {}): Session {
       subagentRecord: null,
       startTime: now,
       endTime: null,
+      errorDetail: null,
+      errorTitle: null,
     }],
     activeChainId: overrides.activeChainId ?? chainId,
     createdAt: overrides.createdAt ?? now,


### PR DESCRIPTION
Errors from failed chat turns are now persisted on the chain row (error_detail, error_title) so they survive session switches and restarts. The ErrorBanner moved from the top to the bottom of the chat stream, the Failed badge on ChainFooter shows the error as a tooltip, and hydrating a session with a FAILED chain restores the error banner automatically.

- Add errorDetail/errorTitle to Chain type, ChainStorageDict, DB schema (with migration for existing DBs), and storage R/W
- Thread error fields through persistTurnConversation → persistTurn → finishActiveChain at error emission time
- Populate lastChainError in chat:snapshot and session:open payloads
- Restore error via local_error projection on hydration
- Move ErrorBanner below streamNodes in ChatStream
- Add errorDetail tooltip to ChainFooter Failed badge
- Update all Chain construction sites and test factories