### PR TITLE
Fix/queued message status

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@ Internal backlog for Orchid. User-facing summary lives in the [README known limi
 - Interface may prevent some changes while streaming (Such as model and reasoning level) but the command pallete still allows to execute
 - Interrupted subagents are being marked as complete - possibly after starting a new chain it is not preserved? - but only on some places (subagent view is correct, main agent context and main chat/session UI appears to not be)
 - replace_symbol can left trailing remnants
-- When a queued message is sent, the running session status is broken (Dont show as running) and may lose information
 
 ## Agent quality
 

--- a/electron/src/renderer/hooks/useChat.ts
+++ b/electron/src/renderer/hooks/useChat.ts
@@ -483,10 +483,7 @@ export function useChat(
     // event cannot make them stale before the next animation frame.
     flushStreamFrame();
     dispatchProjection({ type: 'events', actions: [event] });
-    if ('state' in event) {
-      if (event.state === 'idle') isSendingRef.current = false;
-      return;
-    }
+    if ('state' in event) return;
     if (event.type === 'done') {
       setMessages((current) => mergeTerminalTurnMessages(current, event.messages));
       dispatchProjection({ type: 'clear_stream', status: 'idle' });
@@ -499,6 +496,10 @@ export function useChat(
     }
   }, [dispatchProjection, flushStreamFrame]);
   const deliverEvent = useCallback((event: ChatTurnEventAction) => {
+    // Actor idle/interrupted snapshots can straddle the terminal event. They
+    // must not end the renderer turn or claim affinity for the next queued
+    // turn; done/error owns the terminal handoff and authoritative messages.
+    if ('state' in event && (event.state === 'idle' || event.state === 'interrupted')) return;
     if (bufferHydrationEvent(event)) return;
     if (acceptsEvent(event)) applyLiveEvent(event);
   }, [acceptsEvent, applyLiveEvent, bufferHydrationEvent]);

--- a/electron/tests/unit/queue-status-race.test.tsx
+++ b/electron/tests/unit/queue-status-race.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import { useCallback } from 'react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ChatChunkEvent,
+  ChatDoneEvent,
+  ChatStateEvent,
+  ChatUsageEvent,
+} from '../../src/shared/types/ipc';
+import { MessageRole, MessageType, type Message } from '../../src/shared/types/message';
+import { useChat } from '../../src/renderer/hooks/useChat';
+import { useMessageQueue } from '../../src/renderer/hooks/useMessageQueue';
+import { useQueueAutoFire } from '../../src/renderer/hooks/useQueueAutoFire';
+
+const SESSION_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+let onChunk: ((event: ChatChunkEvent) => void) | null;
+let onDone: ((event: ChatDoneEvent) => void) | null;
+let onState: ((event: ChatStateEvent) => void) | null;
+let onUsage: ((event: ChatUsageEvent) => void) | null;
+let resolveQueuedSend:
+  | ((value: { status: 'started'; sessionId: string; turnId: string }) => void)
+  | null;
+let send: ReturnType<typeof vi.fn>;
+
+function textMessage(id: string, role: MessageRole, content: string): Message {
+  return {
+    id,
+    role,
+    content,
+    type: MessageType.TEXT,
+    tool_calls: null,
+    tool_call_id: null,
+    name: null,
+    thinking: null,
+    timestamp: new Date().toISOString(),
+    usage: null,
+    hidden: false,
+    tool_result: null,
+  };
+}
+
+function useQueueRaceHarness() {
+  const chat = useChat(SESSION_ID);
+  const queue = useMessageQueue(SESSION_ID);
+  const sendQueued = useCallback(
+    (message: string) => chat.send(message, { sessionId: SESSION_ID }),
+    [chat.send],
+  );
+  useQueueAutoFire(
+    chat.status,
+    queue.consumeNext,
+    queue.restoreBatch,
+    queue.editingId,
+    sendQueued,
+  );
+  return { chat, queue };
+}
+
+beforeEach(() => {
+  onChunk = null;
+  onDone = null;
+  onState = null;
+  onUsage = null;
+  resolveQueuedSend = null;
+  vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1));
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  send = vi.fn()
+    .mockResolvedValueOnce({ status: 'started', sessionId: SESSION_ID, turnId: 'turn-1' })
+    .mockImplementationOnce(() => new Promise((resolve) => {
+      resolveQueuedSend = resolve;
+    }));
+  window.orchid = {
+    chat: {
+      send,
+      onChunk: vi.fn((callback) => { onChunk = callback; return () => {}; }),
+      onThinking: vi.fn(() => () => {}),
+      onState: vi.fn((callback) => { onState = callback; return () => {}; }),
+      onDone: vi.fn((callback) => { onDone = callback; return () => {}; }),
+      onError: vi.fn(() => () => {}),
+      onUsage: vi.fn((callback) => { onUsage = callback; return () => {}; }),
+      onToolCallStart: vi.fn(() => () => {}),
+      onToolCallDelta: vi.fn(() => () => {}),
+      onToolCallUpdate: vi.fn(() => () => {}),
+    },
+  } as never;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('queued turn status handoff', () => {
+  it('waits for the prior terminal event before auto-firing the queued turn', async () => {
+    const { result } = renderHook(() => useQueueRaceHarness());
+
+    await act(async () => {
+      expect(await result.current.chat.send('first request', { sessionId: SESSION_ID })).toBe(true);
+    });
+    act(() => {
+      result.current.queue.addToQueue('queued follow-up');
+    });
+
+    await act(async () => {
+      onState?.({
+        sessionId: SESSION_ID,
+        turnId: 'turn-1',
+        sequence: 1,
+        state: 'idle',
+        error: null,
+        interruptState: 'idle',
+        cwd: '/project',
+      });
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(result.current.chat.status).toBe('streaming');
+    expect(result.current.queue.queue).toHaveLength(1);
+
+    await act(async () => {
+      onDone?.({
+        sessionId: SESSION_ID,
+        turnId: 'turn-1',
+        sequence: 2,
+        type: 'done',
+        response: 'first answer',
+        messages: [
+          textMessage('user-1', MessageRole.USER, 'first request'),
+          textMessage('assistant-1', MessageRole.ASSISTANT, 'first answer'),
+        ],
+        interrupted: false,
+        usage: null,
+      });
+    });
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      // Cancellation can publish a trailing idle state after CHAT_DONE. It
+      // must not claim affinity while the queued send handshake is pending.
+      onState?.({
+        sessionId: SESSION_ID,
+        turnId: 'turn-1',
+        sequence: 3,
+        state: 'idle',
+        error: null,
+        interruptState: 'idle',
+        cwd: '/project',
+      });
+      onState?.({
+        sessionId: SESSION_ID,
+        turnId: 'turn-2',
+        sequence: 1,
+        state: 'streaming',
+        error: null,
+        interruptState: 'idle',
+        cwd: '/project',
+      });
+      onChunk?.({
+        sessionId: SESSION_ID,
+        turnId: 'turn-2',
+        sequence: 2,
+        type: 'chunk',
+        segmentId: 'queued-answer',
+        data: 'second answer',
+      });
+      onUsage?.({
+        sessionId: SESSION_ID,
+        turnId: 'turn-2',
+        sequence: 3,
+        type: 'usage',
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
+          cached_tokens: 0,
+        },
+      });
+      resolveQueuedSend?.({ status: 'started', sessionId: SESSION_ID, turnId: 'turn-2' });
+    });
+
+    expect(result.current.chat.status).toBe('streaming');
+    expect(result.current.chat.streamingContent).toBe('second answer');
+    expect(result.current.chat.messages.map((message) => message.content)).toEqual([
+      'first request',
+      'first answer',
+      'queued follow-up',
+    ]);
+    expect(result.current.queue.queue).toHaveLength(0);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed queued chat messages being sent prematurely when an idle status update is received.
  - Ensured queued follow-up messages wait until the current response is fully completed.
  - Improved handling of streamed responses, usage details, and message history across queued turns.
  - Prevented trailing status updates from being associated with the wrong conversation turn.
- **Tests**
  - Added regression coverage for queued message status handoff and response sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->