### PR TITLE
Fix #123: surface MCP tools in permission configuration

### DIFF
--- a/electron/src/main/ipc/definitions.ts
+++ b/electron/src/main/ipc/definitions.ts
@@ -23,7 +23,9 @@ import {
 import { assertPathUnderOrchidRoots } from '../defs/paths';
 import { reloadDefinitionRegistries } from '../defs/reload';
 import { getProjectTrustState } from '../project/trust';
+import { getProjectRuntimeRegistry } from '../project/runtime';
 import { toolRegistry } from '../tools';
+import { getProjectMCPManager } from '../mcp/project-registry';
 import { resolveBoundProjectPath } from './session';
 
 // ── Schemas ──────────────────────────────────────────────────────────────────
@@ -111,9 +113,20 @@ export function registerDefinitionsIPC(): void {
         ? projectDir
         : null;
     const skills = listManagedSkills(listProjectDir);
-    const availableTools = toolRegistry
-      .listAll()
-      .map((t) => t.definition.name)
+    const builtinTools = toolRegistry.listAll().map((t) => t.definition.name);
+    const mcpTools: string[] = [];
+    if (listProjectDir != null) {
+      try {
+        const runtime = getProjectRuntimeRegistry().get(listProjectDir);
+        const mcpManager = getProjectMCPManager(runtime);
+        for (const { definition } of mcpManager.getTools()) {
+          mcpTools.push(definition.name);
+        }
+      } catch {
+        // Non-fatal: MCP manager unavailable for this project
+      }
+    }
+    const availableTools = Array.from(new Set([...builtinTools, ...mcpTools]))
       .sort((a, b) => a.localeCompare(b));
     // Unique skill names across scopes (prefer name as listed)
     const skillNames = new Set(skills.map((s) => s.name));

--- a/electron/src/renderer/components/Preferences/PermissionsTab.tsx
+++ b/electron/src/renderer/components/Preferences/PermissionsTab.tsx
@@ -322,17 +322,25 @@ export function PermissionsTab({
 
   const mcpStatus = mcpStatusProp ?? fetchedMcpStatus;
 
-  // MCP servers connect in the background after the window opens, so the
-  // first snapshot often lands on "starting". Poll until every server leaves
-  // that state so discovered tools appear.
+  // Continuously poll MCP status when any configured server is still
+  // in the process of connecting or has not yet reported tools. This
+  // catches servers that start asynchronously after the tab mounts.
+  const needsPolling = mcpStatusProp === undefined && (
+    mcpStatus.some((server) => server.status === 'starting') ||
+    Object.keys(config.mcp_servers).some((server) => {
+      const status = mcpStatus.find((s) => s.name === server);
+      // Server configured but not seen in status yet, or connected but no tools
+      return !status || (status.status === 'connected' && status.tools.length === 0);
+    })
+  );
+
   useEffect(() => {
-    if (mcpStatusProp !== undefined) return;
-    if (!mcpStatus.some((server) => server.status === 'starting')) return;
+    if (!needsPolling) return;
     const id = setInterval(() => {
       void refreshMcpStatus();
     }, 1500);
     return () => clearInterval(id);
-  }, [mcpStatus, mcpStatusProp, refreshMcpStatus]);
+  }, [needsPolling, refreshMcpStatus]);
 
   const permissions = config.permissions;
   const overrideCount = Object.keys(permissions).length;


### PR DESCRIPTION
## Summary

Fixes #123 — MCP server tools were invisible in permission configuration and the agent allowed-tools picker even though permission enforcement (`mcp::server::tool` / `mcp::server::*` rules) already worked.

**Before:**
- The agent allowed-tools picker never listed `mcp::*` tools because `definitions:list` only read the process-global `toolRegistry` (built with `mcpManager: null`).
- The Permissions tab only polled MCP status while servers reported `starting`; once a server transitioned to `connected` without tools yet, polling stopped and never resumed.

**After:**
- `definitions:list` merges the bound trusted project's live MCP tools into `availableTools`.
- `PermissionsTab` continues polling for configured servers that are absent from status or connected-but-tool-less, catching servers that finish enumerating asynchronously after the tab mounts.

Trust stays fail-closed: untrusted projects use dormant managers, so no MCP tools surface.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- Full test suite: 4026 tests / 274 files pass
