### PR TITLE
fix(context): count reasoning tokens on hidden usage messages

### DIFF
--- a/electron/src/main/providers/accounting/middleware.ts
+++ b/electron/src/main/providers/accounting/middleware.ts
@@ -95,7 +95,11 @@ function withEstimatedReasoning(
   chars: ReasoningChars,
   outputTokens: number | undefined,
 ): NormalizedProviderUsage | null {
-  if (!usage || usage.reasoningTokens !== undefined) return usage;
+  if (!usage) return usage;
+  // A positive provider-reported count is authoritative. A zero or missing count
+  // falls back to the character estimate: models can stream visible reasoning yet
+  // report reasoningTokens = 0, which would otherwise record no reasoning at all.
+  if (typeof usage.reasoningTokens === 'number' && usage.reasoningTokens > 0) return usage;
   const estimated = estimateReasoningTokens(chars, outputTokens);
   return estimated === undefined ? usage : { ...usage, reasoningTokens: estimated };
 }

--- a/electron/src/renderer/components/ContextGrid.tsx
+++ b/electron/src/renderer/components/ContextGrid.tsx
@@ -185,22 +185,16 @@ function computeBreakdown(
       streamingThinkingChars && streamingThinkingChars > 0
         ? Math.round(streamingThinkingChars / 4)
         : 0;
-    const liveOrStreaming = Math.max(providerDelta, streamingTokens);
+    // A positive provider count is authoritative; the thinking-char estimate is
+    // only a fallback for providers that never report reasoning tokens. Taking
+    // the max would let the estimate inflate a turn the provider already counted.
+    const liveOrStreaming = providerDelta > 0 ? providerDelta : streamingTokens;
     const streamingDelta = Math.max(0, streamingTokens - providerDelta);
     const effectiveAssistantTokens = context.assistant_tokens + streamingDelta;
     const effectiveUsedTokens = context.used_tokens + streamingDelta;
     const windowReasoning = persistedReasoning + liveOrStreaming;
-    const hasPersistedReasoningData = messages.some((m) => {
-      const value = m.usage?.reasoning_tokens;
-      return typeof value === 'number' && value >= 0;
-    });
-    const hasProviderReasoningData =
-      persistedReasoning !== 0 ||
-      usageReasoning !== undefined ||
-      contextReasoning !== undefined ||
-      hasPersistedReasoningData;
     let assistant: { response: number; reasoning: number };
-    if (windowReasoning > 0 || hasProviderReasoningData) {
+    if (windowReasoning > 0) {
       const reasoning = Math.min(
         Math.max(0, effectiveAssistantTokens),
         Math.max(0, windowReasoning),
@@ -210,6 +204,12 @@ function computeBreakdown(
         reasoning,
       };
     } else {
+      // No positive provider count. A provider-reported zero is not treated as
+      // authoritative here: models that stream visible thinking but report
+      // reasoning_tokens = 0 would otherwise show no reasoning once the chain
+      // finishes (the live view counts the same thinking via streaming chars).
+      // Fall back to the character-ratio estimate, which yields zero on its own
+      // when there is no visible reasoning text.
       const chars = countMessageChars(messages);
       if (streamingThinkingChars && streamingThinkingChars > 0) {
         chars.reasoning += streamingThinkingChars;

--- a/electron/src/renderer/components/ContextGrid.tsx
+++ b/electron/src/renderer/components/ContextGrid.tsx
@@ -147,7 +147,6 @@ function splitByProviderReasoning(
 function sumPersistedReasoning(messages: readonly Message[]): number {
   let total = 0;
   for (const message of messages) {
-    if (message.hidden) continue;
     const value = message.usage?.reasoning_tokens;
     if (typeof value === 'number' && value >= 0) total += value;
   }

--- a/electron/tests/integration/provider-attempt-accounting.test.ts
+++ b/electron/tests/integration/provider-attempt-accounting.test.ts
@@ -146,6 +146,44 @@ describe('provider attempt accounting middleware', () => {
     expect(ledger.listAttempts('session-1')[0].usage?.reasoningTokens).toBe(40);
   });
 
+  it('estimates reasoning when the provider reports zero but streamed visible thinking', async () => {
+    // Some models stream visible reasoning yet report reasoningTokens = 0. A zero
+    // is not authoritative — otherwise the ledger (and Analytics) would record no
+    // reasoning at all. Fall back to the character estimate; cost still derives
+    // from the provider-reported usage only.
+    const ledger = store();
+    const middleware = createAttemptAccountingMiddleware({
+      store: ledger, sessionId: 'session-1', chainId: 'chain-1', turnId: 'turn-1', snapshot: snapshot(),
+    });
+    const wrapStream = middleware.wrapStream! as unknown as (input: Record<string, unknown>) => Promise<{ stream: ReadableStream<unknown> }>;
+    const result = await wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'reasoning-delta', id: '0', delta: 'r'.repeat(300) });
+            controller.enqueue({ type: 'text-delta', id: '0', delta: 't'.repeat(100) });
+            controller.enqueue({
+              type: 'finish', finishReason: 'stop',
+              usage: {
+                inputTokens: { total: 1000, noCache: 1000, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: 100, text: undefined, reasoning: 0 },
+              },
+            });
+            controller.close();
+          },
+        }),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params: {}, model: {},
+    });
+    await consume(result.stream);
+
+    const attempt = ledger.listAttempts('session-1')[0];
+    expect(attempt.usage?.reasoningTokens).toBe(75);
+    expect(attempt).toMatchObject({ costState: 'calculated', costAmount: '0.0075' });
+  });
+
   it('estimates reasoning tokens for non-streaming generation from content parts', async () => {
     const ledger = store();
     const middleware = createAttemptAccountingMiddleware({

--- a/electron/tests/unit/context-grid.test.ts
+++ b/electron/tests/unit/context-grid.test.ts
@@ -230,6 +230,93 @@ describe('context grid breakdown', () => {
     expect(categories.response).toBe(70);
   });
 
+  it('estimates reasoning from visible thinking when the provider reports zero', () => {
+    // Some models (e.g. GLM) stream visible thinking text but report
+    // reasoning_tokens = 0. The live view counts that thinking via streaming
+    // chars; once the chain finishes the persisted zero must not collapse the
+    // category to 0 — fall back to the character-ratio estimate instead.
+    const thinkingText = 'x'.repeat(24_513);
+    const usage = {
+      prompt_tokens: 96_743,
+      completion_tokens: 3_480,
+      total_tokens: 100_223,
+      cached_tokens: 0,
+      reasoning_tokens: 0,
+      context: {
+        input_tokens: 96_743,
+        output_tokens: 3_480,
+        used_tokens: 100_223,
+        system_tokens: 8_896,
+        tools_tokens: 10_546,
+        tool_use_tokens: 76_680,
+        user_tokens: 32,
+        assistant_tokens: 4_069,
+        reasoning_tokens: 0,
+      },
+    } as const;
+    const usageMessage = {
+      role: 'assistant',
+      content: 'final answer',
+      type: MessageType.TEXT,
+      thinking: null,
+      hidden: false,
+      usage,
+    } as unknown as Message;
+    const thinkingMessage = {
+      role: 'assistant',
+      content: thinkingText,
+      type: MessageType.THINKING,
+      thinking: thinkingText,
+      hidden: false,
+    } as unknown as Message;
+
+    const categories = computeContextCategories(
+      [thinkingMessage, usageMessage], usage, 200_000,
+    );
+
+    expect(categories.reasoning).toBeGreaterThan(0);
+    expect(categories.reasoning + categories.response).toBe(4_069);
+  });
+
+  it('does not inflate a positive provider reasoning count with the streaming estimate', () => {
+    // While a turn is active the provider-reported count (here 500) is
+    // authoritative. The thinking-char estimate (8000 chars -> 2000 tokens)
+    // must not override it, or the live reasoning figure is overstated.
+    const usage = {
+      prompt_tokens: 1_000,
+      completion_tokens: 600,
+      total_tokens: 1_600,
+      cached_tokens: 0,
+      reasoning_tokens: 500,
+      context: {
+        input_tokens: 1_000,
+        output_tokens: 600,
+        used_tokens: 1_600,
+        system_tokens: 100,
+        tools_tokens: 0,
+        tool_use_tokens: 0,
+        user_tokens: 100,
+        assistant_tokens: 3_000,
+        reasoning_tokens: 500,
+      },
+    } as const;
+
+    const html = renderToStaticMarkup(
+      createElement(ContextLegend, {
+        messages: [],
+        usage,
+        maxContext: 100_000,
+        streamingThinkingChars: 8_000,
+        variant: 'panel',
+      }),
+    );
+
+    const reasoningTokens = html.match(
+      /context-panel-label">Reasoning<\/span>.*?context-panel-tokens">([^<]+)</s,
+    )?.[1];
+    expect(reasoningTokens).toBe('500');
+  });
+
   it('excludes hidden messages from every character bucket', () => {
     const hiddenTool = {
       role: 'assistant',

--- a/electron/tests/unit/context-grid.test.ts
+++ b/electron/tests/unit/context-grid.test.ts
@@ -188,6 +188,48 @@ describe('context grid breakdown', () => {
     });
   });
 
+  it('counts reasoning tokens on a hidden usage message after the chain finishes', () => {
+    // When a turn produces no text response (only thinking/tool calls),
+    // finalizeTurn attaches the accumulated usage to a hidden assistant
+    // message. The done event carries the same usage reference, so
+    // isPersistedUsageRef returns true and providerDelta is zeroed.
+    // sumPersistedReasoning must still find the reasoning tokens on the
+    // hidden message — otherwise all assistant tokens are misattributed
+    // to "response" instead of being split between response and reasoning.
+    const usage = {
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+      cached_tokens: 0,
+      reasoning_tokens: 40,
+      context: {
+        input_tokens: 100,
+        output_tokens: 50,
+        used_tokens: 150,
+        system_tokens: 10,
+        tools_tokens: 0,
+        tool_use_tokens: 0,
+        user_tokens: 30,
+        assistant_tokens: 110,
+        reasoning_tokens: 40,
+      },
+    } as const;
+
+    const hiddenUsageMessage = {
+      role: 'assistant',
+      content: '',
+      type: MessageType.TEXT,
+      thinking: null,
+      hidden: true,
+      usage,
+    } as unknown as Message;
+
+    const categories = computeContextCategories([hiddenUsageMessage], usage, 1_000);
+
+    expect(categories.reasoning).toBe(40);
+    expect(categories.response).toBe(70);
+  });
+
   it('excludes hidden messages from every character bucket', () => {
     const hiddenTool = {
       role: 'assistant',


### PR DESCRIPTION
sumPersistedReasoning skipped hidden messages, but finalizeTurn attaches the accumulated usage (including reasoning_tokens) to a hidden assistant message when a turn produces no text response. This caused reasoning tokens to be counted as response tokens after the chain finished, while the live streaming view correctly attributed them — because the live usage object was not yet in the messages array and was picked up via providerDelta.

Remove the hidden-message skip so sumPersistedReasoning aligns with isPersistedUsageRef and hasPersistedReasoningData, which already do not skip hidden messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning-token usage totals by correctly including reasoning tokens from hidden assistant messages.
  * Prevented these tokens from being incorrectly counted as response tokens.

* **Tests**
  * Added regression coverage to verify accurate token categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->