### PR TITLE
fix(security): realpath-based path sandboxing for all mutating filesystem tools

### DIFF
--- a/electron/src/main/agents-md/resolver.ts
+++ b/electron/src/main/agents-md/resolver.ts
@@ -11,6 +11,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Config } from '../config/schema';
 import { resolveToolPath } from '../tools/types';
+import {
+  isPathContainedIn,
+  canonicalizeEffectivePath,
+  canonicalizeExistingPathCached,
+} from '../tools/path-sandbox';
 import { effectiveAgentsMdFilenames } from './config';
 
 /** A single governing instruction file discovered during the upward walk. */
@@ -34,76 +39,8 @@ export interface AgentsMdContent {
 }
 
 // ---------------------------------------------------------------------------
-// Path canonicalization + containment (mirrors permissions/resolver.ts)
+// Per-directory instruction-file lookup
 // ---------------------------------------------------------------------------
-
-function isPathContainedIn(resolved: string, cwd: string): boolean {
-  return resolved === cwd || resolved.startsWith(cwd + path.sep);
-}
-
-function isMissingPathError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    'code' in error &&
-    (error as NodeJS.ErrnoException).code === 'ENOENT'
-  );
-}
-
-/**
- * Canonicalize a path that may not fully exist yet (e.g. a file about to be
- * created): resolve the nearest existing ancestor with `realpathSync.native`
- * and re-append the missing components. Returns null if nothing resolves.
- */
-function canonicalizeEffectivePath(candidate: string): string | null {
-  let current = path.resolve(candidate);
-  const missingParts: string[] = [];
-
-  while (true) {
-    try {
-      const existingParent = fs.realpathSync.native(current);
-      return path.resolve(existingParent, ...missingParts);
-    } catch (error) {
-      if (!isMissingPathError(error)) return null;
-
-      try {
-        fs.lstatSync(current);
-        return null;
-      } catch (lstatError) {
-        if (!isMissingPathError(lstatError)) return null;
-      }
-
-      const parent = path.dirname(current);
-      if (parent === current) return null;
-      missingParts.unshift(path.basename(current));
-      current = parent;
-    }
-  }
-}
-
-function canonicalizeExistingPath(candidate: string): string | null {
-  try {
-    return fs.realpathSync.native(path.resolve(candidate));
-  } catch {
-    return null;
-  }
-}
-
-// The cwd is frozen per turn, so canonicalizing it on every file-tool call
-// repeats a blocking fs.realpathSync.native on the main-process event loop
-// (amplified N× across an apply_patch's files). Memoize the result in a small
-// bounded cache keyed by the resolved cwd, mirroring permissions/resolver.ts.
-// Per-target symlink resolution (canonicalizeEffectivePath) stays live.
-const canonicalPathCache = new Map<string, string | null>();
-const CANONICAL_CACHE_MAX = 256;
-
-function canonicalizeExistingPathCached(candidate: string): string | null {
-  const key = path.resolve(candidate);
-  if (canonicalPathCache.has(key)) return canonicalPathCache.get(key) ?? null;
-  const result = canonicalizeExistingPath(key);
-  if (canonicalPathCache.size >= CANONICAL_CACHE_MAX) canonicalPathCache.clear();
-  canonicalPathCache.set(key, result);
-  return result;
-}
 
 // ---------------------------------------------------------------------------
 // Per-directory instruction-file lookup

--- a/electron/src/main/permissions/resolver.ts
+++ b/electron/src/main/permissions/resolver.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import {
   RISK_CLASS_DEFAULTS,
@@ -10,6 +9,11 @@ import {
   type PermissionResolution,
 } from '../../shared/types/permission';
 import type { Config, PermissionRule } from '../../shared/types/ipc-boundary';
+import {
+  isPathContainedIn,
+  canonicalizeEffectivePath,
+  canonicalizeExistingPathCached,
+} from '../tools/path-sandbox';
 
 // Re-export the shared source-of-truth constants so existing consumers that
 // import them from the resolver (tool-dispatch.ts, permissions/index.ts) keep
@@ -54,67 +58,11 @@ export function extractPathsFromArgs(
   return paths;
 }
 
-function isPathContainedIn(resolved: string, cwd: string): boolean {
-  return resolved === cwd || resolved.startsWith(cwd + path.sep);
-}
-
-function isMissingPathError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    'code' in error &&
-    (error as NodeJS.ErrnoException).code === 'ENOENT'
-  );
-}
-
-function canonicalizeEffectivePath(candidate: string): string | null {
-  let current = path.resolve(candidate);
-  const missingParts: string[] = [];
-
-  while (true) {
-    try {
-      const existingParent = fs.realpathSync.native(current);
-      return path.resolve(existingParent, ...missingParts);
-    } catch (error) {
-      if (!isMissingPathError(error)) return null;
-
-      try {
-        fs.lstatSync(current);
-        return null;
-      } catch (lstatError) {
-        if (!isMissingPathError(lstatError)) return null;
-      }
-
-      const parent = path.dirname(current);
-      if (parent === current) return null;
-      missingParts.unshift(path.basename(current));
-      current = parent;
-    }
-  }
-}
-
-function canonicalizeExistingPath(candidate: string): string | null {
-  try {
-    return fs.realpathSync.native(path.resolve(candidate));
-  } catch {
-    return null;
-  }
-}
-
 // The cwd is frozen per turn, so canonicalizing it on every file-tool call
 // repeats a blocking fs.realpathSync.native on the main-process event loop.
 // Memoize the result in a small bounded cache keyed by the resolved cwd.
 // Per-target symlink resolution (canonicalizeEffectivePath) stays live.
-const canonicalPathCache = new Map<string, string | null>();
-const CANONICAL_CACHE_MAX = 256;
-
-function canonicalizeExistingPathCached(candidate: string): string | null {
-  const key = path.resolve(candidate);
-  if (canonicalPathCache.has(key)) return canonicalPathCache.get(key) ?? null;
-  const result = canonicalizeExistingPath(key);
-  if (canonicalPathCache.size >= CANONICAL_CACHE_MAX) canonicalPathCache.clear();
-  canonicalPathCache.set(key, result);
-  return result;
-}
+// (Imported from ../tools/path-sandbox.)
 
 /** Resolve a file tool's workspace scope ('inside' | 'outside') from its args. */
 export function resolveToolScope(

--- a/electron/src/main/tools/ast/replace-symbol.ts
+++ b/electron/src/main/tools/ast/replace-symbol.ts
@@ -12,7 +12,7 @@ import type { ToolDefinition, ToolHandler } from '../types';
 import { RiskClass } from '../../../shared/types/permission';
 import { genericToolResultMetadata } from '../types';
 import { genericBuiltInToolOutcome } from '../result';
-import { resolveToolPath } from '../types';
+import { assertPathInWorkspace } from '../path-sandbox';
 import { langForExtension, loadQueryFile, parseFile, runQuery } from '../../ast/parser';
 import { atomicWrite, findExtendedRange } from './utils';
 
@@ -53,7 +53,18 @@ export const replaceSymbolDefinition: ToolDefinition = {
 
 export const replaceSymbolHandler: ToolHandler = async (input: unknown, ctx) => {
   const { file_path: rawPath, symbol_name, new_source } = input as ReplaceSymbolInput;
-  const file_path = resolveToolPath(ctx.cwd, rawPath);
+
+  let file_path: string;
+  try {
+    file_path = assertPathInWorkspace(rawPath, ctx.cwd);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return genericBuiltInToolOutcome('replace_symbol', {
+      file: rawPath, symbol: symbol_name, success: false,
+      replacements: 0, error: 'path_traversal',
+      message: msg,
+    }, 'error', 'tool_error', msg);
+  }
 
   try {
     if (!fs.existsSync(file_path)) {

--- a/electron/src/main/tools/filesystem/apply-patch.ts
+++ b/electron/src/main/tools/filesystem/apply-patch.ts
@@ -9,7 +9,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition, ToolHandler, ToolHandlerOutcome } from '../types';
 import { RiskClass } from '../../../shared/types/permission';
-import { resolveToolPath } from '../types';
+import { assertPathInWorkspace } from '../path-sandbox';
 import {
   renderXmlToolResult,
   xmlText,
@@ -200,10 +200,6 @@ function fileError(
   return { path: filePath, operation, status: 'error', error: { code, message } };
 }
 
-function isPathContainedIn(resolved: string, cwd: string): boolean {
-  return resolved === cwd || resolved.startsWith(cwd + path.sep);
-}
-
 function isAbsolutePatchPath(filePath: string): boolean {
   return path.isAbsolute(filePath) || path.win32.isAbsolute(filePath);
 }
@@ -257,9 +253,16 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
   let failed = 0;
 
   for (const hunk of parsed.hunks) {
-    const resolved = resolveToolPath(ctx.cwd, hunk.path);
+    if (isAbsolutePatchPath(hunk.path)) {
+      files.push(fileError(hunk.path, hunk.type === 'add' ? 'create' : hunk.type === 'delete' ? 'delete' : 'update', 'path_traversal', `Path '${hunk.path}' escapes the working directory.`));
+      failed++;
+      continue;
+    }
 
-    if (isAbsolutePatchPath(hunk.path) || !isPathContainedIn(resolved, ctx.cwd)) {
+    let resolved: string;
+    try {
+      resolved = assertPathInWorkspace(hunk.path, ctx.cwd);
+    } catch {
       files.push(fileError(hunk.path, hunk.type === 'add' ? 'create' : hunk.type === 'delete' ? 'delete' : 'update', 'path_traversal', `Path '${hunk.path}' escapes the working directory.`));
       failed++;
       continue;
@@ -338,8 +341,11 @@ export const applyPatchHandler: ToolHandler = async (input: unknown, ctx) => {
         const validated = fileChangeDataSchema.parse(data);
 
         if (hunk.movePath) {
-          const moveResolved = resolveToolPath(ctx.cwd, hunk.movePath);
-          if (isAbsolutePatchPath(hunk.movePath) || !isPathContainedIn(moveResolved, ctx.cwd)) {
+          let moveResolved: string;
+          try {
+            if (isAbsolutePatchPath(hunk.movePath)) throw new Error('absolute path');
+            moveResolved = assertPathInWorkspace(hunk.movePath, ctx.cwd);
+          } catch {
             files.push(fileError(hunk.path, 'update', 'path_traversal', `Move path '${hunk.movePath}' escapes the working directory.`));
             failed++;
             continue;

--- a/electron/src/main/tools/filesystem/edit.ts
+++ b/electron/src/main/tools/filesystem/edit.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import { z } from 'zod';
 import type { ToolDefinition, ToolHandler, ToolHandlerOutcome } from '../types';
 import { RiskClass } from '../../../shared/types/permission';
-import { resolveToolPath } from '../types';
+import { assertPathInWorkspace } from '../path-sandbox';
 import { atomicWrite } from '../ast/utils';
 import { buildStructuredFileChange } from './structured-diff';
 import {
@@ -68,7 +68,14 @@ function errorOutcome(
 
 export const editHandler: ToolHandler = async (input: unknown, ctx) => {
   const { file_path: rawPath, old_string, new_string, replace_all = false } = input as EditInput;
-  const filePath = resolveToolPath(ctx.cwd, rawPath);
+
+  let filePath: string;
+  try {
+    filePath = assertPathInWorkspace(rawPath, ctx.cwd);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return errorOutcome(rawPath, message, 'path_traversal', '');
+  }
 
   let content: string;
   try {

--- a/electron/src/main/tools/filesystem/write.ts
+++ b/electron/src/main/tools/filesystem/write.ts
@@ -9,7 +9,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition, ToolHandler } from '../types';
 import { RiskClass } from '../../../shared/types/permission';
-import { resolveToolPath } from '../types';
+import { assertPathInWorkspace } from '../path-sandbox';
 import { atomicWrite } from '../ast/utils';
 import {
   fileWriteDataSchema,
@@ -62,7 +62,19 @@ function writeData(filePath: string, operation: FileWriteData['operation'], cont
 
 export const writeHandler: ToolHandler = async (input: unknown, ctx) => {
   const { file_path: rawPath, content } = input as WriteInput;
-  const filePath = resolveToolPath(ctx.cwd, rawPath);
+
+  let filePath: string;
+  try {
+    filePath = assertPathInWorkspace(rawPath, ctx.cwd);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      status: 'error',
+      data: writeData(rawPath, 'create', content),
+      error: { code: 'path_traversal', message },
+    };
+  }
+
   const operation: FileWriteData['operation'] = fs.existsSync(filePath) ? 'replace' : 'create';
   const data = writeData(filePath, operation, content);
 

--- a/electron/src/main/tools/index.ts
+++ b/electron/src/main/tools/index.ts
@@ -334,3 +334,4 @@ export type {
   ToolExecutionContext,
 } from './types';
 export { resolveToolPath } from './types';
+export { assertPathInWorkspace } from './path-sandbox';

--- a/electron/src/main/tools/path-sandbox.ts
+++ b/electron/src/main/tools/path-sandbox.ts
@@ -1,0 +1,114 @@
+/**
+ * Realpath-based workspace path sandboxing.
+ *
+ * All mutating filesystem tools must resolve user-supplied paths through
+ * `assertPathInWorkspace` to block symlink-based workspace escapes. The
+ * canonicalization helpers here are the single source of truth — other
+ * modules (`permissions/resolver.ts`, `agents-md/resolver.ts`) import from
+ * here instead of maintaining their own copies.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { resolveToolPath } from './types';
+
+/** Lexical containment check (does not resolve symlinks). */
+export function isPathContainedIn(resolved: string, cwd: string): boolean {
+  return resolved === cwd || resolved.startsWith(cwd + path.sep);
+}
+
+export function isMissingPathError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+/**
+ * Canonicalize a path that may not fully exist yet (e.g. a file about to be
+ * created): resolve the nearest existing ancestor with `realpathSync.native`
+ * and re-append the missing components. Returns null if nothing resolves.
+ */
+export function canonicalizeEffectivePath(candidate: string): string | null {
+  let current = path.resolve(candidate);
+  const missingParts: string[] = [];
+
+  while (true) {
+    try {
+      const existingParent = fs.realpathSync.native(current);
+      return path.resolve(existingParent, ...missingParts);
+    } catch (error) {
+      if (!isMissingPathError(error)) return null;
+
+      try {
+        fs.lstatSync(current);
+        return null;
+      } catch (lstatError) {
+        if (!isMissingPathError(lstatError)) return null;
+      }
+
+      const parent = path.dirname(current);
+      if (parent === current) return null;
+      missingParts.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+/** Canonicalize a path that must already exist on disk. */
+export function canonicalizeExistingPath(candidate: string): string | null {
+  try {
+    return fs.realpathSync.native(path.resolve(candidate));
+  } catch {
+    return null;
+  }
+}
+
+// The cwd is frozen per turn, so canonicalizing it on every file-tool call
+// repeats a blocking fs.realpathSync.native on the main-process event loop
+// (amplified N× across an apply_patch's files). Memoize the result in a small
+// bounded cache keyed by the resolved cwd.
+// Per-target symlink resolution (canonicalizeEffectivePath) stays live.
+const canonicalPathCache = new Map<string, string | null>();
+const CANONICAL_CACHE_MAX = 256;
+
+export function canonicalizeExistingPathCached(candidate: string): string | null {
+  const key = path.resolve(candidate);
+  if (canonicalPathCache.has(key)) return canonicalPathCache.get(key) ?? null;
+  const result = canonicalizeExistingPath(key);
+  if (canonicalPathCache.size >= CANONICAL_CACHE_MAX) canonicalPathCache.clear();
+  canonicalPathCache.set(key, result);
+  return result;
+}
+
+/**
+ * Resolve a user-supplied path against the workspace cwd and verify (via
+ * realpath) that it stays inside the workspace after symlink resolution.
+ *
+ * Handles not-yet-existing paths (e.g. files about to be created) by
+ * resolving the nearest existing ancestor and re-appending missing
+ * components, mirroring the logic in `permissions/resolver.ts`.
+ *
+ * @returns The resolved logical path (symlinks are followed by the caller's
+ *          fs operations, not resolved here).
+ * @throws  If the path escapes the workspace via symlink or cannot be resolved.
+ */
+export function assertPathInWorkspace(userPath: string, cwd: string): string {
+  const resolved = resolveToolPath(cwd, userPath);
+
+  const canonicalCwd = canonicalizeExistingPathCached(cwd);
+  if (canonicalCwd === null) {
+    throw new Error(`Cannot resolve working directory: ${cwd}`);
+  }
+
+  const canonicalTarget = canonicalizeEffectivePath(resolved);
+  if (canonicalTarget === null) {
+    throw new Error(`Cannot resolve path: ${userPath}`);
+  }
+
+  if (!isPathContainedIn(canonicalTarget, canonicalCwd)) {
+    throw new Error(`Path '${userPath}' escapes the working directory.`);
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
## Problem

`resolveToolPath` resolved user-supplied paths lexically only (`path.resolve` + `path.normalize`), never calling `fs.realpathSync`. A symlink inside the project pointing outside the workspace (e.g. `./evil → /etc`) passed all lexical containment checks, allowing file writes/reads outside the sandbox.

- **`write`** — called `resolveToolPath` with **no containment check at all**
- **`edit`** — same, no containment check
- **`apply-patch`** — had `isPathContainedIn` but it was lexical-only, bypassable via directory symlinks
- **`replace-symbol`** — mutating tool with no containment check (same class of bug, not mentioned in issue)

## Fix

Created `tools/path-sandbox.ts` as the single source of truth for realpath-based workspace containment:

- **`assertPathInWorkspace()`** — resolves the path, canonicalizes via `fs.realpathSync.native`, and verifies the canonical target stays inside the canonical workspace root. Handles not-yet-existing paths (e.g. files about to be created) by walking up to the nearest existing ancestor and re-appending missing components.
- **`canonicalizeEffectivePath()`** / **`canonicalizeExistingPathCached()`** — extracted from duplicated copies in `permissions/resolver.ts` and `agents-md/resolver.ts`.

Applied `assertPathInWorkspace` to all four mutating filesystem tools:

| Tool | Before | After |
|------|--------|-------|
| `write` | No check | `assertPathInWorkspace` |
| `edit` | No check | `assertPathInWorkspace` |
| `apply-patch` | Lexical `isPathContainedIn` | `assertPathInWorkspace` (file paths + move destinations) |
| `replace-symbol` | No check | `assertPathInWorkspace` |

Also deduplicated the canonicalization helpers (`isPathContainedIn`, `canonicalizeEffectivePath`, `canonicalizeExistingPath`, `canonicalizeExistingPathCached`, `isMissingPathError`) from `permissions/resolver.ts` and `agents-md/resolver.ts` into the shared module — both files now import from `tools/path-sandbox.ts`.

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run test` — 4026 tests pass (274 files), including existing path traversal tests for apply-patch

Fixes #105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened workspace path protection across file editing, writing, patching, and symbol replacement tools.
  * Rejects absolute paths, unresolved paths, and symlink-based paths that escape the workspace.
  * Returns clear structured errors for invalid or unsafe paths without accessing or modifying files.
* **Refactor**
  * Unified path validation and canonicalization behavior across workspace tools for more consistent protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->