### PR TITLE
fix(permissions): surface MCP tools in permission configuration

### DIFF
--- a/electron/src/main/ipc/definitions.ts
+++ b/electron/src/main/ipc/definitions.ts
@@ -22,6 +22,8 @@ import {
 } from '../defs/manage';
 import { assertPathUnderOrchidRoots } from '../defs/paths';
 import { reloadDefinitionRegistries } from '../defs/reload';
+import { getProjectMCPManager } from '../mcp/project-registry';
+import { getProjectRuntimeRegistry } from '../project/runtime';
 import { getProjectTrustState } from '../project/trust';
 import { toolRegistry } from '../tools';
 import { resolveBoundProjectPath } from './session';
@@ -80,6 +82,31 @@ function projectDirFromEvent(event: Electron.IpcMainInvokeEvent): string | null 
 }
 
 /**
+ * Namespaced MCP tool names (`mcp::server::tool`) for one bound project.
+ *
+ * The builtin-tool singleton never carries MCP tools (they are merged into
+ * per-turn registries), so the allowed-tools picker must source them from the
+ * window's project MCP manager. Untrusted projects hold a dormant manager
+ * with no tools, so this stays trust-safe without an explicit gate. Any
+ * runtime/manager failure must not break definitions listing.
+ */
+function mcpToolNamesForProject(projectDir: string | null): string[] {
+  if (projectDir == null) return [];
+  try {
+    const runtime = getProjectRuntimeRegistry().get(projectDir);
+    return getProjectMCPManager(runtime)
+      .getTools()
+      .map(({ definition }) => definition.name);
+  } catch (error) {
+    console.warn(
+      `Failed to enumerate MCP tools for '${projectDir}' (non-fatal):`,
+      error,
+    );
+    return [];
+  }
+}
+
+/**
  * Validate payload, resolve project dir, run mutation, reload registries.
  * Shared by skill/agent/personality save and delete handlers.
  */
@@ -114,6 +141,7 @@ export function registerDefinitionsIPC(): void {
     const availableTools = toolRegistry
       .listAll()
       .map((t) => t.definition.name)
+      .concat(mcpToolNamesForProject(projectDir))
       .sort((a, b) => a.localeCompare(b));
     // Unique skill names across scopes (prefer name as listed)
     const skillNames = new Set(skills.map((s) => s.name));

--- a/electron/src/renderer/components/Preferences/PermissionsTab.tsx
+++ b/electron/src/renderer/components/Preferences/PermissionsTab.tsx
@@ -315,9 +315,34 @@ export function PermissionsTab({
     }
   }, []);
 
+  // Fetch on mount and whenever the configured server set changes — saving
+  // MCP server config invalidates the main-process managers, so a refetch
+  // re-creates them and picks up newly added servers.
+  const configuredServerKey = useMemo(
+    () => Object.keys(config.mcp_servers).sort().join(' '),
+    [config.mcp_servers],
+  );
   useEffect(() => {
     if (mcpStatusProp !== undefined) return;
     void refreshMcpStatus();
+  }, [configuredServerKey, mcpStatusProp, refreshMcpStatus]);
+
+  // mcp:status is a pull API with no push channel, so re-fetch on the two
+  // lifecycle events that change what the pull returns: workspace binding
+  // (unbound windows always get []) and trust grants (a dormant manager only
+  // starts servers after trust is granted).
+  useEffect(() => {
+    if (mcpStatusProp !== undefined) return;
+    const refresh = () => {
+      void refreshMcpStatus();
+    };
+    const unsubscribers = [
+      window.orchid?.session?.onWorkspaceChanged?.(refresh),
+      window.orchid?.projectTrust?.onChanged?.(refresh),
+    ];
+    return () => {
+      for (const unsubscribe of unsubscribers) unsubscribe?.();
+    };
   }, [mcpStatusProp, refreshMcpStatus]);
 
   const mcpStatus = mcpStatusProp ?? fetchedMcpStatus;

--- a/electron/src/renderer/components/ui/Disclosure.tsx
+++ b/electron/src/renderer/components/ui/Disclosure.tsx
@@ -27,7 +27,7 @@ const VARIANT_CONTENT_CLASS = {
   card: '',
 } as const;
 
-/** Native, keyboard-accessible disclosure with collapse styling. */
+/** Native, keyboard-accessible disclosure with orchid-disclosure styling. */
 export function Disclosure({
   summary,
   children,
@@ -39,16 +39,16 @@ export function Disclosure({
 }: DisclosureProps) {
   return (
     <details
-      className={`collapse collapse-arrow ${VARIANT_CLASS[variant]} ${className}`.trim().replace(/\s+/g, ' ')}
+      className={`orchid-disclosure orchid-disclosure-arrow ${VARIANT_CLASS[variant]} ${className}`.trim().replace(/\s+/g, ' ')}
       {...props}
     >
       <summary
-        className={`collapse-title min-h-0 ${VARIANT_SUMMARY_CLASS[variant]} ${summaryClassName}`.trim().replace(/\s+/g, ' ')}
+        className={`orchid-disclosure-title min-h-0 ${VARIANT_SUMMARY_CLASS[variant]} ${summaryClassName}`.trim().replace(/\s+/g, ' ')}
       >
         {summary}
       </summary>
       <div
-        className={`collapse-content ${VARIANT_CONTENT_CLASS[variant]} ${contentClassName}`.trim().replace(/\s+/g, ' ')}
+        className={`orchid-disclosure-content ${VARIANT_CONTENT_CLASS[variant]} ${contentClassName}`.trim().replace(/\s+/g, ' ')}
       >
         {children}
       </div>

--- a/electron/src/renderer/styles/README.md
+++ b/electron/src/renderer/styles/README.md
@@ -77,7 +77,9 @@ These component roots still appear in feature JSX and are tracked by the drift s
 
 `styles/primitives.css` is the only stylesheet that may define these roots (or their common modifiers such as `btn-primary`, `btn-ghost`). Reserved roots include:
 
-`btn`, `input`, `select`, `textarea`, `alert`, `badge`, `status`, `loading`, `collapse`, `modal`, `tabs`, `tab`, `steps`, `step`, `dropdown`, `table`, `fieldset`, `card`, `kbd`, `tooltip`, `menu`, `checkbox`, `radio`, `toggle`, `range`, `progress`, `link`, `divider`, `avatar`, `navbar`, `drawer`, `hero`, `footer`, `stat`, `toast`, `file-input`, `label`, `join`, `mask`, `stack`, `skeleton`, `indicator`, `list`, `dock`, `fab`, `validator`
+`btn`, `input`, `select`, `textarea`, `alert`, `badge`, `status`, `loading`, `orchid-disclosure`, `modal`, `tabs`, `tab`, `steps`, `step`, `dropdown`, `table`, `fieldset`, `card`, `kbd`, `tooltip`, `menu`, `checkbox`, `radio`, `toggle`, `range`, `progress`, `link`, `divider`, `avatar`, `navbar`, `drawer`, `hero`, `footer`, `stat`, `toast`, `file-input`, `label`, `join`, `mask`, `stack`, `skeleton`, `indicator`, `list`, `dock`, `fab`, `validator`
+
+Note: the disclosure root is `orchid-disclosure`, not `collapse` — Tailwind ships a bare `collapse` visibility utility (`visibility: collapse`) that takes precedence in `@layer utilities` and would permanently hide any `details.collapse`. Never reintroduce a bare `.collapse` component class.
 
 Product-specific names that only *start* like a reserved root but are not the root itself (for example `.input-area`) are allowed.
 

--- a/electron/src/renderer/styles/primitives.css
+++ b/electron/src/renderer/styles/primitives.css
@@ -903,19 +903,23 @@
     padding: 1rem;
   }
 
-  /* ── collapse (details) ─────────────────────────────────────────────────── */
+  /* ── disclosure (details) ─────────────────────────────────────────────────
+   * Named orchid-disclosure rather than collapse: Tailwind ships a bare
+   * `.collapse { visibility: collapse }` utility (table-row collapsing) that
+   * lands in @layer utilities and would permanently hide the component.
+   */
 
-  .collapse {
+  .orchid-disclosure {
     position: relative;
     min-width: 0;
     border-radius: var(--radius-field, 0.5rem);
   }
 
-  details.collapse {
+  details.orchid-disclosure {
     overflow: hidden;
   }
 
-  .collapse-title {
+  .orchid-disclosure-title {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -927,15 +931,15 @@
     transition: background-color var(--transition-fast, 150ms ease);
   }
 
-  .collapse-title::-webkit-details-marker {
+  .orchid-disclosure-title::-webkit-details-marker {
     display: none;
   }
 
-  .collapse-title:hover {
+  .orchid-disclosure-title:hover {
     background: color-mix(in srgb, var(--color-base-content) 4%, transparent);
   }
 
-  .collapse-arrow .collapse-title::after {
+  .orchid-disclosure-arrow .orchid-disclosure-title::after {
     content: '';
     flex-shrink: 0;
     width: 7px;
@@ -948,11 +952,11 @@
     transition: transform var(--transition-normal, 200ms ease);
   }
 
-  details.collapse[open] > .collapse-title::after {
+  details.orchid-disclosure[open] > .orchid-disclosure-title::after {
     transform: rotate(225deg);
   }
 
-  .collapse-content {
+  .orchid-disclosure-content {
     padding: 0.25rem 0.75rem 0.75rem;
     animation: orchid-rise 180ms ease-out;
   }

--- a/electron/tests/integration/renderer-style-contract.test.ts
+++ b/electron/tests/integration/renderer-style-contract.test.ts
@@ -42,7 +42,7 @@ export const RESERVED_COMPONENT_ROOTS = [
   'badge',
   'status',
   'loading',
-  'collapse',
+  'orchid-disclosure',
   'modal',
   'tabs',
   'tab',
@@ -132,7 +132,7 @@ const RESERVED_MODIFIER_ROOTS = new Set([
   'radio',
   'toggle',
   'loading',
-  'collapse',
+  'orchid-disclosure',
   'select',
   'textarea',
   'table',
@@ -923,6 +923,27 @@ describe('Renderer style contract', () => {
         }
       }
       expect(hits, `daisyUI-only vars in: ${hits.join(', ')}`).toEqual([]);
+    });
+
+    it('primitive components do not use Tailwind utility class names verbatim', () => {
+      // Tailwind ships utilities whose names collide with legacy daisyUI
+      // component classes. `.collapse { visibility: collapse }` lands in
+      // @layer utilities, so a <details class="collapse"> renders permanently
+      // hidden (issue #123: invisible MCP permission rows).
+      const disclosureSource = fs.readFileSync(
+        path.join(RENDERER_ROOT, 'components/ui/Disclosure.tsx'),
+        'utf8',
+      );
+      const bareUsage = /(?:^|[\s'"`])collapse(?=[\s'"`]|$)/;
+      expect(
+        bareUsage.test(disclosureSource),
+        `Disclosure must not use Tailwind's bare 'collapse' utility class`,
+      ).toBe(false);
+      const primitivesCss = fs.readFileSync(PRIMITIVES_CSS, 'utf8');
+      expect(
+        /(?:^|[{}@,\s])\.collapse\b/.test(stripCssComments(primitivesCss)),
+        'primitives.css must not declare a bare .collapse component root',
+      ).toBe(false);
     });
   });
 

--- a/electron/tests/unit/definitions-ipc.test.ts
+++ b/electron/tests/unit/definitions-ipc.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Definitions IPC tests — definitions:list availableTools MCP inclusion.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IPC_CHANNELS } from '../../src/shared/types/ipc';
+
+const PROJECT_DIR = '/tmp/orchid-definitions-ipc-project';
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+  const listAll = vi.fn(() => [
+    { definition: { name: 'read' } },
+    { definition: { name: 'write' } },
+  ]);
+  const getTools = vi.fn(() => [
+    { definition: { name: 'mcp::context7::query-docs' } },
+    { definition: { name: 'mcp::context7::resolve-library-id' } },
+  ]);
+  const getManager = vi.fn(() => ({ getTools }));
+  const getRuntime = vi.fn(() => ({ projectDir: PROJECT_DIR, config: {} }));
+
+  return {
+    handlers,
+    ipcMain: {
+      handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, fn);
+      }),
+      removeHandler: vi.fn((channel: string) => {
+        handlers.delete(channel);
+      }),
+    },
+    shell: { showItemInFolder: vi.fn() },
+    resolveBoundProjectPath: vi.fn((): string | null => PROJECT_DIR),
+    getProjectTrustState: vi.fn(() => 'trusted'),
+    listAll,
+    getTools,
+    getManager,
+    getRuntime,
+    listManagedSkills: vi.fn(() => []),
+    listManagedAgents: vi.fn(() => []),
+    listManagedPersonalities: vi.fn(() => []),
+  };
+});
+
+vi.mock('electron', () => ({ ipcMain: mocks.ipcMain, shell: mocks.shell }));
+
+vi.mock('../../src/main/ipc/session', () => ({
+  resolveBoundProjectPath: mocks.resolveBoundProjectPath,
+}));
+
+vi.mock('../../src/main/defs/manage', () => ({
+  listManagedSkills: mocks.listManagedSkills,
+  listManagedAgents: mocks.listManagedAgents,
+  listManagedPersonalities: mocks.listManagedPersonalities,
+  saveSkill: vi.fn(),
+  deleteSkill: vi.fn(),
+  saveAgent: vi.fn(),
+  deleteAgent: vi.fn(),
+  savePersonality: vi.fn(),
+  deletePersonality: vi.fn(),
+}));
+
+vi.mock('../../src/main/defs/paths', () => ({
+  assertPathUnderOrchidRoots: vi.fn((p: string) => p),
+}));
+
+vi.mock('../../src/main/defs/reload', () => ({
+  reloadDefinitionRegistries: vi.fn(),
+}));
+
+vi.mock('../../src/main/project/trust', () => ({
+  getProjectTrustState: mocks.getProjectTrustState,
+}));
+
+vi.mock('../../src/main/project/runtime', () => ({
+  getProjectRuntimeRegistry: () => ({ get: mocks.getRuntime }),
+}));
+
+vi.mock('../../src/main/mcp/project-registry', () => ({
+  getProjectMCPManager: mocks.getManager,
+}));
+
+vi.mock('../../src/main/tools', () => ({
+  toolRegistry: { listAll: mocks.listAll },
+}));
+
+let definitionsIpc: typeof import('../../src/main/ipc/definitions');
+
+beforeEach(async () => {
+  mocks.handlers.clear();
+  mocks.resolveBoundProjectPath.mockReset();
+  mocks.resolveBoundProjectPath.mockReturnValue(PROJECT_DIR);
+  mocks.getProjectTrustState.mockReset();
+  mocks.getProjectTrustState.mockReturnValue('trusted');
+  mocks.listAll.mockClear();
+  mocks.getTools.mockClear();
+  mocks.getManager.mockClear();
+  mocks.getManager.mockReturnValue({ getTools: mocks.getTools });
+  mocks.getRuntime.mockClear();
+  mocks.getRuntime.mockReturnValue({ projectDir: PROJECT_DIR, config: {} });
+
+  definitionsIpc = await import('../../src/main/ipc/definitions');
+  definitionsIpc.registerDefinitionsIPC();
+});
+
+afterEach(() => {
+  definitionsIpc.unregisterDefinitionsIPC();
+});
+
+interface DefinitionsListResult {
+  availableTools: string[];
+}
+
+function getListHandler() {
+  const handler = mocks.handlers.get(IPC_CHANNELS.DEFINITIONS_LIST);
+  if (!handler) throw new Error('definitions:list handler not registered');
+  return handler as (event: unknown) => Promise<DefinitionsListResult>;
+}
+
+describe('definitions:list availableTools', () => {
+  it('includes namespaced MCP tools for a bound project', async () => {
+    const result = await getListHandler()({ sender: { id: 3 } });
+
+    expect(mocks.resolveBoundProjectPath).toHaveBeenCalledWith('3');
+    expect(mocks.getRuntime).toHaveBeenCalledWith(PROJECT_DIR);
+    expect(result.availableTools).toEqual([
+      'mcp::context7::query-docs',
+      'mcp::context7::resolve-library-id',
+      'read',
+      'write',
+    ]);
+  });
+
+  it('omits MCP tools when the window is unbound and does not touch the manager', async () => {
+    mocks.resolveBoundProjectPath.mockReturnValue(null);
+
+    const result = await getListHandler()({ sender: { id: 4 } });
+
+    expect(mocks.getManager).not.toHaveBeenCalled();
+    expect(result.availableTools).toEqual(['read', 'write']);
+  });
+
+  it('falls back to builtin tools when MCP enumeration fails', async () => {
+    mocks.getRuntime.mockImplementation(() => {
+      throw new Error('runtime unavailable');
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await getListHandler()({ sender: { id: 5 } });
+
+    expect(result.availableTools).toEqual(['read', 'write']);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});

--- a/electron/tests/unit/renderer-permissions-tab-mcp.test.tsx
+++ b/electron/tests/unit/renderer-permissions-tab-mcp.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PermissionsTab } from '../../src/renderer/components/Preferences/PermissionsTab';
+import type { Config, MCPServerStatus } from '../../src/shared/types/ipc-boundary';
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    default_model: null,
+    tier_models: {},
+    tier_reasoning_effort: {},
+    ignored_dirs: [],
+    command_timeout: 30,
+    read_line_limit: 1000,
+    grep_max_results: 100,
+    directory_tree_depth: 2,
+    theme: 'default',
+    personality: 'default',
+    rag: {
+      chunk_size: 1000,
+      chunk_overlap: 200,
+      top_k: 5,
+      max_file_size: 1_000_000,
+      embedding_model: 'Xenova/all-MiniLM-L6-v2',
+      embedding_threads: 2,
+      embedding_batch_size: 16,
+      embedding_api_model: null,
+    },
+    ast_max_file_size: 1_048_576,
+    mcp_startup_timeout: 60,
+    mcp_per_server_timeout: 10,
+    mcp_servers: { context7: { command: 'npx' } },
+    providers: {},
+    llm_stream_idle_timeout: 300,
+    llm_stream_retries: 3,
+    background_command_idle_timeout: 900,
+    max_tool_steps: 100,
+    permission_history_size: 10,
+    permissions: {},
+    default_project_dir: null,
+    always_expand_tool_groups: false,
+    has_completed_onboarding: true,
+    ...overrides,
+  };
+}
+
+function connectedStatus(tools: string[]): MCPServerStatus[] {
+  return [
+    { name: 'context7', status: 'connected', toolCount: tools.length, tools, error: null },
+  ];
+}
+
+describe('PermissionsTab live MCP discovery', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    delete (window as { orchid?: unknown }).orchid;
+  });
+
+  function setupOrchid(initialStatus: MCPServerStatus[]) {
+    const status = vi.fn(async () => initialStatus);
+    let workspaceListener: (() => void) | null = null;
+    let trustListener: (() => void) | null = null;
+    const onWorkspaceChanged = vi.fn((callback: () => void) => {
+      workspaceListener = callback;
+      return () => {
+        workspaceListener = null;
+      };
+    });
+    const onTrustChanged = vi.fn((callback: () => void) => {
+      trustListener = callback;
+      return () => {
+        trustListener = null;
+      };
+    });
+    window.orchid = {
+      mcp: { status },
+      session: { onWorkspaceChanged },
+      projectTrust: { onChanged: onTrustChanged },
+    } as never;
+    return {
+      status,
+      onWorkspaceChanged,
+      onTrustChanged,
+      emitWorkspaceChanged: () => workspaceListener?.(),
+      emitTrustChanged: () => trustListener?.(),
+    };
+  }
+
+  it('fetches status on mount and renders live tool rows', async () => {
+    const orchid = setupOrchid(connectedStatus(['query-docs']));
+    render(<PermissionsTab config={makeConfig()} updateDraft={() => {}} />);
+
+    await waitFor(() => expect(orchid.status).toHaveBeenCalledOnce());
+    await screen.findByText('query-docs');
+    expect(orchid.onWorkspaceChanged).toHaveBeenCalledOnce();
+    expect(orchid.onTrustChanged).toHaveBeenCalledOnce();
+  });
+
+  it('refetches when the bound workspace changes', async () => {
+    const orchid = setupOrchid([]);
+    render(<PermissionsTab config={makeConfig()} updateDraft={() => {}} />);
+    await waitFor(() => expect(orchid.status).toHaveBeenCalledTimes(1));
+
+    orchid.status.mockResolvedValue(connectedStatus(['query-docs']));
+    act(() => orchid.emitWorkspaceChanged());
+
+    await waitFor(() => expect(orchid.status).toHaveBeenCalledTimes(2));
+    await screen.findByText('query-docs');
+  });
+
+  it('refetches when project trust changes', async () => {
+    const orchid = setupOrchid([]);
+    render(<PermissionsTab config={makeConfig()} updateDraft={() => {}} />);
+    await waitFor(() => expect(orchid.status).toHaveBeenCalledTimes(1));
+
+    orchid.status.mockResolvedValue(connectedStatus(['query-docs']));
+    act(() => orchid.emitTrustChanged());
+
+    await waitFor(() => expect(orchid.status).toHaveBeenCalledTimes(2));
+    await screen.findByText('query-docs');
+  });
+
+  it('refetches when the configured server set changes', async () => {
+    const orchid = setupOrchid(connectedStatus(['query-docs']));
+    const { rerender } = render(
+      <PermissionsTab config={makeConfig()} updateDraft={() => {}} />,
+    );
+    await waitFor(() => expect(orchid.status).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <PermissionsTab
+        config={makeConfig({
+          mcp_servers: {
+            context7: { command: 'npx' },
+            filesystem: { command: 'npx' },
+          },
+        })}
+        updateDraft={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(orchid.status).toHaveBeenCalledTimes(2));
+  });
+
+  it('unsubscribes from lifecycle events on unmount', () => {
+    const orchid = setupOrchid([]);
+    const { unmount } = render(
+      <PermissionsTab config={makeConfig()} updateDraft={() => {}} />,
+    );
+
+    unmount();
+    act(() => {
+      orchid.emitWorkspaceChanged();
+      orchid.emitTrustChanged();
+    });
+    expect(orchid.status).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/tests/unit/renderer-ui-primitives.test.ts
+++ b/electron/tests/unit/renderer-ui-primitives.test.ts
@@ -75,7 +75,8 @@ describe('Disclosure', () => {
     );
     expect(html).toContain('<details');
     expect(html).toContain('<summary');
-    expect(html).toContain('collapse collapse-arrow');
+    expect(html).toContain('orchid-disclosure orchid-disclosure-arrow');
+    expect(html).not.toMatch(/<details[^>]*class="[^"]*\bcollapse\b/);
     expect(html).toContain('rounded-none border-y border-base-300');
     expect(html).toContain('Long prompt');
     expect(html).not.toMatch(/<details[^>]*\sopen(?:=|\s|>)/);


### PR DESCRIPTION
## Summary

Closes #123 — MCP server tools were not visible in permission configuration. There were **three** compounding causes; two weakened tool discovery, one made the panel literally invisible.

## Root causes fixed

**1. The disclosure panel itself was invisible (the live symptom)**

Every `<Disclosure>` on the page rendered with `visibility: collapse` regardless of open state — summary, wildcard row, and per-tool rows all hidden (they existed in the DOM; rendered text excluded them). Tailwind CSS 4 emits a bare `.collapse { visibility: collapse }` utility (for table-row collapsing) into `@layer utilities` precisely because the string appears in `Disclosure.tsx`; the primitive engine lives in `@layer components`, so the utility wins. Introduced by the daisyUI→Tailwind primitive-engine migration.

**Fix:** renamed the disclosure component root to the `orchid-disclosure` family in `Disclosure.tsx` + `primitives.css`, updated the reserved-root contract list and `styles/README.md`, and added a style-contract gate so a bare `.collapse` component class can never be reintroduced. Affects PermissionsTab's MCP blocks and SubagentView disclosures alike.

**Verified in the running app (CDP-driven):** before the rename, computed visibility was `collapse` with the details element `open` and the server block absent from rendered text; dropping the class exposed every row. After the code change, a fresh app instance shows context7 under Permissions→MCP tools, and a real summary click expands it to reveal `mcp::context7::*`, `query-docs`, and `resolve-library-id` with working mode selectors.

**2. `definitions:list` hard-excluded MCP tools**

`availableTools` came from the process-global `toolRegistry`, built with `mcpManager: null`, so the agent allowed-tools picker could never offer `mcp::*` entries. Now merged from the sender window's project MCP manager (dormant for untrusted projects; failures isolated to an empty MCP contribution).

**3. Fragile one-shot MCP discovery in `PermissionsTab`**

Now refetches on `session:workspace_changed`, `project:trust_changed`, and configured-server-set changes; the existing `starting`-poll remains for in-progress connects.

## Verification

- New `tests/unit/definitions-ipc.test.ts` (3) and `tests/unit/renderer-permissions-tab-mcp.test.tsx` (5)
- Style-contract suite passes with the renamed reserved root + new collision gate
- Full suite: 276 files / 4035 tests; `typecheck` + `lint` clean
- Live end-to-end reproduction driven over CDP: rows visible and toggleable post-fix
