### PR TITLE
Fix #122, #124, #100, #111: subagent state switching, AGENTS.md structure, command widget title, MCP transport toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 electron/node_modules/
 electron/dist/
 electron/release/
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,329 +34,340 @@ The repository-root file `CONCEPTS.md` defines the project's shared domain vocab
 ## Directory Structure
 
 ```
-src/
-├── main/                    # Electron main process
-│   ├── index.ts             # App entry — window creation, lifecycle, shutdown
-│   ├── startup.ts           # Startup snapshot store (phases: starting|ready|degraded|failed)
-│   ├── startup-lifecycle.ts # runStartupLifecycle() — sequential startup steps
-│   ├── agents/              # Agent definitions and subagent orchestration
-│   │   ├── registry.ts      # Load agent definitions (~/.orchid/agents/ + seeded built-ins)
-│   │   ├── defaults/        # Built-in agent definitions (subdirs with marker files)
-│   │   ├── manager.ts       # SubagentManager — spawn/wait/interrupt subagents
-│   │   ├── admission.ts     # Global/per-session admission limits + queue
-│   │   ├── errors.ts        # Subagent error taxonomy
-│   │   ├── types.ts         # Shared subagent types
-│   │   ├── subagent-runner.ts         # Run subagent turns against project runtime
-│   │   ├── subagent-run.ts            # Single run lifecycle
-│   │   ├── subagent-run-assembler.ts  # Assemble run context (prompt, tools, model)
-│   │   ├── subagent-events.ts         # Live event batching knobs
-│   │   ├── subagent-live-projection.ts # Live renderer projection of subagent streams
-│   │   ├── subagent-persistence.ts    # Persist subagent chains (terminal wave batching)
-│   │   ├── subagent-persistence-recovery.ts # Recover chains after crash/restart
-│   │   ├── persist-subagent-chains.ts # Persist subagent chain messages
-│   │   ├── wire-subagents.ts          # Wire subagent lifecycle into manager
-│   │   └── xstate/          # XState machines
-│   │       ├── agent-machine.ts      # Core agent loop (idle→streaming→toolExec→idle)
-│   │       ├── events.ts             # Agent machine event types
-│   │       └── interrupt-machine.ts  # Two-phase Esc cancellation
-│   ├── agents-md/           # AGENTS.md discovery, injection, and write enforcement
-│   │   ├── resolver.ts      # Governing-chain resolver (walk up to workspace root)
-│   │   ├── config.ts        # Defaults + alias normalization
-│   │   ├── inject.ts        # Read-path injection builder
-│   │   └── enforce.ts       # Write-path enforcement evaluator
-│   ├── permissions/         # Tool permission gate + approval flow
-│   │   ├── gate.ts          # checkPermission() — fail-closed pre-handler gate
-│   │   ├── resolver.ts      # Mode resolution: tool-default < project-config < session override
-│   │   ├── evaluator.ts     # `decide-for-me` LLM evaluator (permission-evaluator agent)
-│   │   ├── detection/       # Command risk detection engine
-│   │   │   ├── engine.ts    # Shell-segment analysis, expansion/redirection flags
-│   │   │   ├── packs/filesystem.ts # Destructive/safe filesystem patterns
-│   │   │   └── packs/git.ts # Destructive/safe git patterns
-│   │   ├── approval-store.ts    # Pending approvals, timeouts, owner-window routing
-│   │   ├── session-overrides.ts # Per-session + pre-session draft permission modes
-│   │   └── history.ts       # Recent tool-call history (in-memory, per session+scope)
-│   ├── llm/                 # LLM integration
-│   │   ├── orchestrator.ts  # streamChat() — async generator yielding StreamEvents
-│   │   ├── stream/          # Per-attempt stream plumbing
-│   │   │   ├── events.ts            # StreamEvent union (thinking/content/tool_*/usage/…)
-│   │   │   ├── sdk-event-adapter.ts # Normalize AI SDK parts → StreamEvent
-│   │   │   ├── attempt-controller.ts # Idle watchdog + combined abort signals
-│   │   │   ├── eager-tool-bridge.ts # Feed streamed tool input into EagerToolExecutor
-│   │   │   └── normalized-stream.ts # Unify fullStream/textStream + step-finish drain
-│   │   ├── system-prompt.ts # buildSystemPrompt() — dynamic context injection
-│   │   ├── build-prompt-context.ts # Assemble dynamic per-turn prompt context
-│   │   ├── context-snapshot.ts     # Frozen per-turn context snapshot
-│   │   ├── history.ts       # toApiMessages() — Message[] → AI SDK CoreMessage[]
-│   │   ├── model-messages.ts # toModelMessages() — ApiMessage[] → ModelMessage[]
-│   │   ├── message-factories.ts    # Build AI SDK message objects
-│   │   ├── response-unwrap.ts      # Unwrap provider response shapes
-│   │   ├── reasoning-effort.ts     # Resolve per-turn reasoning effort (session/tier/connection)
-│   │   ├── tool-dispatch.ts # executeToolCall() — permission gate + timeout + output offloading
-│   │   ├── eager-tool-executor.ts # EagerToolExecutor — start tools as their input streams
-│   │   ├── tool-pool.ts     # Tool worker pool singleton (offloadable read-only tools)
-│   │   ├── terminal-result.ts # Canonical error/cancelled tool results without a handler
-│   │   └── middleware/      # AI SDK middleware stack
-│   │       ├── index.ts     # createMiddlewareStack() — retry (+accounting) + throttle
-│   │       ├── retry.ts     # Exponential backoff retry
-│   │       ├── throttle.ts  # Yield rate-limiting
-│   │       ├── provider-quirks.ts  # Tool-output offload thresholds (constants)
-│   │       └── error-classification.ts  # Error types and classification
-│   ├── providers/           # Typed provider connections, drivers, and accounting
-│   │   ├── index.ts         # ProviderRuntime — resolve typed selection + freeze request snapshot
-│   │   ├── resolver.ts      # Resolve {connectionId, modelId} against connections/catalog
-│   │   ├── connection-store.ts # Non-secret connection metadata
-│   │   ├── runtime-context.ts  # Per-request provider runtime context
-│   │   ├── drivers/         # Code-owned origins, auth, protocols, adapters, status parsing
-│   │   │   ├── registry.ts  # Driver registry (origin → driver)
-│   │   │   ├── native.ts    # Specialized provider drivers (owned origins)
-│   │   │   ├── compatible.ts # OpenAI-/Anthropic-compatible custom endpoints
-│   │   │   ├── lilac.ts / neuralwatt.ts / opencode-go.ts # Third-party drivers
-│   │   │   └── types.ts     # Driver interfaces
-│   │   ├── credentials/     # Encrypted vault for API-key secrets (vault.ts)
-│   │   ├── catalog/         # Signed bundled/cached catalog, trust pinning, updater
-│   │   ├── status/          # Provider status cache/service
-│   │   └── accounting/      # SQLite attempt ledger + cost + analytics queries
-│   │       ├── store.ts     # provider_attempts insert/finalize (fail-closed singleton)
-│   │       ├── schema.ts    # Ledger tables (attempts, tool attempts, context snapshots, attribution)
-│   │       ├── cost.ts      # Cost calculation (reported header → token/energy formula)
-│   │       ├── middleware.ts # Attempt accounting middleware (between retry and throttle)
-│   │       ├── tool-attempt-store.ts # Tool invocation telemetry
-│   │       ├── subagent-attribution-store.ts # Subagent chain attribution
-│   │       ├── context-snapshot-store.ts # Per-turn context window snapshots
-│   │       └── analytics-queries.ts # Read-model queries backing the Analytics view
-│   ├── tools/               # Tool registry and built-in tools
-│   │   ├── index.ts         # registerBuiltinTools() — singleton registry setup
-│   │   ├── registry.ts      # ToolRegistry class — register/filter/validate/toJsonSchema
-│   │   ├── types.ts         # ToolDefinition, ToolHandler, RegisteredTool
-│   │   ├── result.ts        # Tool result envelope helpers (AgentProjector)
-│   │   ├── result-retrieval.ts # Retrieve offloaded tool results
-│   │   ├── glob-pattern.ts  # Shared glob matching helper
-│   │   ├── tool-worker.ts   # Worker-thread entry for offloadable tools
-│   │   ├── worker-registry.ts # Registry of tools allowed to run in workers
-│   │   ├── filesystem/      # read, edit, write, read-directory, glob, apply-patch
-│   │   ├── search/          # grep (ripgrep-style)
-│   │   ├── process/         # execute-command, read-output, send-input, terminate
-│   │   │                    # + background-store.ts / foreground-live.ts / head-tail-buffer.ts
-│   │   ├── ast/             # find-symbol-references, get-file-skeleton, get-function,
-│   │   │                    # rename-symbol, replace-symbol, index-tool (+ workers)
-│   │   ├── rag/             # rag-search, rag-index
-│   │   ├── todo/            # create, update, list, delete
-│   │   ├── web/             # fetch
-│   │   ├── skill/           # skill loader
-│   │   ├── mcp/             # MCP resource reader + resource listing
-│   │   ├── ask-question/    # ask_question tool + QuestionStore (agent→user questions)
-│   │   └── subagent/        # delegate, wait, interrupt, answer, close, follow-up, hydrate
-│   ├── ipc/                 # IPC handlers (main process side)
-│   │   ├── index.ts         # registerAllIPC() / unregisterAllIPC()
-│   │   ├── payload-schemas.ts # Zod schemas for IPC payloads
-│   │   ├── chat.ts          # Facade: chat:send/snapshot/stop/cancel/queue_next + bgcmd:*
-│   │   ├── chat/            # Agentic loop internals
-│   │   │   ├── send.ts      # startChatTurn — session single-flight, actors, event flush
-│   │   │   ├── stream.ts    # createProviderStreamFn — freezes runtime snapshot per turn
-│   │   │   ├── events.ts    # Sequenced turn/session event broadcast
-│   │   │   ├── state.ts     # ActiveAgent registry (messages, tool calls, generations)
-│   │   │   ├── snapshot.ts  # Live chat snapshot builder
-│   │   │   ├── persist.ts   # Debounced checkpoints + turn persistence
-│   │   │   ├── abort.ts     # Force-abort / dispose paths
-│   │   │   ├── session.ts   # ensureActiveSession (workspace resolve + trust gate)
-│   │   │   └── title.ts     # Auto-naming via internal session-namer
-│   │   ├── next-request-stop.ts # Stop the next request at the next step boundary
-│   │   ├── chat-history.ts  # chat history helpers
-│   │   ├── config.ts        # config:get, config:save
-│   │   ├── permission.ts    # Approval IPC + session permission mode
-│   │   ├── ask-question.ts  # ask_question IPC (asked/answered/settled)
-│   │   ├── trust.ts         # Trusted-project grant/revoke IPC
-│   │   ├── startup.ts       # Startup snapshot IPC (startup:snapshot/changed/continueDegraded)
-│   │   ├── analytics.ts     # Analytics read-model IPC (analytics:*)
-│   │   ├── session.ts       # session CRUD / workspace bind / trust revocation
-│   │   ├── session-activity.ts # session activity events
-│   │   ├── session-working-set.ts # working-set IPC
-│   │   ├── tool.ts          # tool:execute
-│   │   ├── definitions.ts   # agents/skills/personalities listing
-│   │   ├── subagents.ts     # subagent listing / detail IPC
-│   │   ├── providers.ts     # provider connection CRUD / models / status
-│   │   ├── mcp.ts           # mcp:status
-│   │   ├── rag.ts           # rag:status, rag:index, rag:clear
-│   │   └── ast.ts           # ast:status, ast:index
-│   ├── config/              # Configuration system
-│   │   ├── schema.ts        # Zod schemas — single source of truth for config fields
-│   │   ├── index.ts         # Public config surface
-│   │   ├── loader.ts        # ensureHomeConfig(), ConfigManager — ~/.orchid/ management
-│   │   ├── merge.ts         # Deep merge for project + user configs
-│   │   ├── validation.ts    # Config validation utilities
-│   │   └── write-lock.ts    # Config write serialization
-│   ├── session/             # Session persistence (SQLite)
-│   │   ├── manager.ts       # SessionManager — CRUD, auto-naming
-│   │   ├── db.ts            # ~/.orchid/sessions.db connection (WAL, corruption recovery)
-│   │   ├── schema.ts        # sessions/chains/subagent_chains schema v2
-│   │   ├── storage.ts       # Persistence operations against the session DB
-│   │   ├── singleton.ts     # getSessionManager() + resolveWindowWorkspace
-│   │   ├── draft-reasoning.ts # Pre-session reasoning-effort drafts (per window)
-│   │   ├── activity.ts      # Session activity tracking
-│   │   ├── agents-md-context.ts # Per-session AGENTS.md context tracker (in-memory)
-│   │   └── working-set.ts   # Session working-set (open tabs) tracking
-│   ├── project/             # Workspace binding (session cwd / sticky default)
-│   │   ├── path.ts          # inspect/canonicalize absolute project directories
-│   │   ├── workspace.ts     # draft cwd, sticky default_project_dir, resolveWorkspace*
-│   │   ├── runtime.ts       # ProjectRuntime — config + agents/skills/personalities overlays
-│   │   ├── agents-md.ts     # Root AGENTS.md injection + subagent root seeding
-│   │   ├── personality.ts   # project personality helpers
-│   │   └── trust.ts         # Trusted-project store + fingerprint drift detection
-│   ├── mcp/                 # Model Context Protocol client
-│   │   ├── manager.ts       # MCPManager — start/stop/call/list tools
-│   │   ├── project-registry.ts # Leased per-project managers (trust-gated, lease-counted)
-│   │   ├── schema.ts        # MCPServerConfig types
-│   │   └── transport.ts     # StdioClientTransport wrapper
-│   ├── rag/                 # Retrieval-Augmented Generation
-│   │   ├── chunker.ts       # Text chunking with overlap
-│   │   ├── embedder.ts      # ONNX-based local embedding (fastembed) or API embedder
-│   │   ├── indexer.ts       # File indexing pipeline
-│   │   ├── index-worker.ts  # Worker-thread indexing
-│   │   └── store.ts         # SQLite-backed vector store
-│   ├── ast/                 # Abstract Syntax Tree indexing
-│   │   ├── indexer.ts       # Tree-sitter based code indexing
-│   │   ├── index-worker.ts  # Worker-thread indexing
-│   │   ├── parser.ts        # Tree-sitter parser management
-│   │   ├── queries/         # Tree-sitter query files (.scm, copied by copy-defaults)
-│   │   └── store.ts         # SQLite-backed symbol store
-│   ├── defs/                # Definition file management (agents/skills/personalities)
-│   │   ├── manage.ts        # Create/update/delete definition files
-│   │   ├── paths.ts         # Resolve definition storage paths
-│   │   └── reload.ts        # Reload definitions on change
-│   ├── personality/         # Personality system
-│   │   ├── registry.ts      # loadPersonalities()
-│   │   └── defaults/        # Built-in personalities
-│   ├── skills/              # Skill system
-│   │   ├── registry.ts      # loadSkills() from ~/.orchid/skills/ (built-ins seeded)
-│   │   └── defaults/        # Built-in skills (subdirs with SKILL.md markers)
-│   ├── logging.ts           # FileLogger — ~/.orchid/logs/orchid.log
-│   ├── updater.ts           # Auto-update via electron-updater (events: updater:status_update, updater:progress, updater:error)
-│   └── utils/               # Shared helpers
-│       ├── esm-import.ts    # importESM() — dynamic ESM import for CJS context
-│       ├── sqlite.ts        # Shared SQLite open/WAL/corruption-recovery helper
-│       ├── worker-pool.ts   # Two-lane (main/subagent) worker pool
-│       ├── write-lock.ts    # Generic write-lock helper
-│       ├── seed-defaults.ts # Seed built-in definition subdirs into ~/.orchid/
-│       ├── async.ts / safe-fsync.ts / with-disposable.ts
-├── preload/
-│   └── index.ts             # contextBridge API — window.orchid.* surface
-├── renderer/                # React UI (Vite-bundled)
-│   ├── App.tsx              # Root — startup gate; renders StartupScreen until phase=ready
-│   ├── AppReady.tsx         # Post-startup shell — config load, views, onboarding
-│   ├── main.tsx             # ReactDOM.createRoot entry
-│   ├── index.html           # HTML shell
-│   ├── components/
-│   │   ├── ChatView.tsx     # Main layout — SessionTabBar + LeftSidebar + chat + inspector
-│   │   ├── LeftSidebar.tsx  # Workspace chip, search, project-grouped session list
-│   │   ├── Sidebar.tsx      # Right inspector — Todos, Subagents, Commands, Context, Usage,
-│   │   │                    # Workspace Index, MCP Servers
-│   │   ├── SessionTabBar.tsx # Open-session tab strip (working-set backed)
-│   │   ├── ChatStream.tsx   # Message list with smart auto-scroll
-│   │   ├── InputArea.tsx    # Text input + send button
-│   │   ├── MessageQueue.tsx # Queued follow-up messages (next-request / chain-end)
-│   │   ├── Footer.tsx       # Model name + token usage + elapsed time
-│   │   ├── MessageWidget.tsx # Individual message rendering
-│   │   ├── MarkdownContent.tsx # Markdown rendering
-│   │   ├── CommandPalette.tsx # Cmd+K command palette
-│   │   ├── SlashCommandMenu.tsx # Inline slash-command menu
-│   │   ├── ShortcutsHelp.tsx # Keyboard shortcut reference
-│   │   ├── ContextGrid.tsx  # Context window usage visualization
-│   │   ├── ConfigView.tsx   # Full-screen configuration UI
-│   │   ├── ProjectConfigView.tsx # Project-level config editor (.orchid.json)
-│   │   ├── AnalyticsView.tsx # Usage/cost analytics (tabs: Overview, Sessions,
-│   │   │                    # Models & Providers, Tools, Subagents, Context)
-│   │   ├── StartupScreen.tsx # Startup progress phases/steps
-│   │   ├── ModelPicker.tsx  # Connection/model selection
-│   │   ├── ReasoningSelector.tsx # Per-session reasoning effort picker
-│   │   ├── PermissionApprovalPanel.tsx # Pending tool-approval UI
-│   │   ├── PermissionSelector.tsx # Session permission mode selector
-│   │   ├── AskQuestionOverlay.tsx # Agent ask_question UI
-│   │   ├── TrustProjectDialog.tsx # Trust grant surface-diff report
-│   │   ├── SubagentView.tsx / SubagentTranscript.tsx # Subagent detail views
-│   │   ├── ToolResults/     # Tool result widgets by family (+ registry)
-│   │   ├── ToolWidgets/     # Tool call activity widgets (live command output)
-│   │   ├── ui/              # Typed primitives (Button, TextInput, Select, Tabs, …)
-│   │   ├── Preferences/     # Settings tab panels (used by ConfigView)
-│   │   ├── Providers/       # Connection list/wizard/models/status
-│   │   └── Onboarding/      # First-run setup wizard
-│   ├── hooks/
-│   │   ├── useChat.ts       # Chat state machine (projection, streaming, send/cancel)
-│   │   ├── useSession.ts    # Session CRUD operations
-│   │   ├── useSessionTabs.ts # Working-set backed session tabs
-│   │   ├── useSessionActivity.ts # Session activity state
-│   │   ├── useSubagents.ts  # Subagent list/detail polling
-│   │   ├── useTodos.ts      # Todo list state
-│   │   ├── useProviders.ts  # Provider connections/models state
-│   │   ├── useAnalytics.ts  # Analytics query state + time range
-│   │   ├── useMessageQueue.ts / useQueueAutoFire.ts # Message queue + auto-fire
-│   │   ├── usePermissionApproval.ts # Approval request state
-│   │   ├── useAskQuestion.ts # ask_question state
-│   │   ├── useBackgroundCommands.ts # Background command fleet state
-│   │   ├── useLiveCommandOutput.ts # Foreground/background command output streaming
-│   │   ├── useSmartAutoScroll.ts # Viewport pinning with scroll-away suspension
-│   │   ├── use-responsive-shell.ts # Panel collapse state by width
-│   │   └── useTrustPrompt.ts / useTimeRange.ts
-│   ├── keyboard/            # Shortcut subsystem
-│   │   ├── registry.ts      # SHORTCUTS source of truth + formatting helpers
-│   │   ├── match.ts         # Chord matching (mod/shift/alt, editable-target awareness)
-│   │   ├── types.ts         # KeyChord / ShortcutDef
-│   │   ├── useGlobalShortcuts.ts # Single window keydown dispatcher
-│   │   ├── useFocusTrap.ts  # Modal focus trap (stacked)
-│   │   └── useRovingListIndex.ts # Arrow-key list navigation
-│   ├── commands/
-│   │   └── registry.ts      # Client-side slash commands
-│   ├── themes/              # CSS theme files
-│   │   ├── index.ts         # Theme registry and applyTheme()
-│   │   ├── default.css      # Dark theme (default)
-│   │   ├── light.css
-│   │   ├── bluey.css
-│   │   ├── green-terminal.css
-│   │   ├── solarized-light.css
-│   │   └── windows-xp.css
-│   ├── styles/
-│   │   ├── index.css        # Canonical import order + Tailwind + design tokens
-│   │   ├── primitives.css   # Orchid primitive engine (component roots, theme tokens)
-│   │   ├── components.css   # orchid-* composites (@layer orchid) — base
-│   │   ├── components-chat.css / components-session.css / components-config.css
-│   │   │                    # Surface-area splits of the composite layer
-│   │   ├── shell.css        # App shell geometry
-│   │   ├── motion.css       # Shared motion vocabulary (orchid-* transitions)
-│   │   ├── markdown.css     # Markdown rendering styles
-│   │   ├── exceptions.css   # Scoped style exceptions
-│   │   └── README.md        # Styling contract documentation
-│   └── utils/               # Presentation/state helpers (config drafts, grouping,
-│                            # provider selection, stream building, subagent stream, …)
-└── shared/                  # Shared types between main/preload/renderer
-    ├── types/
-    │   ├── ipc.ts           # IPC channel names, message types, OrchidAPI interface
-    │   ├── ipc-boundary.ts  # Config, Session, Model, MCP types shared across boundary
-    │   ├── ipc-schemas.ts   # Zod schemas for IPC payloads
-    │   ├── message.ts       # Message, Usage, MessageRole, MessageType
-    │   ├── session.ts       # Session, SessionSummary
-    │   ├── chain.ts         # Chain (conversation thread) types
-    │   ├── agent.ts         # Agent definition type
-    │   ├── agent-scope.ts   # Agent scope identity (main vs subagent)
-    │   ├── skill.ts         # Skill definition type
-    │   ├── tool.ts          # ToolCall type
-    │   ├── tool-result.ts   # Canonical tool result envelope types
-    │   ├── tool-result-filesystem.ts / tool-result-apply-patch.ts
-    │   ├── subagent.ts      # Subagent types
-    │   ├── todo.ts          # TodoItem, TodoStatus
-    │   ├── permission.ts    # Permission modes + risk classes
-    │   ├── provider.ts      # ModelSelection + provider connection types
-    │   ├── accounting.ts    # Attempt ledger types
-    │   ├── analytics.ts     # Analytics read-model types
-    │   └── definitions.ts   # Definition (agent/skill/personality) types
-    ├── chat/
-    │   └── turn-projection.ts # Pure reducer: IPC turn events → renderer projection
-    ├── mcp/
-    │   └── recommended-servers.ts # Recommended MCP servers (onboarding opt-in)
-    ├── serialization/
-    │   └── chain-subagent.ts # Chain/subagent serialization helpers
-    ├── commands.ts          # Shared command types + fuzzy-match utilities (definitions live in renderer)
-    ├── usage.ts             # Usage accounting helpers
-    └── utils/
-        └── frontmatter.ts   # YAML frontmatter parser for agent/skill files
+electron/
+├── src/
+│   ├── main/                    # Electron main process
+│   │   ├── index.ts             # App entry — window creation, lifecycle, shutdown
+│   │   ├── startup.ts           # Startup snapshot store (phases: starting|ready|degraded|failed)
+│   │   ├── startup-lifecycle.ts # runStartupLifecycle() — sequential startup steps
+│   │   ├── agents/              # Agent definitions and subagent orchestration
+│   │   │   ├── registry.ts      # Load agent definitions (~/.orchid/agents/ + seeded built-ins)
+│   │   │   ├── defaults/        # Built-in agent definitions (subdirs with marker files)
+│   │   │   ├── manager.ts       # SubagentManager — spawn/wait/interrupt subagents
+│   │   │   ├── admission.ts     # Global/per-session admission limits + queue
+│   │   │   ├── errors.ts        # Subagent error taxonomy
+│   │   │   ├── types.ts         # Shared subagent types
+│   │   │   ├── subagent-runner.ts         # Run subagent turns against project runtime
+│   │   │   ├── subagent-run.ts            # Single run lifecycle
+│   │   │   ├── subagent-run-assembler.ts  # Assemble run context (prompt, tools, model)
+│   │   │   ├── subagent-events.ts         # Live event batching knobs
+│   │   │   ├── subagent-live-projection.ts # Live renderer projection of subagent streams
+│   │   │   ├── subagent-persistence.ts    # Persist subagent chains (terminal wave batching)
+│   │   │   ├── subagent-persistence-recovery.ts # Recover chains after crash/restart
+│   │   │   ├── persist-subagent-chains.ts # Persist subagent chain messages
+│   │   │   ├── wire-subagents.ts          # Wire subagent lifecycle into manager
+│   │   │   └── xstate/          # XState machines
+│   │   │       ├── agent-machine.ts      # Core agent loop (idle→streaming→toolExec→idle)
+│   │   │       ├── events.ts             # Agent machine event types
+│   │   │       └── interrupt-machine.ts  # Two-phase Esc cancellation
+│   │   ├── agents-md/           # AGENTS.md discovery, injection, and write enforcement
+│   │   │   ├── resolver.ts      # Governing-chain resolver (walk up to workspace root)
+│   │   │   ├── config.ts        # Defaults + alias normalization
+│   │   │   ├── inject.ts        # Read-path injection builder
+│   │   │   └── enforce.ts       # Write-path enforcement evaluator
+│   │   ├── permissions/         # Tool permission gate + approval flow
+│   │   │   ├── gate.ts          # checkPermission() — fail-closed pre-handler gate
+│   │   │   ├── resolver.ts      # Mode resolution: tool-default < project-config < session override
+│   │   │   ├── evaluator.ts     # `decide-for-me` LLM evaluator (permission-evaluator agent)
+│   │   │   ├── detection/       # Command risk detection engine
+│   │   │   │   ├── engine.ts    # Shell-segment analysis, expansion/redirection flags
+│   │   │   │   ├── packs/filesystem.ts # Destructive/safe filesystem patterns
+│   │   │   │   └── packs/git.ts # Destructive/safe git patterns
+│   │   │   ├── approval-store.ts    # Pending approvals, timeouts, owner-window routing
+│   │   │   ├── session-overrides.ts # Per-session + pre-session draft permission modes
+│   │   │   └── history.ts       # Recent tool-call history (in-memory, per session+scope)
+│   │   ├── llm/                 # LLM integration
+│   │   │   ├── orchestrator.ts  # streamChat() — async generator yielding StreamEvents
+│   │   │   ├── stream/          # Per-attempt stream plumbing
+│   │   │   │   ├── events.ts            # StreamEvent union (thinking/content/tool_*/usage/…)
+│   │   │   │   ├── sdk-event-adapter.ts # Normalize AI SDK parts → StreamEvent
+│   │   │   │   ├── attempt-controller.ts # Idle watchdog + combined abort signals
+│   │   │   │   ├── eager-tool-bridge.ts # Feed streamed tool input into EagerToolExecutor
+│   │   │   │   └── normalized-stream.ts # Unify fullStream/textStream + step-finish drain
+│   │   │   ├── system-prompt.ts # buildSystemPrompt() — dynamic context injection
+│   │   │   ├── build-prompt-context.ts # Assemble dynamic per-turn prompt context
+│   │   │   ├── context-snapshot.ts     # Frozen per-turn context snapshot
+│   │   │   ├── history.ts       # toApiMessages() — Message[] → AI SDK CoreMessage[]
+│   │   │   ├── model-messages.ts # toModelMessages() — ApiMessage[] → ModelMessage[]
+│   │   │   ├── message-factories.ts    # Build AI SDK message objects
+│   │   │   ├── response-unwrap.ts      # Unwrap provider response shapes
+│   │   │   ├── reasoning-effort.ts     # Resolve per-turn reasoning effort (session/tier/connection)
+│   │   │   ├── tool-dispatch.ts # executeToolCall() — permission gate + timeout + output offloading
+│   │   │   ├── eager-tool-executor.ts # EagerToolExecutor — start tools as their input streams
+│   │   │   ├── tool-pool.ts     # Tool worker pool singleton (offloadable read-only tools)
+│   │   │   ├── terminal-result.ts # Canonical error/cancelled tool results without a handler
+│   │   │   └── middleware/      # AI SDK middleware stack
+│   │   │       ├── index.ts     # createMiddlewareStack() — retry (+accounting) + throttle
+│   │   │       ├── retry.ts     # Exponential backoff retry
+│   │   │       ├── throttle.ts  # Yield rate-limiting
+│   │   │       ├── provider-quirks.ts  # Tool-output offload thresholds (constants)
+│   │   │       └── error-classification.ts  # Error types and classification
+│   │   ├── providers/           # Typed provider connections, drivers, and accounting
+│   │   │   ├── index.ts         # ProviderRuntime — resolve typed selection + freeze request snapshot
+│   │   │   ├── resolver.ts      # Resolve {connectionId, modelId} against connections/catalog
+│   │   │   ├── connection-store.ts # Non-secret connection metadata
+│   │   │   ├── runtime-context.ts  # Per-request provider runtime context
+│   │   │   ├── drivers/         # Code-owned origins, auth, protocols, adapters, status parsing
+│   │   │   │   ├── registry.ts  # Driver registry (origin → driver)
+│   │   │   │   ├── native.ts    # Specialized provider drivers (owned origins)
+│   │   │   │   ├── compatible.ts # OpenAI-/Anthropic-compatible custom endpoints
+│   │   │   │   ├── lilac.ts / neuralwatt.ts / opencode-go.ts # Third-party drivers
+│   │   │   │   └── types.ts     # Driver interfaces
+│   │   │   ├── credentials/     # Encrypted vault for API-key secrets (vault.ts)
+│   │   │   ├── catalog/         # Signed bundled/cached catalog, trust pinning, updater
+│   │   │   ├── status/          # Provider status cache/service
+│   │   │   └── accounting/      # SQLite attempt ledger + cost + analytics queries
+│   │   │       ├── store.ts     # provider_attempts insert/finalize (fail-closed singleton)
+│   │   │       ├── schema.ts    # Ledger tables (attempts, tool attempts, context snapshots, attribution)
+│   │   │       ├── cost.ts      # Cost calculation (reported header → token/energy formula)
+│   │   │       ├── middleware.ts # Attempt accounting middleware (between retry and throttle)
+│   │   │       ├── tool-attempt-store.ts # Tool invocation telemetry
+│   │   │       ├── subagent-attribution-store.ts # Subagent chain attribution
+│   │   │       ├── context-snapshot-store.ts # Per-turn context window snapshots
+│   │   │       └── analytics-queries.ts # Read-model queries backing the Analytics view
+│   │   ├── tools/               # Tool registry and built-in tools
+│   │   │   ├── index.ts         # registerBuiltinTools() — singleton registry setup
+│   │   │   ├── registry.ts      # ToolRegistry class — register/filter/validate/toJsonSchema
+│   │   │   ├── types.ts         # ToolDefinition, ToolHandler, RegisteredTool
+│   │   │   ├── result.ts        # Tool result envelope helpers (AgentProjector)
+│   │   │   ├── result-retrieval.ts # Retrieve offloaded tool results
+│   │   │   ├── glob-pattern.ts  # Shared glob matching helper
+│   │   │   ├── tool-worker.ts   # Worker-thread entry for offloadable tools
+│   │   │   ├── worker-registry.ts # Registry of tools allowed to run in workers
+│   │   │   ├── filesystem/      # read, edit, write, read-directory, glob, apply-patch
+│   │   │   ├── search/          # grep (ripgrep-style)
+│   │   │   ├── process/         # execute-command, read-output, send-input, terminate
+│   │   │   │                    # + background-store.ts / foreground-live.ts / head-tail-buffer.ts
+│   │   │   ├── ast/             # find-symbol-references, get-file-skeleton, get-function,
+│   │   │   │                    # rename-symbol, replace-symbol, index-tool (+ workers)
+│   │   │   ├── rag/             # rag-search, rag-index
+│   │   │   ├── todo/            # create, update, list, delete
+│   │   │   ├── web/             # fetch
+│   │   │   ├── skill/           # skill loader
+│   │   │   ├── mcp/             # MCP resource reader + resource listing
+│   │   │   ├── ask-question/    # ask_question tool + QuestionStore (agent→user questions)
+│   │   │   └── subagent/        # delegate, wait, interrupt, answer, close, follow-up, hydrate
+│   │   ├── ipc/                 # IPC handlers (main process side)
+│   │   │   ├── index.ts         # registerAllIPC() / unregisterAllIPC()
+│   │   │   ├── payload-schemas.ts # Zod schemas for IPC payloads
+│   │   │   ├── chat.ts          # Facade: chat:send/snapshot/stop/cancel/queue_next + bgcmd:*
+│   │   │   ├── chat/            # Agentic loop internals
+│   │   │   │   ├── send.ts      # startChatTurn — session single-flight, actors, event flush
+│   │   │   │   ├── stream.ts    # createProviderStreamFn — freezes runtime snapshot per turn
+│   │   │   │   ├── events.ts    # Sequenced turn/session event broadcast
+│   │   │   │   ├── state.ts     # ActiveAgent registry (messages, tool calls, generations)
+│   │   │   │   ├── snapshot.ts  # Live chat snapshot builder
+│   │   │   │   ├── persist.ts   # Debounced checkpoints + turn persistence
+│   │   │   │   ├── abort.ts     # Force-abort / dispose paths
+│   │   │   │   ├── session.ts   # ensureActiveSession (workspace resolve + trust gate)
+│   │   │   │   └── title.ts     # Auto-naming via internal session-namer
+│   │   │   ├── next-request-stop.ts # Stop the next request at the next step boundary
+│   │   │   ├── chat-history.ts  # chat history helpers
+│   │   │   ├── config.ts        # config:get, config:save
+│   │   │   ├── permission.ts    # Approval IPC + session permission mode
+│   │   │   ├── ask-question.ts  # ask_question IPC (asked/answered/settled)
+│   │   │   ├── trust.ts         # Trusted-project grant/revoke IPC
+│   │   │   ├── startup.ts       # Startup snapshot IPC (startup:snapshot/changed/continueDegraded)
+│   │   │   ├── analytics.ts     # Analytics read-model IPC (analytics:*)
+│   │   │   ├── session.ts       # session CRUD / workspace bind / trust revocation
+│   │   │   ├── session-activity.ts # session activity events
+│   │   │   ├── session-working-set.ts # working-set IPC
+│   │   │   ├── tool.ts          # tool:execute
+│   │   │   ├── definitions.ts   # agents/skills/personalities listing
+│   │   │   ├── subagents.ts     # subagent listing / detail IPC
+│   │   │   ├── providers.ts     # provider connection CRUD / models / status
+│   │   │   ├── mcp.ts           # mcp:status
+│   │   │   ├── rag.ts           # rag:status, rag:index, rag:clear
+│   │   │   └── ast.ts           # ast:status, ast:index
+│   │   ├── config/              # Configuration system
+│   │   │   ├── schema.ts        # Zod schemas — single source of truth for config fields
+│   │   │   ├── index.ts         # Public config surface
+│   │   │   ├── loader.ts        # ensureHomeConfig(), ConfigManager — ~/.orchid/ management
+│   │   │   ├── merge.ts         # Deep merge for project + user configs
+│   │   │   ├── validation.ts    # Config validation utilities
+│   │   │   └── write-lock.ts    # Config write serialization
+│   │   ├── session/             # Session persistence (SQLite)
+│   │   │   ├── manager.ts       # SessionManager — CRUD, auto-naming
+│   │   │   ├── db.ts            # ~/.orchid/sessions.db connection (WAL, corruption recovery)
+│   │   │   ├── schema.ts        # sessions/chains/subagent_chains schema v2
+│   │   │   ├── storage.ts       # Persistence operations against the session DB
+│   │   │   ├── singleton.ts     # getSessionManager() + resolveWindowWorkspace
+│   │   │   ├── draft-reasoning.ts # Pre-session reasoning-effort drafts (per window)
+│   │   │   ├── activity.ts      # Session activity tracking
+│   │   │   ├── agents-md-context.ts # Per-session AGENTS.md context tracker (in-memory)
+│   │   │   └── working-set.ts   # Session working-set (open tabs) tracking
+│   │   ├── project/             # Workspace binding (session cwd / sticky default)
+│   │   │   ├── path.ts          # inspect/canonicalize absolute project directories
+│   │   │   ├── workspace.ts     # draft cwd, sticky default_project_dir, resolveWorkspace*
+│   │   │   ├── runtime.ts       # ProjectRuntime — config + agents/skills/personalities overlays
+│   │   │   ├── agents-md.ts     # Root AGENTS.md injection + subagent root seeding
+│   │   │   ├── personality.ts   # project personality helpers
+│   │   │   └── trust.ts         # Trusted-project store + fingerprint drift detection
+│   │   ├── mcp/                 # Model Context Protocol client
+│   │   │   ├── manager.ts       # MCPManager — start/stop/call/list tools
+│   │   │   ├── project-registry.ts # Leased per-project managers (trust-gated, lease-counted)
+│   │   │   ├── schema.ts        # MCPServerConfig types
+│   │   │   └── transport.ts     # StdioClientTransport wrapper
+│   │   ├── rag/                 # Retrieval-Augmented Generation
+│   │   │   ├── chunker.ts       # Text chunking with overlap
+│   │   │   ├── embedder.ts      # ONNX-based local embedding (fastembed) or API embedder
+│   │   │   ├── indexer.ts       # File indexing pipeline
+│   │   │   ├── index-worker.ts  # Worker-thread indexing
+│   │   │   └── store.ts         # SQLite-backed vector store
+│   │   ├── ast/                 # Abstract Syntax Tree indexing
+│   │   │   ├── indexer.ts       # Tree-sitter based code indexing
+│   │   │   ├── index-worker.ts  # Worker-thread indexing
+│   │   │   ├── parser.ts        # Tree-sitter parser management
+│   │   │   ├── queries/         # Tree-sitter query files (.scm, copied by copy-defaults)
+│   │   │   └── store.ts         # SQLite-backed symbol store
+│   │   ├── defs/                # Definition file management (agents/skills/personalities)
+│   │   │   ├── manage.ts        # Create/update/delete definition files
+│   │   │   ├── paths.ts         # Resolve definition storage paths
+│   │   │   └── reload.ts        # Reload definitions on change
+│   │   ├── personality/         # Personality system
+│   │   │   ├── registry.ts      # loadPersonalities()
+│   │   │   └── defaults/        # Built-in personalities
+│   │   ├── skills/              # Skill system
+│   │   │   ├── registry.ts      # loadSkills() from ~/.orchid/skills/ (built-ins seeded)
+│   │   │   └── defaults/        # Built-in skills (subdirs with SKILL.md markers)
+│   │   ├── logging.ts           # FileLogger — ~/.orchid/logs/orchid.log
+│   │   ├── updater.ts           # Auto-update via electron-updater (events: updater:status_update, updater:progress, updater:error)
+│   │   └── utils/               # Shared helpers
+│   │       ├── esm-import.ts    # importESM() — dynamic ESM import for CJS context
+│   │       ├── sqlite.ts        # Shared SQLite open/WAL/corruption-recovery helper
+│   │       ├── worker-pool.ts   # Two-lane (main/subagent) worker pool
+│   │       ├── write-lock.ts    # Generic write-lock helper
+│   │       ├── seed-defaults.ts # Seed built-in definition subdirs into ~/.orchid/
+│   │       ├── async.ts / safe-fsync.ts / with-disposable.ts
+│   ├── preload/
+│   │   └── index.ts             # contextBridge API — window.orchid.* surface
+│   ├── renderer/                # React UI (Vite-bundled)
+│   │   ├── App.tsx              # Root — startup gate; renders StartupScreen until phase=ready
+│   │   ├── AppReady.tsx         # Post-startup shell — config load, views, onboarding
+│   │   ├── main.tsx             # ReactDOM.createRoot entry
+│   │   ├── index.html           # HTML shell
+│   │   ├── components/
+│   │   │   ├── ChatView.tsx     # Main layout — SessionTabBar + LeftSidebar + chat + inspector
+│   │   │   ├── LeftSidebar.tsx  # Workspace chip, search, project-grouped session list
+│   │   │   ├── Sidebar.tsx      # Right inspector — Todos, Subagents, Commands, Context, Usage,
+│   │   │   │                    # Workspace Index, MCP Servers
+│   │   │   ├── SessionTabBar.tsx # Open-session tab strip (working-set backed)
+│   │   │   ├── ChatStream.tsx   # Message list with smart auto-scroll
+│   │   │   ├── InputArea.tsx    # Text input + send button
+│   │   │   ├── MessageQueue.tsx # Queued follow-up messages (next-request / chain-end)
+│   │   │   ├── Footer.tsx       # Model name + token usage + elapsed time
+│   │   │   ├── MessageWidget.tsx # Individual message rendering
+│   │   │   ├── MarkdownContent.tsx # Markdown rendering
+│   │   │   ├── CommandPalette.tsx # Cmd+K command palette
+│   │   │   ├── SlashCommandMenu.tsx # Inline slash-command menu
+│   │   │   ├── ShortcutsHelp.tsx # Keyboard shortcut reference
+│   │   │   ├── ContextGrid.tsx  # Context window usage visualization
+│   │   │   ├── ConfigView.tsx   # Full-screen configuration UI
+│   │   │   ├── ProjectConfigView.tsx # Project-level config editor (.orchid.json)
+│   │   │   ├── AnalyticsView.tsx # Usage/cost analytics (tabs: Overview, Sessions,
+│   │   │   │                    # Models & Providers, Tools, Subagents, Context)
+│   │   │   ├── StartupScreen.tsx # Startup progress phases/steps
+│   │   │   ├── ModelPicker.tsx  # Connection/model selection
+│   │   │   ├── ReasoningSelector.tsx # Per-session reasoning effort picker
+│   │   │   ├── PermissionApprovalPanel.tsx # Pending tool-approval UI
+│   │   │   ├── PermissionSelector.tsx # Session permission mode selector
+│   │   │   ├── AskQuestionOverlay.tsx # Agent ask_question UI
+│   │   │   ├── TrustProjectDialog.tsx # Trust grant surface-diff report
+│   │   │   ├── SubagentView.tsx / SubagentTranscript.tsx # Subagent detail views
+│   │   │   ├── ToolResults/     # Tool result widgets by family (+ registry)
+│   │   │   ├── ToolWidgets/     # Tool call activity widgets (live command output)
+│   │   │   ├── ui/              # Typed primitives (Button, TextInput, Select, Tabs, …)
+│   │   │   ├── Preferences/     # Settings tab panels (used by ConfigView)
+│   │   │   ├── Providers/       # Connection list/wizard/models/status
+│   │   │   └── Onboarding/      # First-run setup wizard
+│   │   ├── hooks/
+│   │   │   ├── useChat.ts       # Chat state machine (projection, streaming, send/cancel)
+│   │   │   ├── useSession.ts    # Session CRUD operations
+│   │   │   ├── useSessionTabs.ts # Working-set backed session tabs
+│   │   │   ├── useSessionActivity.ts # Session activity state
+│   │   │   ├── useSubagents.ts  # Subagent list/detail polling
+│   │   │   ├── useTodos.ts      # Todo list state
+│   │   │   ├── useProviders.ts  # Provider connections/models state
+│   │   │   ├── useAnalytics.ts  # Analytics query state + time range
+│   │   │   ├── useMessageQueue.ts / useQueueAutoFire.ts # Message queue + auto-fire
+│   │   │   ├── usePermissionApproval.ts # Approval request state
+│   │   │   ├── useAskQuestion.ts # ask_question state
+│   │   │   ├── useBackgroundCommands.ts # Background command fleet state
+│   │   │   ├── useLiveCommandOutput.ts # Foreground/background command output streaming
+│   │   │   ├── useSmartAutoScroll.ts # Viewport pinning with scroll-away suspension
+│   │   │   ├── use-responsive-shell.ts # Panel collapse state by width
+│   │   │   └── useTrustPrompt.ts / useTimeRange.ts
+│   │   ├── keyboard/            # Shortcut subsystem
+│   │   │   ├── registry.ts      # SHORTCUTS source of truth + formatting helpers
+│   │   │   ├── match.ts         # Chord matching (mod/shift/alt, editable-target awareness)
+│   │   │   ├── types.ts         # KeyChord / ShortcutDef
+│   │   │   ├── useGlobalShortcuts.ts # Single window keydown dispatcher
+│   │   │   ├── useFocusTrap.ts  # Modal focus trap (stacked)
+│   │   │   └── useRovingListIndex.ts # Arrow-key list navigation
+│   │   ├── commands/
+│   │   │   └── registry.ts      # Client-side slash commands
+│   │   ├── themes/              # CSS theme files
+│   │   │   ├── index.ts         # Theme registry and applyTheme()
+│   │   │   ├── default.css      # Dark theme (default)
+│   │   │   ├── light.css
+│   │   │   ├── bluey.css
+│   │   │   ├── green-terminal.css
+│   │   │   ├── solarized-light.css
+│   │   │   └── windows-xp.css
+│   │   ├── styles/
+│   │   │   ├── index.css        # Canonical import order + Tailwind + design tokens
+│   │   │   ├── primitives.css   # Orchid primitive engine (component roots, theme tokens)
+│   │   │   ├── components.css   # orchid-* composites (@layer orchid) — base
+│   │   │   ├── components-chat.css / components-session.css / components-config.css
+│   │   │   │                    # Surface-area splits of the composite layer
+│   │   │   ├── shell.css        # App shell geometry
+│   │   │   ├── motion.css       # Shared motion vocabulary (orchid-* transitions)
+│   │   │   ├── markdown.css     # Markdown rendering styles
+│   │   │   ├── exceptions.css   # Scoped style exceptions
+│   │   │   └── README.md        # Styling contract documentation
+│   │   └── utils/               # Presentation/state helpers (config drafts, grouping,
+│   │                            # provider selection, stream building, subagent stream, …)
+│   └── shared/                  # Shared types between main/preload/renderer
+│       ├── types/
+│       │   ├── ipc.ts           # IPC channel names, message types, OrchidAPI interface
+│       │   ├── ipc-boundary.ts  # Config, Session, Model, MCP types shared across boundary
+│       │   ├── ipc-schemas.ts   # Zod schemas for IPC payloads
+│       │   ├── message.ts       # Message, Usage, MessageRole, MessageType
+│       │   ├── session.ts       # Session, SessionSummary
+│       │   ├── chain.ts         # Chain (conversation thread) types
+│       │   ├── agent.ts         # Agent definition type
+│       │   ├── agent-scope.ts   # Agent scope identity (main vs subagent)
+│       │   ├── skill.ts         # Skill definition type
+│       │   ├── tool.ts          # ToolCall type
+│       │   ├── tool-result.ts   # Canonical tool result envelope types
+│       │   ├── tool-result-filesystem.ts / tool-result-apply-patch.ts
+│       │   ├── subagent.ts      # Subagent types
+│       │   ├── todo.ts          # TodoItem, TodoStatus
+│       │   ├── permission.ts    # Permission modes + risk classes
+│       │   ├── provider.ts      # ModelSelection + provider connection types
+│       │   ├── accounting.ts    # Attempt ledger types
+│       │   ├── analytics.ts     # Analytics read-model types
+│       │   └── definitions.ts   # Definition (agent/skill/personality) types
+│       ├── chat/
+│       │   └── turn-projection.ts # Pure reducer: IPC turn events → renderer projection
+│       ├── mcp/
+│       │   └── recommended-servers.ts # Recommended MCP servers (onboarding opt-in)
+│       ├── serialization/
+│       │   └── chain-subagent.ts # Chain/subagent serialization helpers
+│       ├── commands.ts          # Shared command types + fuzzy-match utilities (definitions live in renderer)
+│       ├── usage.ts             # Usage accounting helpers
+│       └── utils/
+│           └── frontmatter.ts   # YAML frontmatter parser for agent/skill files
+├── tests/
+├── scripts/
+├── package.json
+├── tsconfig.json
+├── tsconfig.node.json
+├── tsconfig.migration.json
+├── vite.config.ts
+├── eslint.config.mjs
+├── electron-builder.yml
+└── README.md
 ```
 
 ## Build & Development
@@ -738,6 +749,8 @@ Motion is a shared interaction contract, not local decoration. Use it to explain
 - **Imports**: grouped (external, internal, types) with blank line separators
 
 ## Key Files for Common Tasks
+
+> **Note:** All paths in the table below are relative to the Electron app root (`electron/`). For example, `src/main/...` means `electron/src/main/...`.
 
 | Task | Files |
 |------|-------|

--- a/electron/src/renderer/components/Preferences/MCPServersTab.tsx
+++ b/electron/src/renderer/components/Preferences/MCPServersTab.tsx
@@ -1,7 +1,10 @@
 /**
  * MCPServersTab — list, edit, delete, and add MCP servers.
  *
- * Each server has: command (or url), args, env.
+ * Each server uses exactly one transport:
+ * - stdio: command + args + env (spawns a child process)
+ * - http:  url + headers (connects to a remote endpoint)
+ *
  * Changes to MCP servers trigger a restart prompt.
  */
 import { useState, useCallback } from 'react';
@@ -16,12 +19,16 @@ import { TextInput } from '../ui/TextInput';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
+type TransportType = 'stdio' | 'http';
+
 export interface MCPServerEntry {
   id: string;
+  transport: TransportType;
   command?: string;
   url?: string;
   args: string[];
   env: Record<string, string>;
+  headers: Record<string, string>;
 }
 
 export interface MCPServersTabProps {
@@ -31,10 +38,13 @@ export interface MCPServersTabProps {
 
 interface EditingServer {
   id: string;
+  transport: TransportType;
   command: string;
   url: string;
   argsText: string; // space-separated or JSON array
   envText: string; // KEY=VALUE per line
+  authToken: string;
+  headers: Record<string, string>; // non-auth headers, preserved across edits
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -42,21 +52,37 @@ interface EditingServer {
 function parseServer(id: string, data: Record<string, unknown>): MCPServerEntry {
   const args = data.args;
   const env = data.env;
+  const headers = data.headers;
+  const transport: TransportType = data.url ? 'http' : 'stdio';
   return {
     id,
+    transport,
     command: data.command as string | undefined,
     url: data.url as string | undefined,
     args: Array.isArray(args) ? (args as string[]) : [],
     env: env && typeof env === 'object' ? (env as Record<string, string>) : {},
+    headers:
+      headers && typeof headers === 'object'
+        ? (headers as Record<string, string>)
+        : {},
   };
 }
 
 function serverToDict(s: MCPServerEntry): Record<string, unknown> {
   const dict: Record<string, unknown> = {};
-  if (s.command) dict.command = s.command;
-  if (s.url) dict.url = s.url;
-  if (s.args.length > 0) dict.args = s.args;
-  if (Object.keys(s.env).length > 0) dict.env = s.env;
+  if (s.transport === 'http') {
+    if (s.url) dict.url = s.url;
+    if (Object.keys(s.headers).length > 0) dict.headers = s.headers;
+  } else {
+    if (s.command) dict.command = s.command;
+    if (s.args.length > 0) dict.args = s.args;
+    if (Object.keys(s.env).length > 0) dict.env = s.env;
+    const nonAuthHeaders: Record<string, string> = {};
+    for (const [k, v] of Object.entries(s.headers)) {
+      if (k !== 'Authorization') nonAuthHeaders[k] = v;
+    }
+    if (Object.keys(nonAuthHeaders).length > 0) dict.headers = nonAuthHeaders;
+  }
   return dict;
 }
 
@@ -87,6 +113,19 @@ function parseEnvText(text: string): Record<string, string> {
   return env;
 }
 
+function extractAuthToken(headers: Record<string, string>): string {
+  const auth = headers['Authorization'] ?? '';
+  return auth.startsWith('Bearer ') ? auth.slice('Bearer '.length) : auth;
+}
+
+function withoutAuth(headers: Record<string, string>): Record<string, string> {
+  const rest: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (k !== 'Authorization') rest[k] = v;
+  }
+  return rest;
+}
+
 // ── Component ────────────────────────────────────────────────────────────────
 
 export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
@@ -102,12 +141,15 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
     setEditingId(s.id);
     setEditForm({
       id: s.id,
+      transport: s.transport,
       command: s.command ?? '',
       url: s.url ?? '',
       argsText: s.args.join(' '),
       envText: Object.entries(s.env)
         .map(([k, v]) => `${k}=${v}`)
         .join('\n'),
+      authToken: extractAuthToken(s.headers),
+      headers: withoutAuth(s.headers),
     });
     setIsAdding(false);
   }, []);
@@ -123,11 +165,23 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
 
     const server: MCPServerEntry = {
       id: editForm.id,
+      transport: editForm.transport,
       args: parseArgsText(editForm.argsText),
       env: parseEnvText(editForm.envText),
+      headers: { ...editForm.headers },
     };
-    if (editForm.command) server.command = editForm.command;
-    if (editForm.url) server.url = editForm.url;
+
+    if (editForm.transport === 'stdio') {
+      if (editForm.command) server.command = editForm.command;
+    } else {
+      if (editForm.url) server.url = editForm.url;
+      if (editForm.authToken) {
+        server.headers = {
+          ...editForm.headers,
+          Authorization: `Bearer ${editForm.authToken}`,
+        };
+      }
+    }
 
     const updated = { ...mcpServers };
     if (editingId !== editForm.id && editingId in updated) {
@@ -154,10 +208,13 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
     setEditingId(null);
     setEditForm({
       id: '',
+      transport: 'stdio',
       command: '',
       url: '',
       argsText: '',
       envText: '',
+      authToken: '',
+      headers: {},
     });
     setIsAdding(true);
   }, []);
@@ -166,6 +223,44 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
     <div className="flex flex-col gap-4">
       {title && <div className="config-card-title text-primary font-semibold">{title}</div>}
       <div className="config-form-grid">
+        <FormField label="Transport" className="config-field config-form-grid-full">
+          <div
+            className="flex gap-1 rounded-box border border-base-300 bg-base-200/60 p-0.5 w-fit"
+            role="group"
+            aria-label="MCP server transport"
+          >
+            <Button
+              type="button"
+              size="xs"
+              variant={form.transport === 'stdio' ? 'primary' : 'ghost'}
+              className={[
+                'h-7 min-h-7 border-0 shadow-none font-medium',
+                form.transport === 'stdio'
+                  ? ''
+                  : 'bg-transparent text-base-content/70 hover:bg-base-300/60',
+              ].join(' ')}
+              aria-pressed={form.transport === 'stdio'}
+              onClick={() => setEditForm({ ...form, transport: 'stdio' })}
+            >
+              Command (stdio)
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant={form.transport === 'http' ? 'primary' : 'ghost'}
+              className={[
+                'h-7 min-h-7 border-0 shadow-none font-medium',
+                form.transport === 'http'
+                  ? ''
+                  : 'bg-transparent text-base-content/70 hover:bg-base-300/60',
+              ].join(' ')}
+              aria-pressed={form.transport === 'http'}
+              onClick={() => setEditForm({ ...form, transport: 'http' })}
+            >
+              URL (HTTP)
+            </Button>
+          </div>
+        </FormField>
         <FormField label="Server ID" htmlFor="mcp-server-id" className="config-field">
           <TextInput
             id="mcp-server-id"
@@ -177,57 +272,81 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
             placeholder="my-mcp-server"
           />
         </FormField>
-        <FormField label="Command" htmlFor="mcp-server-command" className="config-field">
-          <TextInput
-            id="mcp-server-command"
-            type="text"
-            value={form.command}
-            onChange={(e) => setEditForm({ ...form, command: e.target.value })}
-            bordered
-            className="w-full"
-            placeholder="npx"
-          />
-        </FormField>
-        <FormField label="URL (for SSE servers)" htmlFor="mcp-server-url" className="config-field">
-          <TextInput
-            id="mcp-server-url"
-            type="text"
-            value={form.url}
-            onChange={(e) => setEditForm({ ...form, url: e.target.value })}
-            bordered
-            className="w-full"
-            placeholder="http://localhost:3000"
-          />
-        </FormField>
-        <FormField
-          label="Arguments (space-separated)"
-          htmlFor="mcp-server-args"
-          className="config-field"
-        >
-          <TextInput
-            id="mcp-server-args"
-            type="text"
-            value={form.argsText}
-            onChange={(e) => setEditForm({ ...form, argsText: e.target.value })}
-            bordered
-            className="w-full"
-            placeholder="-y @upstash/context7-mcp"
-          />
-        </FormField>
-        <FormField
-          label="Environment Variables (KEY=VALUE per line)"
-          htmlFor="mcp-server-env"
-          className="config-field config-form-grid-full"
-        >
-          <textarea
-            id="mcp-server-env"
-            value={form.envText}
-            onChange={(e) => setEditForm({ ...form, envText: e.target.value })}
-            className="textarea textarea-bordered w-full"
-            rows={3}
-            placeholder="API_KEY=sk-..."
-          />
-        </FormField>
+        {form.transport === 'stdio' ? (
+          <>
+            <FormField label="Command" htmlFor="mcp-server-command" className="config-field">
+              <TextInput
+                id="mcp-server-command"
+                type="text"
+                value={form.command}
+                onChange={(e) => setEditForm({ ...form, command: e.target.value })}
+                bordered
+                className="w-full"
+                placeholder="npx"
+              />
+            </FormField>
+            <FormField
+              label="Arguments (space-separated)"
+              htmlFor="mcp-server-args"
+              className="config-field"
+            >
+              <TextInput
+                id="mcp-server-args"
+                type="text"
+                value={form.argsText}
+                onChange={(e) => setEditForm({ ...form, argsText: e.target.value })}
+                bordered
+                className="w-full"
+                placeholder="-y @upstash/context7-mcp"
+              />
+            </FormField>
+            <FormField
+              label="Environment Variables (KEY=VALUE per line)"
+              htmlFor="mcp-server-env"
+              className="config-field config-form-grid-full"
+            >
+              <textarea
+                id="mcp-server-env"
+                value={form.envText}
+                onChange={(e) => setEditForm({ ...form, envText: e.target.value })}
+                className="textarea textarea-bordered w-full"
+                rows={3}
+                placeholder="API_KEY=sk-..."
+              />
+            </FormField>
+          </>
+        ) : (
+          <>
+            <FormField label="URL" htmlFor="mcp-server-url" className="config-field">
+              <TextInput
+                id="mcp-server-url"
+                type="text"
+                value={form.url}
+                onChange={(e) => setEditForm({ ...form, url: e.target.value })}
+                bordered
+                className="w-full"
+                placeholder="http://localhost:3000"
+              />
+            </FormField>
+            <FormField
+              label="Auth Token"
+              htmlFor="mcp-server-token"
+              className="config-field"
+              hint="Sent as an Authorization: Bearer header."
+            >
+              <TextInput
+                id="mcp-server-token"
+                type="password"
+                value={form.authToken}
+                onChange={(e) => setEditForm({ ...form, authToken: e.target.value })}
+                bordered
+                className="w-full"
+                placeholder="Bearer token"
+                autoComplete="off"
+              />
+            </FormField>
+          </>
+        )}
       </div>
       <div className="flex justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={cancelEdit} type="button">

--- a/electron/src/renderer/components/Preferences/MCPServersTab.tsx
+++ b/electron/src/renderer/components/Preferences/MCPServersTab.tsx
@@ -77,11 +77,6 @@ function serverToDict(s: MCPServerEntry): Record<string, unknown> {
     if (s.command) dict.command = s.command;
     if (s.args.length > 0) dict.args = s.args;
     if (Object.keys(s.env).length > 0) dict.env = s.env;
-    const nonAuthHeaders: Record<string, string> = {};
-    for (const [k, v] of Object.entries(s.headers)) {
-      if (k !== 'Authorization') nonAuthHeaders[k] = v;
-    }
-    if (Object.keys(nonAuthHeaders).length > 0) dict.headers = nonAuthHeaders;
   }
   return dict;
 }
@@ -113,15 +108,20 @@ function parseEnvText(text: string): Record<string, string> {
   return env;
 }
 
+function isAuthorizationHeader(key: string): boolean {
+  return key.toLowerCase() === 'authorization';
+}
+
 function extractAuthToken(headers: Record<string, string>): string {
-  const auth = headers['Authorization'] ?? '';
-  return auth.startsWith('Bearer ') ? auth.slice('Bearer '.length) : auth;
+  const auth =
+    Object.entries(headers).find(([key]) => isAuthorizationHeader(key))?.[1] ?? '';
+  return /^bearer /i.test(auth) ? auth.slice('Bearer '.length) : auth;
 }
 
 function withoutAuth(headers: Record<string, string>): Record<string, string> {
   const rest: Record<string, string> = {};
-  for (const [k, v] of Object.entries(headers)) {
-    if (k !== 'Authorization') rest[k] = v;
+  for (const [key, value] of Object.entries(headers)) {
+    if (!isAuthorizationHeader(key)) rest[key] = value;
   }
   return rest;
 }
@@ -232,13 +232,8 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
             <Button
               type="button"
               size="xs"
-              variant={form.transport === 'stdio' ? 'primary' : 'ghost'}
-              className={[
-                'h-7 min-h-7 border-0 shadow-none font-medium',
-                form.transport === 'stdio'
-                  ? ''
-                  : 'bg-transparent text-base-content/70 hover:bg-base-300/60',
-              ].join(' ')}
+              variant={form.transport === 'stdio' ? 'selected' : 'ghost'}
+              className="h-7 min-h-7 border-0 font-medium"
               aria-pressed={form.transport === 'stdio'}
               onClick={() => setEditForm({ ...form, transport: 'stdio' })}
             >
@@ -247,13 +242,8 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
             <Button
               type="button"
               size="xs"
-              variant={form.transport === 'http' ? 'primary' : 'ghost'}
-              className={[
-                'h-7 min-h-7 border-0 shadow-none font-medium',
-                form.transport === 'http'
-                  ? ''
-                  : 'bg-transparent text-base-content/70 hover:bg-base-300/60',
-              ].join(' ')}
+              variant={form.transport === 'http' ? 'selected' : 'ghost'}
+              className="h-7 min-h-7 border-0 font-medium"
               aria-pressed={form.transport === 'http'}
               onClick={() => setEditForm({ ...form, transport: 'http' })}
             >

--- a/electron/src/renderer/components/ToolResults/ToolResultShell.tsx
+++ b/electron/src/renderer/components/ToolResults/ToolResultShell.tsx
@@ -68,16 +68,18 @@ function ResultBody({ block, canonical, sessionId }: { block: ToolBlock; canonic
   }
 }
 
-/** Display label for a running foreground command, derived from its args. */
-function foregroundCommandLabel(block: ToolBlock): string {
+/** Command text and description for a running foreground command, from its args. */
+function foregroundCommandInfo(block: ToolBlock): { command: string; description?: string } {
+  let command = '';
+  let description: string | undefined;
   try {
     const parsed = JSON.parse(block.args) as { command?: unknown; description?: unknown };
-    if (typeof parsed.command === 'string' && parsed.command.trim()) return parsed.command;
-    if (typeof parsed.description === 'string' && parsed.description.trim()) return parsed.description;
+    if (typeof parsed.command === 'string' && parsed.command.trim()) command = parsed.command;
+    if (typeof parsed.description === 'string' && parsed.description.trim()) description = parsed.description;
   } catch {
     // Args can be partial while streaming; fall through to a generic label.
   }
-  return block.toolName || 'command';
+  return { command: command || description || block.toolName || 'command', description };
 }
 
 function lifecycleBadge(block: ToolBlock, canonical: CanonicalToolResult | null, custom?: ReactNode) {
@@ -140,6 +142,7 @@ export function ToolResultShell({
         // Foreground live mirror keyed by the tool call id (block.id). The
         // canonical stdout/stderr result replaces this widget on completion.
         // Stop propagation so the widget's own controls never collapse the shell.
+        const { command, description } = foregroundCommandInfo(block);
         return (
           <div
             onClick={(event) => event.stopPropagation()}
@@ -148,7 +151,8 @@ export function ToolResultShell({
             <LiveCommandInline
               target={{ toolCallId: block.id }}
               sessionId={sessionId}
-              commandText={foregroundCommandLabel(block)}
+              commandText={command}
+              description={description}
             />
           </div>
         );

--- a/electron/src/renderer/components/ToolWidgets/LiveCommandInline.tsx
+++ b/electron/src/renderer/components/ToolWidgets/LiveCommandInline.tsx
@@ -86,11 +86,12 @@ export function LiveCommandInline({
   const { output, exitCode, isRunning, isAvailable, interactive, owner, refresh } =
     useLiveCommandOutput(target, sessionId, true, expanded, expectedCreatedAt);
 
-  // Build title: matches Python's _build_title()
+  // Build title: prefer the description, falling back to the raw command —
+  // mirrors commandTitle() in tool-title.ts.
   const title = useMemo(() => {
-    const cmdDisplay = commandText
-      ? `$ ${commandText}`
-      : description || (commandId !== null ? `Command #${commandId}` : 'Command');
+    const cmdDisplay = description
+      || (commandText ? `$ ${commandText}` : null)
+      || (commandId !== null ? `Command #${commandId}` : 'Command');
 
     if (!isAvailable) {
       return `${cmdDisplay} (unavailable)`;
@@ -189,6 +190,9 @@ export function LiveCommandInline({
       </button>
       <CollapsibleRegion open={expanded} id={panelId}>
         <div className="orchid-live-command-body">
+          {commandText && description && description !== commandText && (
+            <pre className="orchid-live-command-cmd">$ {commandText}</pre>
+          )}
           <pre className="orchid-live-command-pre">
             {displayOutput || (!isAvailable
               ? isBackground

--- a/electron/src/renderer/components/ui/Button.tsx
+++ b/electron/src/renderer/components/ui/Button.tsx
@@ -1,7 +1,14 @@
 import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
 import { Icon, type IconName } from '../Icon';
 
-export type ButtonVariant = 'primary' | 'ghost' | 'error' | 'warning' | 'neutral' | 'link';
+export type ButtonVariant =
+  | 'primary'
+  | 'selected'
+  | 'ghost'
+  | 'error'
+  | 'warning'
+  | 'neutral'
+  | 'link';
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 export type ButtonShape = 'default' | 'square' | 'circle';
 
@@ -20,6 +27,7 @@ export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement
 
 const VARIANT_CLASS: Record<ButtonVariant, string> = {
   primary: 'btn-primary',
+  selected: 'btn-selected',
   ghost: 'btn-ghost',
   error: 'btn-error',
   warning: 'btn-warning',

--- a/electron/src/renderer/styles/components.css
+++ b/electron/src/renderer/styles/components.css
@@ -511,6 +511,10 @@
     overflow-y: auto;
   }
 
+  .orchid-live-command-cmd {
+    @apply m-0 overflow-x-auto whitespace-pre-wrap border-b border-base-300 px-3 py-1.5 font-mono text-xs opacity-70;
+  }
+
   .orchid-live-command-exit {
     @apply border-t border-base-content/10 px-3 py-1 opacity-60;
     font-size: 1rem;

--- a/electron/src/renderer/styles/primitives.css
+++ b/electron/src/renderer/styles/primitives.css
@@ -124,6 +124,18 @@
       0 4px 12px color-mix(in srgb, var(--btn-primary-bg, var(--color-primary)) 28%, transparent);
   }
 
+  .btn-selected {
+    --btn-bg: var(--btn-primary-bg, var(--color-primary));
+    --btn-bg-hover: var(--btn-primary-hover, var(--color-primary));
+    --btn-fg: var(--btn-primary-text, var(--color-primary-content));
+    --btn-border: transparent;
+    box-shadow: none;
+  }
+
+  .btn-selected:hover:not(:disabled) {
+    border-color: transparent;
+  }
+
   .btn-ghost {
     --btn-bg: transparent;
     --btn-bg-hover: color-mix(in srgb, var(--color-base-content) 6%, transparent);

--- a/electron/src/shared/types/ipc-schemas.ts
+++ b/electron/src/shared/types/ipc-schemas.ts
@@ -605,6 +605,9 @@ const subagentDeltaBaseSchema = z.object({
 export const subagentSpawnedEventSchema = subagentDeltaBaseSchema.extend({
   type: z.literal('spawned'), record: ipcSubagentSummarySchema, usage: usageSchema.nullable(),
 });
+export const subagentStatusChangedEventSchema = subagentDeltaBaseSchema.extend({
+  type: z.literal('status_changed'), status: subagentStatusSchema,
+});
 export const subagentTextDeltaEventSchema = subagentDeltaBaseSchema.extend({
   type: z.literal('text_delta'), segmentId: z.string(), append: z.string(),
 });
@@ -633,6 +636,7 @@ export const subagentTerminalEventSchema = subagentDeltaBaseSchema.extend({
 });
 export const subagentDeltaEventSchema = z.discriminatedUnion('type', [
   subagentSpawnedEventSchema,
+  subagentStatusChangedEventSchema,
   subagentTextDeltaEventSchema,
   subagentThinkingDeltaEventSchema,
   subagentToolStartEventSchema,

--- a/electron/tests/integration/chat-sidebar.test.ts
+++ b/electron/tests/integration/chat-sidebar.test.ts
@@ -443,8 +443,8 @@ describe('Sidebar Commands Section', () => {
     renderCommandsSidebar({
       status: 'ready',
       commands: [
-        makeBgCommand({ command: 'npm run dev' }),
-        makeBgCommand({ id: 2, command: 'pytest -x', scopeName: 'Researcher', agentScopeId: 'sub-9' }),
+        makeBgCommand({ command: 'npm run dev', description: '' }),
+        makeBgCommand({ id: 2, command: 'pytest -x', scopeName: 'Researcher', agentScopeId: 'sub-9', description: '' }),
       ],
     });
     await flushSnapshots();
@@ -493,8 +493,8 @@ describe('Sidebar Commands Section', () => {
     renderCommandsSidebar({
       status: 'ready',
       commands: [
-        makeBgCommand({ id: 1, command: 'npm run dev' }),
-        makeBgCommand({ id: 2, command: 'pytest -x', running: false, exitCode: 0 }),
+        makeBgCommand({ id: 1, command: 'npm run dev', description: '' }),
+        makeBgCommand({ id: 2, command: 'pytest -x', running: false, exitCode: 0, description: '' }),
         makeBgCommand({
           id: 3,
           command: 'cargo build',
@@ -502,6 +502,7 @@ describe('Sidebar Commands Section', () => {
           exitCode: 1,
           scopeName: 'Builder',
           agentScopeId: 'sub-2',
+          description: '',
         }),
       ],
     });

--- a/electron/tests/unit/chat-rendering-contract.test.ts
+++ b/electron/tests/unit/chat-rendering-contract.test.ts
@@ -477,7 +477,7 @@ describe('live command gating (process liveness)', () => {
 
     expect(container.querySelector('.orchid-live-command')).toBeTruthy();
     expect(container.querySelector('.orchid-tool-running-hint')).toBeNull();
-    expect(container.querySelector('.orchid-live-command-title')?.textContent).toContain('sleep 30');
+    expect(container.querySelector('.orchid-live-command-title')?.textContent).toContain('wait for it');
     expect(api.snapshot).toHaveBeenCalledTimes(1);
     expect(api.snapshot).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'call-fg-1', lastN: 50, sessionId: 'sess-2' }));
   });

--- a/electron/tests/unit/live-command-inline.test.tsx
+++ b/electron/tests/unit/live-command-inline.test.tsx
@@ -233,4 +233,64 @@ describe('LiveCommandInline', () => {
     expect(pre).toBeTruthy();
     expect(pre?.textContent).toBe('red\nplain\n');
   });
+
+  it('shows the description in the title and the raw command in the body', async () => {
+    installBgCmd({ interactive: false });
+
+    const { container } = render(
+      <LiveCommandInline
+        target={{ commandId: 10 }}
+        sessionId="sess-1"
+        commandText="npm run dev"
+        description="Start the dev server"
+      />,
+    );
+    await flush();
+
+    expand(/Start the dev server \(running\)/);
+
+    const cmd = container.querySelector('.orchid-live-command-cmd');
+    expect(cmd).toBeTruthy();
+    expect(cmd?.textContent).toBe('$ npm run dev');
+  });
+
+  it('omits the body command line when the description matches the command', async () => {
+    installBgCmd({ interactive: false });
+
+    const { container } = render(
+      <LiveCommandInline
+        target={{ commandId: 11 }}
+        sessionId="sess-1"
+        commandText="npm run dev"
+        description="npm run dev"
+      />,
+    );
+    await flush();
+
+    expand(/npm run dev \(running\)/);
+
+    expect(container.querySelector('.orchid-live-command-cmd')).toBeNull();
+  });
+
+  it('foreground path shows description in title and raw command in body', async () => {
+    installBgCmd({ interactive: true });
+
+    const { container } = render(
+      <LiveCommandInline
+        target={{ toolCallId: 'call-desc' }}
+        sessionId="sess-1"
+        commandText="sleep 5"
+        description="Wait five seconds"
+      />,
+    );
+    await flush();
+
+    expand(/Wait five seconds \(running\)/);
+
+    const cmd = container.querySelector('.orchid-live-command-cmd');
+    expect(cmd).toBeTruthy();
+    expect(cmd?.textContent).toBe('$ sleep 5');
+    expect(screen.queryByRole('button', { name: 'Stop' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Send' })).toBeNull();
+  });
 });

--- a/electron/tests/unit/mcp-servers-tab.test.tsx
+++ b/electron/tests/unit/mcp-servers-tab.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MCPServersTab } from '../../src/renderer/components/Preferences/MCPServersTab';
+
+afterEach(() => {
+  cleanup();
+});
+
+function inputValue(label: string): string {
+  return (screen.getByLabelText(label) as HTMLInputElement).value;
+}
+
+describe('MCPServersTab serialization', () => {
+  it('omits headers entirely when an HTTP server is switched to stdio', () => {
+    const onChange = vi.fn();
+    render(
+      <MCPServersTab
+        mcpServers={{
+          'remote-server': {
+            url: 'http://localhost:3000',
+            headers: { Authorization: 'Bearer tok', 'X-Custom': 'keep-me' },
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Command (stdio)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const saved = onChange.mock.calls[0][0] as Record<string, Record<string, unknown>>;
+    expect(Object.keys(saved)).toEqual(['remote-server']);
+    expect(saved['remote-server']).not.toHaveProperty('headers');
+    expect(saved['remote-server']).not.toHaveProperty('url');
+  });
+
+  it('keeps headers for HTTP servers on save', () => {
+    const onChange = vi.fn();
+    render(
+      <MCPServersTab
+        mcpServers={{
+          remote: {
+            url: 'http://localhost:3000',
+            headers: { Authorization: 'Bearer tok', 'X-Custom': 'keep-me' },
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      remote: {
+        url: 'http://localhost:3000',
+        headers: { Authorization: 'Bearer tok', 'X-Custom': 'keep-me' },
+      },
+    });
+  });
+});
+
+describe('MCPServersTab auth header handling', () => {
+  it('matches the Authorization header and Bearer scheme case-insensitively', () => {
+    const onChange = vi.fn();
+    render(
+      <MCPServersTab
+        mcpServers={{
+          remote: {
+            url: 'http://localhost:3000',
+            headers: { authorization: 'bearer secret-token', 'x-api-key': 'k1' },
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(inputValue('Auth Token')).toBe('secret-token');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onChange).toHaveBeenCalledWith({
+      remote: {
+        url: 'http://localhost:3000',
+        headers: { 'x-api-key': 'k1', Authorization: 'Bearer secret-token' },
+      },
+    });
+  });
+
+  it('preserves non-Bearer authorization values and unrelated headers', () => {
+    render(
+      <MCPServersTab
+        mcpServers={{
+          remote: {
+            url: 'http://localhost:3000',
+            headers: { AUTHORIZATION: 'Basic abc123', 'X-Trace': 'on' },
+          },
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(inputValue('Auth Token')).toBe('Basic abc123');
+  });
+});

--- a/electron/tests/unit/preload-validation.test.ts
+++ b/electron/tests/unit/preload-validation.test.ts
@@ -54,6 +54,18 @@ function textDelta(sequence: number): Record<string, unknown> {
   };
 }
 
+function statusChanged(sequence: number, status: string): Record<string, unknown> {
+  return {
+    sessionId: SESSION_ID,
+    subagentId: 'sub-1',
+    runId: 'run-1',
+    sequence,
+    sessionRevision: sequence,
+    type: 'status_changed',
+    status,
+  };
+}
+
 function terminalEvent(sequence: number): Record<string, unknown> {
   return {
     sessionId: SESSION_ID,
@@ -199,6 +211,27 @@ describe('preload SUBAGENTS_EVENT validation', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0]?.events).toHaveLength(2);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('delivers status_changed events (queued→running) instead of dropping them', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    emit({
+      sessionId: SESSION_ID,
+      events: [statusChanged(1, 'queued'), statusChanged(2, 'running')],
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.events.map((event) => event.type)).toEqual([
+      'status_changed',
+      'status_changed',
+    ]);
+    expect(
+      received[0]?.events.map((event) =>
+        event.type === 'status_changed' ? event.status : null,
+      ),
+    ).toEqual(['queued', 'running']);
     expect(warn).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
#122: Add missing status_changed variant to subagentDeltaEventSchema in ipc-schemas.ts. Preload Zod validation was silently dropping all status_changed delta events, so Queued→Running transitions never reached the renderer. Added regression test in preload-validation.test.ts.

#124: Restructure AGENTS.md Directory Structure tree to root at electron/ instead of src/, add missing top-level entries (tests/, scripts/, config files), add path-relative note to Key Files table.

#100: Swap LiveCommandInline title preference to description-first (matching the existing commandTitle pattern in tool-title.ts), pass description from ToolResultShell foreground path, add raw command to body when description differs. Updated affected tests.

#111: Add transport toggle (stdio vs HTTP) to MCPServersTab editor, conditionally render fields, strip inactive transport keys on save, add auth token field for HTTP transport that writes to headers.Authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server settings now support both `stdio` and HTTP connections, including custom headers and bearer authentication.
  * Live command results show a readable description while retaining the underlying command when useful.
  * Added support for displaying validated subagent status-change events.

* **Bug Fixes**
  * Improved handling and preservation of MCP authentication and non-authorization headers.
  * Improved command labels and output presentation for foreground and background tasks.

* **Documentation**
  * Updated project documentation to reflect the Electron application structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->