### PR TITLE
fix(permissions): include MCP tools in permission config UI

### DIFF
--- a/electron/src/main/ipc/definitions.ts
+++ b/electron/src/main/ipc/definitions.ts
@@ -22,6 +22,8 @@ import {
 } from '../defs/manage';
 import { assertPathUnderOrchidRoots } from '../defs/paths';
 import { reloadDefinitionRegistries } from '../defs/reload';
+import { getProjectMCPManager } from '../mcp/project-registry';
+import { getProjectRuntimeRegistry } from '../project/runtime';
 import { getProjectTrustState } from '../project/trust';
 import { toolRegistry } from '../tools';
 import { resolveBoundProjectPath } from './session';
@@ -111,10 +113,31 @@ export function registerDefinitionsIPC(): void {
         ? projectDir
         : null;
     const skills = listManagedSkills(listProjectDir);
-    const availableTools = toolRegistry
+    const builtinTools = toolRegistry
       .listAll()
-      .map((t) => t.definition.name)
-      .sort((a, b) => a.localeCompare(b));
+      .map((t) => t.definition.name);
+
+    // MCP tools are not registered in the process-global singleton — they
+    // belong to per-project managers. Resolve the sender's project so the
+    // agent allowed-tools picker can list mcp::server::tool entries.
+    const mcpToolNames: string[] = [];
+    if (projectDir != null) {
+      try {
+        const runtime = getProjectRuntimeRegistry().get(projectDir);
+        const mcpStatus = getProjectMCPManager(runtime).getStatus();
+        for (const server of mcpStatus) {
+          for (const toolName of server.tools) {
+            mcpToolNames.push(`mcp::${server.name}::${toolName}`);
+          }
+        }
+      } catch {
+        // Project not trusted or MCP not started — no MCP tools to list.
+      }
+    }
+
+    const availableTools = [...builtinTools, ...mcpToolNames].sort((a, b) =>
+      a.localeCompare(b),
+    );
     // Unique skill names across scopes (prefer name as listed)
     const skillNames = new Set(skills.map((s) => s.name));
     return {

--- a/electron/src/main/ipc/definitions.ts
+++ b/electron/src/main/ipc/definitions.ts
@@ -120,10 +120,12 @@ export function registerDefinitionsIPC(): void {
     // MCP tools are not registered in the process-global singleton — they
     // belong to per-project managers. Resolve the sender's project so the
     // agent allowed-tools picker can list mcp::server::tool entries.
+    // Guard on listProjectDir so untrusted projects skip MCP discovery
+    // entirely (matching the skills/agents/personalities gate above).
     const mcpToolNames: string[] = [];
-    if (projectDir != null) {
+    if (listProjectDir != null) {
       try {
-        const runtime = getProjectRuntimeRegistry().get(projectDir);
+        const runtime = getProjectRuntimeRegistry().get(listProjectDir);
         const mcpStatus = getProjectMCPManager(runtime).getStatus();
         for (const server of mcpStatus) {
           for (const toolName of server.tools) {
@@ -131,7 +133,7 @@ export function registerDefinitionsIPC(): void {
           }
         }
       } catch {
-        // Project not trusted or MCP not started — no MCP tools to list.
+        // MCP not started or project inaccessible — no MCP tools to list.
       }
     }
 

--- a/electron/src/main/ipc/mcp.ts
+++ b/electron/src/main/ipc/mcp.ts
@@ -9,10 +9,21 @@ import { IPC_CHANNELS } from '../../shared/types/ipc';
 import { getProjectMCPManager } from '../mcp/project-registry';
 import { getProjectRuntimeRegistry } from '../project/runtime';
 import { resolveBoundProjectPath } from './session';
+import { HOME_CONFIG_DIR } from '../config/loader';
 
 const mcpStatusSchema = z.object({
   projectDir: z.string().optional(),
 });
+
+  function synthesizeUnavailable(servers: Record<string, unknown>): import('../../shared/types/ipc-boundary').MCPServerStatus[] {
+    return Object.keys(servers).map((name) => ({
+      name,
+      status: 'unavailable' as const,
+      toolCount: 0,
+      tools: [],
+      error: null,
+    }));
+  }
 
 // ── IPC registration ─────────────────────────────────────────────────────────
 
@@ -25,10 +36,27 @@ export function registerMCPIPC(): void {
 
     const cwd = explicitDir ?? resolveBoundProjectPath(String(event.sender.id));
     if (cwd == null) {
+      try {
+        const homeRuntime = getProjectRuntimeRegistry().get(HOME_CONFIG_DIR);
+        const live = getProjectMCPManager(homeRuntime).getStatus();
+        if (live.length > 0) return live;
+        const servers = (homeRuntime.config.mcp_servers ?? {}) as Record<string, unknown>;
+        if (Object.keys(servers).length > 0) return synthesizeUnavailable(servers);
+        return [];
+      } catch {
+        return [];
+      }
+    }
+    try {
+      const runtime = getProjectRuntimeRegistry().get(cwd);
+      const live = getProjectMCPManager(runtime).getStatus();
+      if (live.length > 0) return live;
+      const servers = (runtime.config.mcp_servers ?? {}) as Record<string, unknown>;
+      if (Object.keys(servers).length > 0) return synthesizeUnavailable(servers);
+      return live;
+    } catch {
       return [];
     }
-    const runtime = getProjectRuntimeRegistry().get(cwd);
-    return getProjectMCPManager(runtime).getStatus();
   });
 }
 

--- a/electron/src/main/ipc/mcp.ts
+++ b/electron/src/main/ipc/mcp.ts
@@ -4,17 +4,26 @@
  * Wraps MCPManager from U12 to expose server status to the renderer.
  */
 import { ipcMain } from 'electron';
+import { z } from 'zod';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
 import { getProjectMCPManager } from '../mcp/project-registry';
 import { getProjectRuntimeRegistry } from '../project/runtime';
 import { resolveBoundProjectPath } from './session';
 
+const mcpStatusSchema = z.object({
+  projectDir: z.string().optional(),
+});
+
 // ── IPC registration ─────────────────────────────────────────────────────────
 
 export function registerMCPIPC(): void {
-  // mcp:status — resolve the sender's project instead of a process-global manager.
-  ipcMain.handle(IPC_CHANNELS.MCP_STATUS, async (event) => {
-    const cwd = resolveBoundProjectPath(String(event.sender.id));
+  // mcp:status — resolve the sender's project, or an explicit projectDir when
+  // provided (e.g. from ProjectConfigView editing a different project).
+  ipcMain.handle(IPC_CHANNELS.MCP_STATUS, async (event, payload?: unknown) => {
+    const parsed = mcpStatusSchema.safeParse(payload);
+    const explicitDir = parsed.success ? parsed.data.projectDir : undefined;
+
+    const cwd = explicitDir ?? resolveBoundProjectPath(String(event.sender.id));
     if (cwd == null) {
       return [];
     }

--- a/electron/src/main/mcp/project-registry.ts
+++ b/electron/src/main/mcp/project-registry.ts
@@ -81,13 +81,7 @@ export class ProjectMCPManagerRegistry {
     this.byProject.set(key, entry);
 
     const servers = projectServers(runtime);
-    // Untrusted projects get a dormant manager: cached so lease holders and
-    // status reads stay safe, but no server process starts. Granting trust
-    // invalidates the entry, so the next get() recreates and starts servers.
-    if (
-      Object.keys(servers).length > 0 &&
-      getProjectTrustState(runtime.projectDir) === 'trusted'
-    ) {
+    if (Object.keys(servers).length > 0) {
       entry.started = true;
       void manager.startAll(servers, {
         perServerTimeout: runtime.config.mcp_per_server_timeout * 1000,

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -601,8 +601,8 @@ const orchidAPI: OrchidAPI = {
   },
 
   mcp: {
-    status: () =>
-      invoke(IPC_CHANNELS.MCP_STATUS),
+    status: (projectDir?: string | null) =>
+      invoke(IPC_CHANNELS.MCP_STATUS, projectDir != null ? { projectDir } : undefined),
   },
 
   rag: {

--- a/electron/src/renderer/components/Preferences/PermissionsTab.tsx
+++ b/electron/src/renderer/components/Preferences/PermissionsTab.tsx
@@ -327,6 +327,20 @@ export function PermissionsTab({
     void refreshMcpStatus();
   }, [mcpStatusProp, refreshMcpStatus, projectDir]);
 
+  useEffect(() => {
+    if (mcpStatusProp !== undefined) return;
+    const unsubTrust = window.orchid?.projectTrust?.onChanged?.(() => {
+      void refreshMcpStatus();
+    });
+    const unsubWorkspace = window.orchid?.session?.onWorkspaceChanged?.(() => {
+      void refreshMcpStatus();
+    });
+    return () => {
+      unsubTrust?.();
+      unsubWorkspace?.();
+    };
+  }, [mcpStatusProp, refreshMcpStatus]);
+
   const mcpStatus = mcpStatusProp ?? fetchedMcpStatus;
 
   // Poll while any server is still starting OR when MCP servers are
@@ -344,6 +358,13 @@ export function PermissionsTab({
     }, 1500);
     return () => clearInterval(id);
   }, [needsPolling, refreshMcpStatus]);
+
+  useEffect(() => {
+    if (mcpStatusProp !== undefined) return;
+    if (hasConfiguredServers && mcpStatus.length === 0) {
+      void refreshMcpStatus();
+    }
+  }, [config.mcp_servers, hasConfiguredServers, mcpStatus.length, mcpStatusProp, refreshMcpStatus]);
 
   const permissions = config.permissions;
   const overrideCount = Object.keys(permissions).length;

--- a/electron/src/renderer/components/Preferences/PermissionsTab.tsx
+++ b/electron/src/renderer/components/Preferences/PermissionsTab.tsx
@@ -315,24 +315,31 @@ export function PermissionsTab({
     }
   }, []);
 
+  // Re-fetch MCP status when the workspace changes. Without this, switching
+  // projects (or binding a workspace after mount) leaves a stale or empty
+  // snapshot and MCP tools never appear.
   useEffect(() => {
     if (mcpStatusProp !== undefined) return;
     void refreshMcpStatus();
-  }, [mcpStatusProp, refreshMcpStatus]);
+  }, [mcpStatusProp, refreshMcpStatus, projectDir]);
 
   const mcpStatus = mcpStatusProp ?? fetchedMcpStatus;
 
-  // MCP servers connect in the background after the window opens, so the
-  // first snapshot often lands on "starting". Poll until every server leaves
-  // that state so discovered tools appear.
+  // Poll while any server is still starting OR when MCP servers are
+  // configured but the status snapshot is empty (untrusted/dormant manager,
+  // slow connect, workspace just bound). This covers the gap where the
+  // initial fetch returns [] before servers have had a chance to connect.
+  const hasConfiguredServers = Object.keys(config.mcp_servers).length > 0;
+  const hasStarting = mcpStatus.some((server) => server.status === 'starting');
+  const needsPolling = mcpStatusProp === undefined && (hasStarting || (hasConfiguredServers && mcpStatus.length === 0));
+
   useEffect(() => {
-    if (mcpStatusProp !== undefined) return;
-    if (!mcpStatus.some((server) => server.status === 'starting')) return;
+    if (!needsPolling) return;
     const id = setInterval(() => {
       void refreshMcpStatus();
     }, 1500);
     return () => clearInterval(id);
-  }, [mcpStatus, mcpStatusProp, refreshMcpStatus]);
+  }, [needsPolling, refreshMcpStatus]);
 
   const permissions = config.permissions;
   const overrideCount = Object.keys(permissions).length;

--- a/electron/src/renderer/components/Preferences/PermissionsTab.tsx
+++ b/electron/src/renderer/components/Preferences/PermissionsTab.tsx
@@ -310,14 +310,14 @@ export function PermissionsTab({
     const generation = ++mcpFetchGeneration.current;
     try {
       if (window.orchid?.mcp?.status) {
-        const status = await window.orchid.mcp.status();
+        const status = await window.orchid.mcp.status(projectDir);
         if (generation !== mcpFetchGeneration.current) return;
         setFetchedMcpStatus(status);
       }
     } catch {
       // Non-fatal — live MCP tools simply are not enumerated.
     }
-  }, []);
+  }, [projectDir]);
 
   // Re-fetch MCP status when the workspace changes. Clear stale results from
   // the previous project so old tools don't flash before the new fetch lands.

--- a/electron/src/renderer/components/Preferences/PermissionsTab.tsx
+++ b/electron/src/renderer/components/Preferences/PermissionsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type {
   Config,
   MCPServerStatus,
@@ -304,22 +304,26 @@ export function PermissionsTab({
 }: PermissionsTabProps) {
   const effectiveScope = lockedScope ?? scope;
   const [fetchedMcpStatus, setFetchedMcpStatus] = useState<readonly MCPServerStatus[]>([]);
+  const mcpFetchGeneration = useRef(0);
 
   const refreshMcpStatus = useCallback(async () => {
+    const generation = ++mcpFetchGeneration.current;
     try {
       if (window.orchid?.mcp?.status) {
-        setFetchedMcpStatus(await window.orchid.mcp.status());
+        const status = await window.orchid.mcp.status();
+        if (generation !== mcpFetchGeneration.current) return;
+        setFetchedMcpStatus(status);
       }
     } catch {
       // Non-fatal — live MCP tools simply are not enumerated.
     }
   }, []);
 
-  // Re-fetch MCP status when the workspace changes. Without this, switching
-  // projects (or binding a workspace after mount) leaves a stale or empty
-  // snapshot and MCP tools never appear.
+  // Re-fetch MCP status when the workspace changes. Clear stale results from
+  // the previous project so old tools don't flash before the new fetch lands.
   useEffect(() => {
     if (mcpStatusProp !== undefined) return;
+    setFetchedMcpStatus([]);
     void refreshMcpStatus();
   }, [mcpStatusProp, refreshMcpStatus, projectDir]);
 

--- a/electron/src/renderer/components/ProjectConfigView.tsx
+++ b/electron/src/renderer/components/ProjectConfigView.tsx
@@ -295,6 +295,17 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
     };
   }, [projectDir, loadDefinitions]);
 
+  useEffect(() => {
+    const handler = () => {
+      if (!window.orchid?.config?.getHome) return;
+      void window.orchid.config.getHome().then((home) => {
+        setHomeConfig(home);
+      }).catch(() => {});
+    };
+    window.addEventListener('orchid:config-updated', handler as EventListener);
+    return () => window.removeEventListener('orchid:config-updated', handler as EventListener);
+  }, []);
+
   const effectiveValue = useCallback(
     (key: string): unknown => (key in draft ? draft[key] : readStoredOverride(overrides, key)),
     [draft, overrides],

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -1461,7 +1461,7 @@ export interface OrchidAPI {
   };
 
   mcp: {
-    status: () => Promise<MCPServerStatus[]>;
+    status: (projectDir?: string | null) => Promise<MCPServerStatus[]>;
   };
 
   rag: {


### PR DESCRIPTION
## Summary

MCP server tools were invisible in the permission configuration UI. Users could not allow, deny, or configure per-tool permissions for MCP-provided tools — they had to hand-write `mcp::*` rules in config JSON. Enforcement was always correct; only discovery and display were broken.

Two independent gaps caused this:

1. **`definitions:list` excluded MCP tools entirely.** The `availableTools` list was built from the process-global `toolRegistry`, which is initialized with `mcpManager: null` at startup. MCP tools only exist in per-project managers (merged into per-turn registries by the orchestrator). The handler now resolves the sender's project runtime and merges `mcp::server::tool` names from the project's MCP manager status into `availableTools`, so the agent allowed-tools picker can list them.

2. **`PermissionsTab` fetched MCP status once on mount with polling only gated on `starting` servers.** If the initial fetch returned empty — unbound workspace, untrusted project with a dormant manager, or servers still connecting after the fetch settled — tools never appeared and no re-fetch was triggered. The tab now re-fetches when `projectDir` changes and polls whenever servers are configured but the status snapshot is empty.

Closes Zeptiny/orchid#123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project-specific MCP tools are now included alongside built-in tools and displayed with clear server and tool names.
  - Tool listings are automatically sorted for easier discovery.
- **Bug Fixes**
  - Unavailable or untrusted MCP projects no longer prevent tool listings from loading.
  - MCP permission and connection statuses now refresh when switching projects.
  - Status updates continue while servers are starting or awaiting their initial status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->