### PR TITLE
fix(ipc): allow project config access for non-selected session projects

### DIFF
--- a/electron/src/main/ipc/config.ts
+++ b/electron/src/main/ipc/config.ts
@@ -23,7 +23,6 @@ import {
   listPersonalityNames,
   loadPersonalities,
 } from '../personality/registry';
-import { canonicalizeProjectDirectory } from '../project/path';
 import { clearProjectRuntimeRegistry } from '../project/runtime';
 import { invalidateAllProjectMCPManagers } from '../mcp/project-registry';
 import {
@@ -31,7 +30,7 @@ import {
   configSaveProjectSchema,
   configReadProjectSchema,
 } from './payload-schemas';
-import { resolveWindowWorkspace } from './session';
+import { resolveAuthorizedProjectDir } from './project-target';
 
 const PROJECT_CONFIG_ALLOWED_KEYS = new Set([
   'command_timeout',
@@ -71,25 +70,6 @@ const PROJECT_CONFIG_ALLOWED_KEYS = new Set([
   'theme',
   'personality',
 ]);
-
-function selectedProjectDir(senderId: number): string | null {
-  const workspace = resolveWindowWorkspace(String(senderId));
-  return workspace.status === 'valid' ? workspace.cwd : null;
-}
-
-function verifyProjectWorkspace(senderId: number, projectDir: string): string {
-  const selected = selectedProjectDir(senderId);
-  const expected = canonicalizeProjectDirectory(projectDir);
-  if (selected == null || expected == null) {
-    throw new Error('Cannot access project config without a bound project.');
-  }
-  if (selected !== expected) {
-    throw new Error('Project config target no longer matches the selected workspace.');
-  }
-  return expected;
-}
-
-
 
 // ── IPC registration ─────────────────────────────────────────────────────────
 
@@ -170,7 +150,7 @@ export function registerConfigIPC(): void {
     if (!parsed.success) {
       throw new Error('config:read_project requires a non-empty projectDir string');
     }
-    const verifiedProjectDir = verifyProjectWorkspace(event.sender.id, parsed.data);
+    const verifiedProjectDir = resolveAuthorizedProjectDir(event.sender.id, parsed.data);
     const configPath = path.join(verifiedProjectDir, PROJECT_CONFIG_NAME);
     const raw = loadJsonSafe(configPath);
     return { projectDir: verifiedProjectDir, overrides: isPlainObject(raw) ? raw : {} };
@@ -180,7 +160,7 @@ export function registerConfigIPC(): void {
     const parsed = configSaveProjectSchema.parse(payload);
     const { projectDir, updates } = parsed;
 
-    const verifiedProjectDir = verifyProjectWorkspace(event.sender.id, projectDir);
+    const verifiedProjectDir = resolveAuthorizedProjectDir(event.sender.id, projectDir);
 
     const filteredUpdates: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(updates)) {

--- a/electron/src/main/ipc/permission.ts
+++ b/electron/src/main/ipc/permission.ts
@@ -28,7 +28,6 @@ import { isPlainObject } from '../config/merge';
 import { permissionsConfigSchema } from '../config/schema';
 import { withConfigSaveLock } from '../config/write-lock';
 import { invalidateAllProjectMCPManagers } from '../mcp/project-registry';
-import { canonicalizeProjectDirectory } from '../project/path';
 import { clearProjectRuntimeRegistry } from '../project/runtime';
 import {
   approvalStore,
@@ -40,6 +39,7 @@ import {
   webContentsForWindowId,
 } from './chat';
 import { permissionConfigScopeSaveSchema } from './payload-schemas';
+import { resolveAuthorizedProjectDir } from './project-target';
 import { getSessionManager, resolveWindowWorkspace } from '../session/singleton';
 import {
   sessionPermissionOverrides,
@@ -293,15 +293,10 @@ export function registerPermissionIPC(): void {
       const parsed = permissionConfigScopeSaveSchema.parse(payload);
       let verifiedProjectDir: string | null = null;
       if (parsed.scope === 'project') {
-        const selected = selectedProjectDir(event.sender.id);
-        const expected = canonicalizeProjectDirectory(parsed.expectedProjectDir);
-        if (selected == null || expected == null) {
-          throw new Error('Cannot save project permissions without a bound project.');
-        }
-        if (selected !== expected) {
-          throw new Error('Project permission target no longer matches the selected workspace.');
-        }
-        verifiedProjectDir = selected;
+        verifiedProjectDir = resolveAuthorizedProjectDir(
+          event.sender.id,
+          parsed.expectedProjectDir,
+        );
       }
 
       return withConfigSaveLock(async () => {

--- a/electron/src/main/ipc/project-target.ts
+++ b/electron/src/main/ipc/project-target.ts
@@ -1,0 +1,52 @@
+/**
+ * Project-config target authorization.
+ *
+ * Sidebar project settings can be opened for any project that has sessions,
+ * regardless of which session is currently selected in the window. Project
+ * config IPC targets are therefore authorized when the canonical requested
+ * directory is either the window's resolved workspace (draft → active
+ * session → sticky default) or the cwd of any saved session. Everything
+ * else fails closed.
+ */
+import { getSessionManager, resolveWindowWorkspace } from '../session/singleton';
+import { canonicalizeProjectDirectory } from '../project/path';
+
+/**
+ * Resolve a renderer-supplied project directory to its canonical path when
+ * the sender window is authorized to read/write that project's config.
+ *
+ * @throws When the directory is invalid or is neither the selected workspace nor a session project.
+ */
+export function resolveAuthorizedProjectDir(senderId: number, projectDir: string): string {
+  const canonical = canonicalizeProjectDirectory(projectDir);
+  if (canonical == null) {
+    throw new Error(`Project config target is not a valid project directory: ${projectDir}`);
+  }
+
+  const workspace = resolveWindowWorkspace(String(senderId));
+  if (workspace.status === 'valid' && workspace.cwd != null && workspace.cwd === canonical) {
+    return canonical;
+  }
+
+  if (isSessionProject(canonical)) {
+    return canonical;
+  }
+
+  throw new Error(
+    'Project config target does not match the selected workspace or any project with sessions.',
+  );
+}
+
+function isSessionProject(canonical: string): boolean {
+  let summaries;
+  try {
+    summaries = getSessionManager().listSaved();
+  } catch {
+    return false;
+  }
+  return summaries.some((summary) => {
+    const cwd = summary.cwd;
+    if (cwd == null || cwd === '') return false;
+    return cwd === canonical || canonicalizeProjectDirectory(cwd) === canonical;
+  });
+}

--- a/electron/tests/unit/config-ipc.test.ts
+++ b/electron/tests/unit/config-ipc.test.ts
@@ -15,7 +15,10 @@ import { defaults } from '../../src/main/config/schema';
 
 const mocks = vi.hoisted(() => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
-  const state = { workspaceCwd: null as string | null };
+  const state = {
+    workspaceCwd: null as string | null,
+    sessionCwds: [] as string[],
+  };
 
   return {
     handlers,
@@ -35,7 +38,6 @@ const mocks = vi.hoisted(() => {
     clearProjectRuntimeRegistry: vi.fn(),
     invalidateAllProjectMCPManagers: vi.fn(),
     canonicalizeProjectDirectory: vi.fn((dir: string) => dir),
-    resolveWindowWorkspace: vi.fn(() => ({ status: 'valid' as const, cwd: state.workspaceCwd })),
   };
 });
 
@@ -96,8 +98,15 @@ vi.mock('../../src/main/project/path', () => ({
   canonicalizeProjectDirectory: mocks.canonicalizeProjectDirectory,
 }));
 
-vi.mock('../../src/main/ipc/session', () => ({
-  resolveWindowWorkspace: mocks.resolveWindowWorkspace,
+vi.mock('../../src/main/session/singleton', () => ({
+  resolveWindowWorkspace: vi.fn(() => (
+    mocks.state.workspaceCwd == null
+      ? { cwd: null, source: 'unbound', status: 'unbound' }
+      : { cwd: mocks.state.workspaceCwd, source: 'session', status: 'valid' }
+  )),
+  getSessionManager: () => ({
+    listSaved: () => mocks.state.sessionCwds.map((cwd) => ({ cwd })),
+  }),
 }));
 
 // ── Import after mocks ──────────────────────────────────────────────────────
@@ -114,10 +123,10 @@ beforeEach(async () => {
   mocks.clearProjectRuntimeRegistry.mockClear();
   mocks.invalidateAllProjectMCPManagers.mockClear();
   mocks.canonicalizeProjectDirectory.mockClear();
-  mocks.resolveWindowWorkspace.mockClear();
 
   projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-config-ipc-'));
   mocks.state.workspaceCwd = projectDir;
+  mocks.state.sessionCwds = [];
 
   // Fresh default config state for each test
   configState = defaults() as unknown as Record<string, unknown>;
@@ -132,6 +141,7 @@ beforeEach(async () => {
 afterEach(() => {
   configIpc.unregisterConfigIPC();
   mocks.state.workspaceCwd = null;
+  mocks.state.sessionCwds = [];
   fs.rmSync(projectDir, { recursive: true, force: true });
 });
 
@@ -333,16 +343,31 @@ describe('config:read_project', () => {
     await expect(callReadProject(null)).rejects.toThrow(/non-empty projectDir/);
   });
 
-  it('rejects when the bound workspace is a different project', async () => {
+  it('returns overrides for a session project even when a different workspace is selected', async () => {
     mocks.state.workspaceCwd = '/some/other/workspace';
+    mocks.state.sessionCwds = [projectDir];
+    writeProjectConfig({ theme: 'project-dark' });
 
-    await expect(callReadProject(projectDir)).rejects.toThrow(/selected workspace|without a bound project/i);
+    await expect(callReadProject(projectDir)).resolves.toEqual({
+      projectDir,
+      overrides: { theme: 'project-dark' },
+    });
   });
 
-  it('rejects when no workspace is bound', async () => {
+  it('rejects when the target is neither the selected workspace nor a session project', async () => {
+    mocks.state.workspaceCwd = '/some/other/workspace';
+
+    await expect(callReadProject(projectDir)).rejects.toThrow(
+      /selected workspace or any project with sessions/i,
+    );
+  });
+
+  it('rejects when no workspace is bound and the project has no sessions', async () => {
     mocks.state.workspaceCwd = null;
 
-    await expect(callReadProject(projectDir)).rejects.toThrow(/without a bound project/i);
+    await expect(callReadProject(projectDir)).rejects.toThrow(
+      /selected workspace or any project with sessions/i,
+    );
   });
 });
 
@@ -404,10 +429,22 @@ describe('config:save_project', () => {
     });
   });
 
-  it('rejects a projectDir that does not match the bound workspace', async () => {
+  it('saves to a session project that is not the selected workspace', async () => {
+    mocks.state.workspaceCwd = '/some/other/workspace';
+    mocks.state.sessionCwds = [projectDir];
+
+    await callSaveProject({ theme: 'cross-project' });
+    const write = lastProjectWrite();
+    expect(write.path).toBe(path.join(projectDir, '.orchid.json'));
+    expect(write.data['theme']).toBe('cross-project');
+  });
+
+  it('rejects a projectDir that is neither the selected workspace nor a session project', async () => {
     mocks.state.workspaceCwd = '/some/other/workspace';
 
-    await expect(callSaveProject({ theme: 'x' })).rejects.toThrow(/selected workspace/);
+    await expect(callSaveProject({ theme: 'x' })).rejects.toThrow(
+      /selected workspace or any project with sessions/i,
+    );
     expect(mocks.writtenConfigs).toHaveLength(0);
   });
 });

--- a/electron/tests/unit/permission-ipc.test.ts
+++ b/electron/tests/unit/permission-ipc.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => {
     handlers,
     selectedByWebContents,
     projectDirByWebContents: new Map<number, string>(),
+    sessionCwds: [] as string[],
     activeTurnOwnerBySession,
     webContentsById,
     forceAbortMainTurn: vi.fn(),
@@ -48,6 +49,7 @@ const mocks = vi.hoisted(() => {
         // in-memory gate map the permission gate actually reads.
         hydrateSessionPermissionOverride(id, mode as PermissionMode | null);
       }),
+      listSaved: vi.fn(() => mocks.sessionCwds.map((cwd) => ({ cwd }))),
     },
     sessionPermissionModeById,
   };
@@ -142,6 +144,7 @@ describe('permission IPC ownership', () => {
     mocks.activeTurnOwnerBySession.clear();
     mocks.webContentsById.clear();
     mocks.projectDirByWebContents.clear();
+    mocks.sessionCwds = [];
     mocks.forceAbortMainTurn.mockClear();
     approvalStore.cleanupAll();
     _resetConfigSaveChainForTests();
@@ -282,7 +285,7 @@ describe('permission IPC ownership', () => {
       scope: 'project',
       expectedProjectDir: projectDirB,
       updates: { edit: 'allow' },
-    })).toThrow('no longer matches');
+    })).toThrow('does not match the selected workspace');
 
     let release!: () => void;
     const blocker = withConfigSaveLock(() => new Promise<void>((resolve) => {
@@ -303,6 +306,29 @@ describe('permission IPC ownership', () => {
       .toEqual({ permissions: { edit: 'allow' } });
     expect(JSON.parse(fs.readFileSync(path.join(projectDirB, '.orchid.json'), 'utf8')))
       .toEqual({ permissions: {} });
+  });
+
+  it('saves project permissions for a session project that is not the selected workspace', async () => {
+    const viewedProjectDir = path.join(TEST_CONFIG_ROOT, 'viewed-project');
+    const selectedProjectDir = path.join(TEST_CONFIG_ROOT, 'selected-project');
+    fs.mkdirSync(viewedProjectDir, { recursive: true });
+    fs.mkdirSync(selectedProjectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(viewedProjectDir, '.orchid.json'),
+      JSON.stringify({ permissions: { edit: 'ask' } }),
+    );
+    mocks.projectDirByWebContents.set(10, selectedProjectDir);
+    mocks.sessionCwds = [viewedProjectDir];
+
+    const save = mocks.handlers.get(IPC_CHANNELS.CONFIG_SAVE_PERMISSION_SCOPE)!;
+    await expect(save(eventFrom(10), {
+      scope: 'project',
+      expectedProjectDir: viewedProjectDir,
+      updates: { edit: 'allow' },
+    })).resolves.toEqual({ status: 'saved' });
+
+    expect(JSON.parse(fs.readFileSync(path.join(viewedProjectDir, '.orchid.json'), 'utf8')))
+      .toEqual({ permissions: { edit: 'allow' } });
   });
 
   it('does not follow an attacker-planted predictable temp symlink during project save', async () => {
@@ -357,7 +383,7 @@ describe('permission IPC ownership', () => {
       scope: 'project',
       expectedProjectDir: '/tmp/attacker-selected',
       updates: { edit: 'allow' },
-    })).toThrow('without a bound project');
+    })).toThrow('not a valid project directory');
 
     expect(() => save(eventFrom(10), {
       scope: 'global',

--- a/electron/tests/unit/project-target.test.ts
+++ b/electron/tests/unit/project-target.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    workspaceCwd: null as string | null,
+    sessionCwds: [] as string[],
+    listSavedThrows: false,
+  };
+  return {
+    state,
+    canonicalizeProjectDirectory: vi.fn((dir: string) => (dir.startsWith('/bad') ? null : dir)),
+  };
+});
+
+vi.mock('../../src/main/project/path', () => ({
+  canonicalizeProjectDirectory: mocks.canonicalizeProjectDirectory,
+}));
+
+vi.mock('../../src/main/session/singleton', () => ({
+  resolveWindowWorkspace: vi.fn(() => (
+    mocks.state.workspaceCwd == null
+      ? { cwd: null, source: 'unbound', status: 'unbound' }
+      : { cwd: mocks.state.workspaceCwd, source: 'session', status: 'valid' }
+  )),
+  getSessionManager: () => ({
+    listSaved: () => {
+      if (mocks.state.listSavedThrows) throw new Error('session db unavailable');
+      return mocks.state.sessionCwds.map((cwd) => ({ cwd }));
+    },
+  }),
+}));
+
+import { resolveAuthorizedProjectDir } from '../../src/main/ipc/project-target';
+
+describe('resolveAuthorizedProjectDir', () => {
+  beforeEach(() => {
+    mocks.state.workspaceCwd = null;
+    mocks.state.sessionCwds = [];
+    mocks.state.listSavedThrows = false;
+    mocks.canonicalizeProjectDirectory.mockImplementation((dir: string) =>
+      dir.startsWith('/bad') ? null : dir,
+    );
+  });
+
+  it('authorizes the selected workspace', () => {
+    mocks.state.workspaceCwd = '/work/project';
+    expect(resolveAuthorizedProjectDir(1, '/work/project')).toBe('/work/project');
+  });
+
+  it('authorizes a project that has sessions even when another workspace is selected', () => {
+    mocks.state.workspaceCwd = '/work/other';
+    mocks.state.sessionCwds = ['/work/project'];
+    expect(resolveAuthorizedProjectDir(1, '/work/project')).toBe('/work/project');
+  });
+
+  it('matches session cwds through canonicalization', () => {
+    mocks.state.workspaceCwd = '/work/other';
+    mocks.state.sessionCwds = ['/work/project/'];
+    mocks.canonicalizeProjectDirectory.mockImplementation((dir: string) =>
+      dir.endsWith('/') ? dir.slice(0, -1) : dir,
+    );
+    expect(resolveAuthorizedProjectDir(1, '/work/project')).toBe('/work/project');
+  });
+
+  it('rejects a directory that is neither the workspace nor a session project', () => {
+    mocks.state.workspaceCwd = '/work/other';
+    mocks.state.sessionCwds = ['/work/session-project'];
+    expect(() => resolveAuthorizedProjectDir(1, '/work/unknown')).toThrow(
+      /does not match the selected workspace or any project with sessions/,
+    );
+  });
+
+  it('rejects when nothing is bound and the project has no sessions', () => {
+    expect(() => resolveAuthorizedProjectDir(1, '/work/project')).toThrow(
+      /does not match the selected workspace or any project with sessions/,
+    );
+  });
+
+  it('rejects directories that cannot be canonicalized', () => {
+    mocks.state.workspaceCwd = '/bad/dir';
+    expect(() => resolveAuthorizedProjectDir(1, '/bad/dir')).toThrow(
+      /not a valid project directory/,
+    );
+  });
+
+  it('fails closed when the session store is unavailable', () => {
+    mocks.state.workspaceCwd = '/work/other';
+    mocks.state.sessionCwds = ['/work/project'];
+    mocks.state.listSavedThrows = true;
+    expect(() => resolveAuthorizedProjectDir(1, '/work/project')).toThrow(
+      /does not match the selected workspace or any project with sessions/,
+    );
+    expect(resolveAuthorizedProjectDir(1, '/work/other')).toBe('/work/other');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #130 — opening a project's configuration/settings from the sidebar failed with "Failed to load project configuration." whenever the currently selected session belonged to a different project.

## Root cause

`config:read_project`, `config:save_project`, and project-scope `config:save_permission_scope` all required the requested `projectDir` to equal the **window's resolved workspace** (draft cwd → active session cwd → sticky default). Clicking a project header in the sidebar opens `ProjectConfigView` for *that* project without changing the selected session, so the equality check rejected the read the moment the two differed.

This had been fixed once before in fd8d73a (reads resolved via canonical path only), but 7bce1c4 re-introduced workspace-equality on reads during a fail-closed hardening sweep, regressing the sidebar settings flow.

## Fix

New main-process helper `resolveAuthorizedProjectDir()` (`src/main/ipc/project-target.ts`), shared by the config and permission IPC handlers. A target is authorized when its canonical path is either:

- the window's resolved workspace (unchanged behavior for session-aligned flows), or
- the cwd of any saved session — exactly the set of projects the sidebar surface can reach.

Invalid/un-canonicalizable directories and unknown paths still fail closed; a hijacked renderer cannot steer writes into arbitrary directories. The verified canonical target is captured **before** the config save lock is queued, so a save waiting in the lock cannot drift onto a different project if the workspace changes mid-queue.

## Verification

- New `project-target.test.ts`: authorization matrix (workspace match, session-project match, non-canonical session cwd spelling, unknown dir, invalid dir, fail-closed when the session store throws).
- `config-ipc.test.ts` / `permission-ipc.test.ts`: flipped the cross-project rejection cases into success cases, kept rejections for unknown/unbound targets, added coverage for cross-project permission saves; the queued-write race test still passes.
- `npm run typecheck`, `npm run lint`, `npm run check:runtime-cycles`, and the full unit suite (275 files / 4036 tests) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project configuration and permission changes are now restricted to authorized workspace or session project directories.
  * Unauthorized, invalid, or unavailable project targets are rejected safely.
  * Session projects can now read and save configuration and permissions even when they are not the currently selected workspace.

* **Tests**
  * Added coverage for workspace and session project authorization, path matching, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->