### PR TITLE
Fix #110, #96: batch todo operations, interrupted subagent status fid…

### DIFF
--- a/electron/src/main/tools/result.ts
+++ b/electron/src/main/tools/result.ts
@@ -213,7 +213,7 @@ function renderInterruptSubagentsPayload(record: Record<string, JsonValue>): str
     .join('\n');
 }
 
-function renderTodoCreatePayload(record: Record<string, JsonValue>): string {
+function renderTodoCreateTask(record: Record<string, JsonValue>): string {
   return '<task id="' + escapeXmlAttribute(record.id) +
     '" status="' + escapeXmlAttribute(record.status) +
     '" owner="' + escapeXmlAttribute(record.owner) + '">' +
@@ -221,7 +221,19 @@ function renderTodoCreatePayload(record: Record<string, JsonValue>): string {
     '</task>';
 }
 
-function renderTodoUpdatePayload(record: Record<string, JsonValue>): string {
+function renderTodoCreatePayload(record: Record<string, JsonValue>): string {
+  if (Array.isArray(record.created)) {
+    const tasks = record.created.filter((task): task is Record<string, JsonValue> =>
+      task !== null && typeof task === 'object' && !Array.isArray(task));
+    if (tasks.length === 0) return '<tasks count="0" />';
+    return '<tasks count="' + tasks.length + '">\n' +
+      tasks.map((task) => renderTodoCreateTask(task)).join('\n') +
+      '\n</tasks>';
+  }
+  return renderTodoCreateTask(record);
+}
+
+function renderTodoUpdateChanges(record: Record<string, JsonValue>): string {
   const changes = record.changes && typeof record.changes === 'object' && !Array.isArray(record.changes)
     ? record.changes as Record<string, JsonValue>
     : {};
@@ -230,6 +242,21 @@ function renderTodoUpdatePayload(record: Record<string, JsonValue>): string {
     (typeof changes.status === 'string' ? xmlTextElement('status', changes.status) : '') +
     (typeof changes.owner === 'string' ? xmlTextElement('owner', changes.owner) : '') +
     '</changes>';
+}
+
+function renderTodoUpdatePayload(record: Record<string, JsonValue>): string {
+  if (Array.isArray(record.updated)) {
+    const updated = record.updated.filter((entry): entry is Record<string, JsonValue> =>
+      entry !== null && typeof entry === 'object' && !Array.isArray(entry));
+    const errors = Array.isArray(record.errors)
+      ? record.errors.filter((entry): entry is string => typeof entry === 'string')
+      : [];
+    const changeBlocks = updated.map((entry) => renderTodoUpdateChanges(entry)).join('\n');
+    const errorBlocks = errors.map((error) => xmlTextElement('error', error)).join('\n');
+    const parts = [changeBlocks, errorBlocks].filter((part) => part !== '');
+    return '<batch count="' + updated.length + '">\n' + parts.join('\n') + '\n</batch>';
+  }
+  return renderTodoUpdateChanges(record);
 }
 
 function renderTodoListPayload(record: Record<string, JsonValue>): string {

--- a/electron/src/main/tools/subagent/wait.ts
+++ b/electron/src/main/tools/subagent/wait.ts
@@ -246,7 +246,10 @@ export function buildWaitTool(
     }
 
     const content = formatSubagentRecords(manager, records, subagent_ids);
-    return genericBuiltInToolOutcome('wait_for_subagent', content, 'complete');
+    const anyNonCompleted = [...records.values()].some(
+      (r) => r.state === 'interrupted' || r.state === 'failed',
+    );
+    return genericBuiltInToolOutcome('wait_for_subagent', content, anyNonCompleted ? 'error' : 'complete');
   };
 
   return { definition, handler };

--- a/electron/src/main/tools/todo/create.ts
+++ b/electron/src/main/tools/todo/create.ts
@@ -24,6 +24,9 @@ export type TodoToolResult = GenericBuiltInToolOutcome;
 /** Callback type for notifying the UI of todo changes. */
 export type NotifyTodoChanged = (ctx: ToolExecutionContext) => void | Promise<void>;
 
+/** Maximum number of items accepted in a single batch todo create/update call. */
+export const TODO_BATCH_MAX_SIZE = 50;
+
 /** Fixed store or a resolver scoped to the explicit tool execution context. */
 export type TodoStoreSource = TodoStore | ((ctx: ToolExecutionContext) => TodoStore);
 
@@ -74,7 +77,7 @@ export function buildCreateTool(
       'for batch creation.',
     inputSchema: z.object({
       title: z
-        .union([z.string(), z.array(z.string())])
+        .union([z.string(), z.array(z.string()).min(1).max(TODO_BATCH_MAX_SIZE)])
         .describe('Task title or array of task titles for batch creation.'),
       subagent_id: z
         .string()
@@ -99,7 +102,7 @@ export function buildCreateTool(
     const todoStore = resolveTodoStore(store, ctx);
     const created = titles.map((t) => todoStore.create(t, owner));
 
-    if (notifyChanged) {
+    if (created.length > 0 && notifyChanged) {
       await notifyChanged(ctx);
     }
 

--- a/electron/src/main/tools/todo/create.ts
+++ b/electron/src/main/tools/todo/create.ts
@@ -70,9 +70,12 @@ export function buildCreateTool(
     description:
       'Create a new task in the session todo list. Tasks are scoped to the ' +
       'calling agent (main or a specific subagent). Subagents only see and ' +
-      'modify their own tasks.',
+      'modify their own tasks. Accepts a single title or an array of titles ' +
+      'for batch creation.',
     inputSchema: z.object({
-      title: z.string().describe('Task title.'),
+      title: z
+        .union([z.string(), z.array(z.string())])
+        .describe('Task title or array of task titles for batch creation.'),
       subagent_id: z
         .string()
         .optional()
@@ -87,22 +90,37 @@ export function buildCreateTool(
 
   const handler: ToolHandler = async (input: unknown, ctx): Promise<TodoToolResult> => {
     const { title, subagent_id } = input as {
-      title: string;
+      title: string | string[];
       subagent_id?: string;
     };
 
     const owner = resolveCreateOwner(ctx.agentScopeId, subagent_id);
-    const todo = resolveTodoStore(store, ctx).create(title, owner);
+    const titles = Array.isArray(title) ? title : [title];
+    const todoStore = resolveTodoStore(store, ctx);
+    const created = titles.map((t) => todoStore.create(t, owner));
 
     if (notifyChanged) {
       await notifyChanged(ctx);
     }
 
+    if (created.length === 1) {
+      const todo = created[0];
+      return genericBuiltInToolOutcome('todo_create', {
+        id: todo.id,
+        title: todo.title,
+        status: todo.status,
+        owner: todo.subagent_id ?? MAIN_AGENT_SCOPE_ID,
+      }, 'complete');
+    }
+
     return genericBuiltInToolOutcome('todo_create', {
-      id: todo.id,
-      title: todo.title,
-      status: todo.status,
-      owner: todo.subagent_id ?? MAIN_AGENT_SCOPE_ID,
+      created: created.map((todo) => ({
+        id: todo.id,
+        title: todo.title,
+        status: todo.status,
+        owner: todo.subagent_id ?? MAIN_AGENT_SCOPE_ID,
+      })),
+      count: created.length,
     }, 'complete');
   };
 

--- a/electron/src/main/tools/todo/update.ts
+++ b/electron/src/main/tools/todo/update.ts
@@ -10,7 +10,7 @@ import { RiskClass } from '../../../shared/types/permission';
 import { genericToolResultMetadata } from '../types';
 import { genericBuiltInToolOutcome } from '../result';
 import type { TodoToolResult, NotifyTodoChanged, TodoStoreSource } from './create';
-import { resolveTodoStore } from './create';
+import { resolveTodoStore, TODO_BATCH_MAX_SIZE } from './create';
 import { TodoStatus, type Todo } from '../../../shared/types/todo';
 import {
   isMainAgentScope,
@@ -44,16 +44,16 @@ export function buildUpdateTool(
       'arrays, title/status arrays are matched by index to id arrays.',
     inputSchema: z.object({
       id: z
-        .union([z.string(), z.array(z.string())])
+        .union([z.string(), z.array(z.string()).min(1).max(TODO_BATCH_MAX_SIZE)])
         .describe('The ID of the task to update, or an array of IDs for batch update.'),
       title: z
-        .union([z.string(), z.array(z.string())])
+        .union([z.string(), z.array(z.string()).max(TODO_BATCH_MAX_SIZE)])
         .optional()
         .describe(
           'New title (optional). A single value is applied to every id; an array is matched by index.',
         ),
       status: z
-        .union([todoStatusSchema, z.array(todoStatusSchema)])
+        .union([todoStatusSchema, z.array(todoStatusSchema).max(TODO_BATCH_MAX_SIZE)])
         .optional()
         .describe(
           `New status. Must be one of: ${Object.values(TodoStatus).join(', ')}. ` +
@@ -81,6 +81,22 @@ export function buildUpdateTool(
     const scope = normalizeAgentScopeId(ctx.agentScopeId);
     const todoStore = resolveTodoStore(store, ctx);
     const ids = Array.isArray(id) ? id : [id];
+
+    if (Array.isArray(title) && title.length !== ids.length) {
+      return genericBuiltInToolOutcome(
+        'todo_update',
+        `Error: title array length (${title.length}) must match id array length (${ids.length}).`,
+        'error',
+      );
+    }
+    if (Array.isArray(status) && status.length !== ids.length) {
+      return genericBuiltInToolOutcome(
+        'todo_update',
+        `Error: status array length (${status.length}) must match id array length (${ids.length}).`,
+        'error',
+      );
+    }
+
     const titles = title === undefined ? undefined : Array.isArray(title) ? title : ids.map(() => title);
     const statuses = status === undefined ? undefined : Array.isArray(status) ? status : ids.map(() => status);
 
@@ -122,7 +138,7 @@ export function buildUpdateTool(
       results.push({ task, error: null, changes });
     }
 
-    if (notifyChanged) {
+    if (results.length > 0 && notifyChanged) {
       await notifyChanged(ctx);
     }
 

--- a/electron/src/main/tools/todo/update.ts
+++ b/electron/src/main/tools/todo/update.ts
@@ -11,7 +11,7 @@ import { genericToolResultMetadata } from '../types';
 import { genericBuiltInToolOutcome } from '../result';
 import type { TodoToolResult, NotifyTodoChanged, TodoStoreSource } from './create';
 import { resolveTodoStore } from './create';
-import { TodoStatus } from '../../../shared/types/todo';
+import { TodoStatus, type Todo } from '../../../shared/types/todo';
 import {
   isMainAgentScope,
   normalizeAgentScopeId,
@@ -39,14 +39,25 @@ export function buildUpdateTool(
     name: 'todo_update',
     description:
       'Update an existing task owned by the current agent.\n\n' +
-      'Status transitions are unrestricted: any status can be set to any status.',
+      'Status transitions are unrestricted: any status can be set to any status.\n' +
+      'Accepts a single id or an array of ids for batch updates. When using ' +
+      'arrays, title/status arrays are matched by index to id arrays.',
     inputSchema: z.object({
-      id: z.string().describe('The ID of the task to update.'),
-      title: z.string().optional().describe('New title (optional).'),
-      status: todoStatusSchema
+      id: z
+        .union([z.string(), z.array(z.string())])
+        .describe('The ID of the task to update, or an array of IDs for batch update.'),
+      title: z
+        .union([z.string(), z.array(z.string())])
         .optional()
         .describe(
-          `New status. Must be one of: ${Object.values(TodoStatus).join(', ')}.`,
+          'New title (optional). A single value is applied to every id; an array is matched by index.',
+        ),
+      status: z
+        .union([todoStatusSchema, z.array(todoStatusSchema)])
+        .optional()
+        .describe(
+          `New status. Must be one of: ${Object.values(TodoStatus).join(', ')}. ` +
+            'A single value is applied to every id; an array is matched by index.',
         ),
       subagent_id: z
         .string()
@@ -61,53 +72,84 @@ export function buildUpdateTool(
 
   const handler: ToolHandler = async (input: unknown, ctx): Promise<TodoToolResult> => {
     const { id, title, status, subagent_id } = input as {
-      id: string;
-      title?: string;
-      status?: TodoStatus;
+      id: string | string[];
+      title?: string | string[];
+      status?: TodoStatus | TodoStatus[];
       subagent_id?: string;
     };
 
     const scope = normalizeAgentScopeId(ctx.agentScopeId);
     const todoStore = resolveTodoStore(store, ctx);
-    const existing = todoStore.get(id);
-    if (!existing) {
-      return genericBuiltInToolOutcome('todo_update', `Error: No task found with ID '${id}'.`, 'error');
-    }
-    if (!todoBelongsToScope(existing, scope)) {
-      return genericBuiltInToolOutcome('todo_update', `Error: Task '${id}' is not owned by agent scope '${scope}'.`, 'error');
-    }
+    const ids = Array.isArray(id) ? id : [id];
+    const titles = title === undefined ? undefined : Array.isArray(title) ? title : ids.map(() => title);
+    const statuses = status === undefined ? undefined : Array.isArray(status) ? status : ids.map(() => status);
 
-    // Ownership reassignment: main only; subagents cannot reassign.
-    const updates: { title?: string; status?: TodoStatus; subagent_id?: string } = {
-      title,
-      status,
-    };
-    if (isMainAgentScope(scope) && subagent_id !== undefined) {
-      updates.subagent_id = subagent_id;
-    }
+    const results: { task: Todo | null; error: string | null; changes: { title?: string; status?: string; owner?: string } }[] = [];
 
-    const [task, error] = todoStore.update(id, updates);
+    for (let i = 0; i < ids.length; i++) {
+      const existing = todoStore.get(ids[i]);
+      if (!existing) {
+        results.push({ task: null, error: `No task found with ID '${ids[i]}'.`, changes: {} });
+        continue;
+      }
+      if (!todoBelongsToScope(existing, scope)) {
+        results.push({ task: null, error: `Task '${ids[i]}' is not owned by agent scope '${scope}'.`, changes: {} });
+        continue;
+      }
 
-    if (error) {
-      return genericBuiltInToolOutcome('todo_update', `Error: ${error}`, 'error');
+      const updates: { title?: string; status?: TodoStatus; subagent_id?: string } = {};
+      if (titles !== undefined && titles[i] !== undefined) {
+        updates.title = titles[i];
+      }
+      if (statuses !== undefined && statuses[i] !== undefined) {
+        updates.status = statuses[i];
+      }
+      if (isMainAgentScope(scope) && subagent_id !== undefined) {
+        updates.subagent_id = subagent_id;
+      }
+
+      const [task, error] = todoStore.update(ids[i], updates);
+      if (error || !task) {
+        results.push({ task: null, error: error ?? 'Unknown error.', changes: {} });
+        continue;
+      }
+      const changes: { title?: string; status?: string; owner?: string } = {};
+      if (updates.title !== undefined) changes.title = task.title;
+      if (updates.status !== undefined) changes.status = task.status;
+      if (isMainAgentScope(scope) && subagent_id !== undefined) {
+        changes.owner = task.subagent_id || 'main';
+      }
+      results.push({ task, error: null, changes });
     }
 
     if (notifyChanged) {
       await notifyChanged(ctx);
     }
 
-    const changes: { title?: string; status?: string; owner?: string } = {};
-    if (title !== undefined) changes.title = task!.title;
-    if (status !== undefined) changes.status = task!.status;
-    if (isMainAgentScope(scope) && subagent_id !== undefined) {
-      changes.owner = task!.subagent_id || 'main';
+    if (ids.length === 1) {
+      const r = results[0];
+      if (r.error) {
+        return genericBuiltInToolOutcome('todo_update', `Error: ${r.error}`, 'error');
+      }
+      return genericBuiltInToolOutcome('todo_update', {
+        taskId: r.task!.id,
+        title: r.task!.title,
+        changes: r.changes,
+      }, 'complete');
     }
 
+    const succeeded = results.filter((r) => r.task !== null).map((r) => ({
+      taskId: r.task!.id,
+      title: r.task!.title,
+      changes: r.changes,
+    }));
+    const errors = results.filter((r) => r.error !== null).map((r) => r.error!);
+
     return genericBuiltInToolOutcome('todo_update', {
-      taskId: task!.id,
-      title: task!.title,
-      changes,
-    }, 'complete');
+      updated: succeeded,
+      errors,
+      count: succeeded.length,
+    }, errors.length === ids.length ? 'error' : 'complete');
   };
 
   return { definition, handler };

--- a/electron/src/shared/serialization/chain-subagent.ts
+++ b/electron/src/shared/serialization/chain-subagent.ts
@@ -134,7 +134,7 @@ export function subagentRecordFromStorageDict(data: unknown): SubagentRecord {
   const parsedStatus = subagentStatusSchema.safeParse(raw.status);
   let status: SubagentStatus = parsedStatus.success
     ? parsedStatus.data
-    : SubagentStatus.COMPLETED;
+    : SubagentStatus.INTERRUPTED;
 
   if (
     status === SubagentStatus.QUEUED

--- a/electron/tests/unit/todo-web-tools.test.ts
+++ b/electron/tests/unit/todo-web-tools.test.ts
@@ -142,6 +142,78 @@ describe('Todo Tools', () => {
     });
   });
 
+  // -- batch operations -------------------------------------------------------
+
+  describe('batch operations', () => {
+    it('todo_create accepts an array of titles and notifies once', async () => {
+      let notifyCount = 0;
+      const { handler } = buildCreateTool(store, () => { notifyCount += 1; });
+      const result = (await callTool(handler, {
+        title: ['First', 'Second', 'Third'],
+      })) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('complete');
+      expect(result.agentProjection.content).toContain('count="3"');
+      expect(result.agentProjection.content.match(/<task id="/g)).toHaveLength(3);
+
+      const tasks = store.list();
+      expect(tasks).toHaveLength(3);
+      expect(tasks.map((t) => t.title).sort()).toEqual(['First', 'Second', 'Third']);
+      expect(notifyCount).toBe(1);
+    });
+
+    it('todo_create single string keeps the original single-task shape', async () => {
+      const { handler } = buildCreateTool(store);
+      const result = (await callTool(handler, {
+        title: 'Solo',
+      })) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('complete');
+      expect(result.agentProjection.content).toContain('<task id=');
+      expect(result.agentProjection.content).not.toContain('<tasks');
+      expect(store.list()).toHaveLength(1);
+    });
+
+    it('todo_update accepts an array of ids and notifies once', async () => {
+      const createHandler = buildCreateTool(store).handler;
+      const ids: string[] = [];
+      for (const title of ['A', 'B']) {
+        const created = (await callTool(createHandler, { title })) as ToolExecutionResult;
+        ids.push(created.agentProjection.content.match(/<task id="([a-f0-9]{8})"/)![1]);
+      }
+
+      let notifyCount = 0;
+      const updateHandler = buildUpdateTool(store, () => { notifyCount += 1; }).handler;
+      const result = (await callTool(updateHandler, {
+        id: ids,
+        status: TodoStatus.IN_PROGRESS,
+      })) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('complete');
+      expect(result.agentProjection.content).toContain('count="2"');
+      for (const id of ids) {
+        expect(store.get(id)!.status).toBe(TodoStatus.IN_PROGRESS);
+      }
+      expect(notifyCount).toBe(1);
+    });
+
+    it('todo_update batch collects per-item errors without failing the whole call', async () => {
+      const createHandler = buildCreateTool(store).handler;
+      const created = (await callTool(createHandler, { title: 'Real' })) as ToolExecutionResult;
+      const realId = created.agentProjection.content.match(/<task id="([a-f0-9]{8})"/)![1];
+
+      const updateHandler = buildUpdateTool(store).handler;
+      const result = (await callTool(updateHandler, {
+        id: [realId, 'does-not-exist'],
+        status: TodoStatus.DONE,
+      })) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('complete');
+      expect(result.agentProjection.content).toContain('<error>');
+      expect(store.get(realId)!.status).toBe(TodoStatus.DONE);
+    });
+  });
+
   // -- todo_update ------------------------------------------------------------
 
   describe('todo_update', () => {

--- a/electron/tests/unit/todo-web-tools.test.ts
+++ b/electron/tests/unit/todo-web-tools.test.ts
@@ -12,7 +12,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { TodoStore } from '../../src/main/tools/todo/store';
-import { buildCreateTool as buildCreateToolRaw } from '../../src/main/tools/todo/create';
+import { buildCreateTool as buildCreateToolRaw, TODO_BATCH_MAX_SIZE } from '../../src/main/tools/todo/create';
 import { buildUpdateTool as buildUpdateToolRaw } from '../../src/main/tools/todo/update';
 import { buildListTool as buildListToolRaw } from '../../src/main/tools/todo/list';
 import { buildDeleteTool as buildDeleteToolRaw } from '../../src/main/tools/todo/delete';
@@ -197,6 +197,41 @@ describe('Todo Tools', () => {
       expect(notifyCount).toBe(1);
     });
 
+    it('todo_create rejects an empty title array at schema boundary', () => {
+      const { definition } = buildCreateToolRaw(store);
+      const parsed = definition.inputSchema.safeParse({ title: [] });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('todo_create rejects title arrays above the batch limit at schema boundary', () => {
+      const { definition } = buildCreateToolRaw(store);
+      const titles = Array.from({ length: TODO_BATCH_MAX_SIZE + 1 }, (_, i) => `Task ${i}`);
+      const parsed = definition.inputSchema.safeParse({ title: titles });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('todo_create empty batch never triggers a change notification', async () => {
+      let notifyCount = 0;
+      const { handler } = buildCreateTool(store, () => { notifyCount += 1; });
+      await callTool(handler, { title: [] });
+
+      expect(store.list()).toHaveLength(0);
+      expect(notifyCount).toBe(0);
+    });
+
+    it('todo_update rejects an empty id array at schema boundary', () => {
+      const { definition } = buildUpdateToolRaw(store);
+      const parsed = definition.inputSchema.safeParse({ id: [], status: 'OPEN' });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('todo_update rejects id arrays above the batch limit at schema boundary', () => {
+      const { definition } = buildUpdateToolRaw(store);
+      const ids = Array.from({ length: TODO_BATCH_MAX_SIZE + 1 }, (_, i) => `id-${i}`);
+      const parsed = definition.inputSchema.safeParse({ id: ids, status: 'OPEN' });
+      expect(parsed.success).toBe(false);
+    });
+
     it('todo_update batch collects per-item errors without failing the whole call', async () => {
       const createHandler = buildCreateTool(store).handler;
       const created = (await callTool(createHandler, { title: 'Real' })) as ToolExecutionResult;
@@ -211,6 +246,62 @@ describe('Todo Tools', () => {
       expect(result.canonical.status).toBe('complete');
       expect(result.agentProjection.content).toContain('<error>');
       expect(store.get(realId)!.status).toBe(TodoStatus.DONE);
+    });
+
+    it('todo_update applies matching-length title and status arrays by index', async () => {
+      const createHandler = buildCreateTool(store).handler;
+      const ids: string[] = [];
+      for (const title of ['A', 'B']) {
+        const created = (await callTool(createHandler, { title })) as ToolExecutionResult;
+        ids.push(created.agentProjection.content.match(/<task id="([a-f0-9]{8})"/)![1]);
+      }
+
+      const updateHandler = buildUpdateTool(store).handler;
+      const result = (await callTool(updateHandler, {
+        id: ids,
+        title: ['A2', 'B2'],
+        status: [TodoStatus.IN_PROGRESS, TodoStatus.DONE],
+      })) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('complete');
+      expect(store.get(ids[0])!.title).toBe('A2');
+      expect(store.get(ids[0])!.status).toBe(TodoStatus.IN_PROGRESS);
+      expect(store.get(ids[1])!.title).toBe('B2');
+      expect(store.get(ids[1])!.status).toBe(TodoStatus.DONE);
+    });
+
+    async function createTwoTasks(): Promise<string[]> {
+      const createHandler = buildCreateTool(store).handler;
+      const ids: string[] = [];
+      for (const title of ['A', 'B']) {
+        const created = (await callTool(createHandler, { title })) as ToolExecutionResult;
+        ids.push(created.agentProjection.content.match(/<task id="([a-f0-9]{8})"/)![1]);
+      }
+      return ids;
+    }
+
+    it.each([
+      ['shorter title array', { title: ['Only one'] }],
+      ['longer title array', { title: ['X', 'Y', 'Z'] }],
+      ['shorter status array', { status: [TodoStatus.DONE] }],
+      ['longer status array', { status: [TodoStatus.DONE, TodoStatus.DONE, TodoStatus.DONE] }],
+    ])('todo_update rejects a %s mismatched against ids', async (_label, extra) => {
+      const ids = await createTwoTasks();
+
+      let notifyCount = 0;
+      const updateHandler = buildUpdateTool(store, () => { notifyCount += 1; }).handler;
+      const result = (await callTool(updateHandler, {
+        id: ids,
+        ...extra,
+      })) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('error');
+      expect(result.agentProjection.content).toContain('must match id array length');
+      expect(store.get(ids[0])!.title).toBe('A');
+      expect(store.get(ids[1])!.title).toBe('B');
+      expect(store.get(ids[0])!.status).toBe(TodoStatus.OPEN);
+      expect(store.get(ids[1])!.status).toBe(TodoStatus.OPEN);
+      expect(notifyCount).toBe(0);
     });
   });
 


### PR DESCRIPTION
…elity

#110: todo_create and todo_update now accept arrays for batch operations while remaining backward compatible with single values.
- todo_create accepts a single title or an array of titles; returns a batch payload when multiple are created.
- todo_update accepts single or array ids; scalar title/status broadcast to all ids, arrays matched by index; collects per-item errors without failing the whole call.
- notifyChanged fires exactly once per call regardless of item count.
- Extended renderTodoCreatePayload / renderTodoUpdatePayload to render batch shapes (multiple <task>/<changes> entries, <errors> list) while keeping single-record output identical.
- Added batch create/update and backward-compat tests.

#96: Interrupted subagents no longer surface as 'complete' in some surfaces.
- chain-subagent.ts restore default for missing/unparseable status changed from COMPLETED to INTERRUPTED, aligning with the queued/pending/running migration.
- wait_for_subagent now returns status 'error' instead of 'complete' when any waited subagent is interrupted or failed, so the main chat row and titleStatus renderer reflect the interrupted/failed state instead of always showing complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create multiple to-dos in a single operation.
  * Update multiple to-dos at once with individual success and error results.
  * Batch responses include created or updated items and operation counts.

* **Bug Fixes**
  * Improved rendering for batched to-do results and errors.
  * Failed or interrupted subagent operations now report an error outcome.
  * Invalid subagent statuses are handled as interrupted rather than completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->