### PR TITLE
feat(compaction): /compact command + preserve_percent scales with current usage

### DIFF
--- a/electron/src/main/agents/subagent-compaction-controller.ts
+++ b/electron/src/main/agents/subagent-compaction-controller.ts
@@ -457,6 +457,9 @@ export class SubagentCompactionController {
           config: cfg2 ?? { threshold: 0.85, preserve_percent: 0.25 },
           contextTokens: this._contextTokens ?? 0,
           tokensPerChar: tpc3,
+          // Preserve scales against current usage — post-compaction input is
+          // the best available estimate for the retried stream's context.
+          currentInputTokens: postTokens > 0 ? postTokens : null,
         });
         // Exhaustion test: with chain inference splitting summary heads into
         // their own chains, the range may still contain the previous head

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -9,11 +9,13 @@ import {
 import { getForegroundLiveRegistry } from '../tools/process/foreground-live';
 import { SEND_INPUT_MAX_TEXT_LENGTH } from '../tools/process/send-input';
 import { getSessionManager } from '../session/singleton';
-import { IPC_CHANNELS, type ChatSessionSnapshot } from '../../shared/types/ipc';
+import { IPC_CHANNELS, type ChatSessionSnapshot, type ChatCompactResult } from '../../shared/types/ipc';
 import { ChainStatus, lastChainError } from '../../shared/types/chain';
 import { flattenSessionMessages } from '../../shared/types/session';
+import { getProjectTrustState } from '../project/trust';
+import { getProjectRuntimeRegistry } from '../project/runtime';
 import { clearAllChatHistory } from './chat-history';
-import { chatCancelSchema, chatQueueNextSchema, chatSendSchema, chatSnapshotSchema, chatStopSchema } from './payload-schemas';
+import { chatCancelSchema, chatCompactSchema, chatQueueNextSchema, chatSendSchema, chatSnapshotSchema, chatStopSchema } from './payload-schemas';
 import { requestNextRequestStop } from './next-request-stop';
 import { completeSessionActivity } from './session-activity';
 import {
@@ -32,6 +34,7 @@ import {
   forceStopSession,
 } from './chat/abort';
 import { startChatTurn } from './chat/send';
+import { compactSessionNow } from './chat/compaction';
 import { triggerInterruptedTurnAutoName } from './chat/title';
 import type { AgentContext } from '../agents/xstate/agent-machine';
 
@@ -162,6 +165,30 @@ export function registerChatIPC(): void {
     const parsed = chatQueueNextSchema.safeParse(payload ?? {});
     if (!parsed.success) throw new Error(`Invalid chat:queue_next payload: ${parsed.error.message}`);
     requestNextRequestStop(parsed.data.sessionId);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.CHAT_COMPACT, async (event, payload: unknown): Promise<ChatCompactResult> => {
+    const parsed = chatCompactSchema.safeParse(payload ?? {});
+    if (!parsed.success) throw new Error(`Invalid chat:compact payload: ${parsed.error.message}`);
+    const windowId = String(event.sender.id);
+    const sessionId = parsed.data.sessionId ?? getSessionManager().getActive(windowId)?.id;
+    if (!sessionId) {
+      return { status: 'nothing_to_compact', sessionId: '', detail: 'No active session to compact.' };
+    }
+    const session = getSessionManager().getSession(sessionId);
+    if (!session) {
+      return { status: 'nothing_to_compact', sessionId, detail: 'Session not found.' };
+    }
+    const boundCwd = session.cwd?.trim();
+    if (!boundCwd || getProjectTrustState(boundCwd) !== 'trusted') {
+      return { status: 'nothing_to_compact', sessionId, detail: 'The project folder for this session is not trusted.' };
+    }
+    const runtime = getProjectRuntimeRegistry().get(boundCwd);
+    const selection = session.selection ?? runtime.config.default_model;
+    if (!selection) {
+      return { status: 'nothing_to_compact', sessionId, detail: 'A provider connection and model are required before compacting.' };
+    }
+    return compactSessionNow(sessionId, runtime, selection);
   });
 
   ipcMain.handle(IPC_CHANNELS.CHAT_CANCEL, async (event, payload: unknown) => {

--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -408,6 +408,7 @@ export function unregisterChatIPC(): void {
   ipcMain.removeHandler(IPC_CHANNELS.CHAT_QUEUE_NEXT);
   ipcMain.removeHandler(IPC_CHANNELS.CHAT_STOP);
   ipcMain.removeHandler(IPC_CHANNELS.CHAT_SNAPSHOT);
+  ipcMain.removeHandler(IPC_CHANNELS.CHAT_COMPACT);
   ipcMain.removeHandler(IPC_CHANNELS.BG_CMD_SNAPSHOT);
   ipcMain.removeHandler(IPC_CHANNELS.BG_CMD_LIST);
   ipcMain.removeHandler(IPC_CHANNELS.BG_CMD_SEND_INPUT);

--- a/electron/src/main/ipc/chat/compaction.ts
+++ b/electron/src/main/ipc/chat/compaction.ts
@@ -71,7 +71,7 @@ import {
   runCompactionAttempt,
   type CompactionAttemptOutcome,
 } from '../../llm/compaction/run-attempt';
-import { activeAgents, sessionsStarting } from './state';
+import { activeAgents, runWithSessionOperationGate, sessionsStarting } from './state';
 import { sendSessionEvent, sendTurnEvent, webContentsForWindowId } from './events';
 import {
   historyFromSession,
@@ -1240,7 +1240,19 @@ export function handleUsageCompaction(
  * ride the existing SESSION_COMPACTION / SESSION_UPDATED events the durable
  * persist path emits, so an idle renderer reloads without extra plumbing.
  */
-export async function compactSessionNow(
+export function compactSessionNow(
+  sessionId: string,
+  runtime: ProjectRuntime,
+  selection: ModelSelection,
+): Promise<ChatCompactResult> {
+  // Hold the per-session operation gate across the whole compaction — busy
+  // check through compaction persistence and the terminal widget event — so a
+  // chat turn cannot start on a half-compacted history: startChatTurn waits
+  // the gate out before claiming its turn-start slot.
+  return runWithSessionOperationGate(sessionId, () => compactIdleSession(sessionId, runtime, selection));
+}
+
+async function compactIdleSession(
   sessionId: string,
   runtime: ProjectRuntime,
   selection: ModelSelection,
@@ -1297,9 +1309,10 @@ export async function compactSessionNow(
     // attribution is best-effort
   }
   // Widget feedback on the idle session: preparing opens the compaction
-  // widget; every non-applying exit below emits the terminal phase so the
-  // widget can never stay stuck on 'preparing' (tryCompact's success
-  // branches emit 'complete' themselves via completeCompactionWidget).
+  // widget; the pending-consumption apply and the success path below emit the
+  // terminal 'complete' phase themselves (completeCompactionWidget), and every
+  // other exit emits 'failed' so the widget can never stay stuck on
+  // 'preparing'/'compacting' and the idle event identity is cleared.
   emitCompactionProgress(sessionId, 'preparing', 'Compacting context', {
     mode: runtime.config.compaction.main.mode,
   });
@@ -1307,7 +1320,10 @@ export async function compactSessionNow(
     sessionId, messages, runtime, selection, contextTokens, accountingStore, chainId, randomUUID(),
     { manual: true },
   );
-  if (result.didApply) return { status: 'compacted', sessionId };
+  if (result.didApply) {
+    completeCompactionWidget(sessionId);
+    return { status: 'compacted', sessionId };
+  }
   emitCompactionProgress(
     sessionId,
     'failed',

--- a/electron/src/main/ipc/chat/compaction.ts
+++ b/electron/src/main/ipc/chat/compaction.ts
@@ -26,14 +26,16 @@ import type { ModelSelection } from '../../../shared/types/provider';
 import { ChainStatus } from '../../../shared/types/chain';
 import type { Chain } from '../../../shared/types/chain';
 import type { Message } from '../../../shared/types/message';
-import { IPC_CHANNELS } from '../../../shared/types/ipc';
+import { IPC_CHANNELS, type ChatCompactResult } from '../../../shared/types/ipc';
 import { MAIN_AGENT_SCOPE_ID } from '../../../shared/types/agent-scope';
 import type { CompactionProgressEvent, CompactionProgressPhase } from '../../../shared/types/compaction-progress';
 import type { ProjectRuntime } from '../../project/runtime';
 import type { ProviderAccountingStore } from '../../providers/accounting/store';
+import { getProviderRuntime } from '../../providers';
+import { getProviderAccountingStore } from '../../providers/accounting/store';
 import { getSessionManager } from '../../session/singleton';
 import { onSessionDeleted } from '../../session/manager';
-import { setChatHistory } from '../chat-history';
+import { getChatHistory, setChatHistory } from '../chat-history';
 import {
   clearCompactionPause,
   clearCompactionPausesForSession,
@@ -69,9 +71,10 @@ import {
   runCompactionAttempt,
   type CompactionAttemptOutcome,
 } from '../../llm/compaction/run-attempt';
-import { activeAgents } from './state';
-import { sendTurnEvent, webContentsForWindowId } from './events';
+import { activeAgents, sessionsStarting } from './state';
+import { sendSessionEvent, sendTurnEvent, webContentsForWindowId } from './events';
 import {
+  historyFromSession,
   persistCompactionBetweenTurns as persistCompaction,
   persistCompactionDurable,
   publishCompactedSession,
@@ -119,6 +122,33 @@ function trackSelectiveRun(sessionId: string, run: Promise<unknown>): void {
 const compactionProgressEpochs = new Map<string, number>();
 
 /**
+ * Per-session synthetic event identity for idle compactions (manual
+ * `/compact`): stable turnId for the compaction's lifecycle plus a monotonic
+ * sequence, minted lazily and dropped on the terminal phase so the next idle
+ * compaction starts a fresh stream.
+ */
+const idleCompactionEventIds = new Map<string, { turnId: string; sequence: number }>();
+
+function idleCompactionIdentity(
+  sessionId: string,
+  terminal: boolean,
+): { sessionId: string; turnId: string; sequence: number } | null {
+  // A turn is starting (chat:send's send-time sync compaction window) — a
+  // synthetic turnId here would poison the renderer's turn affinity before
+  // the real turn's first event arrives and the whole turn would be dropped.
+  if (sessionsStarting.has(sessionId)) return null;
+  let entry = idleCompactionEventIds.get(sessionId);
+  if (!entry) {
+    entry = { turnId: randomUUID(), sequence: 0 };
+    idleCompactionEventIds.set(sessionId, entry);
+  }
+  entry.sequence += 1;
+  const identity = { sessionId, turnId: entry.turnId, sequence: entry.sequence };
+  if (terminal) idleCompactionEventIds.delete(sessionId);
+  return identity;
+}
+
+/**
  * Emit a typed compaction-progress event through the sequenced turn-event
  * broadcast. Replaces the synthetic `'compaction'` tool-call channel (review
  * #37): no JSON-stringified state, no `toolName` interception, no fake
@@ -128,6 +158,12 @@ const compactionProgressEpochs = new Map<string, number>();
  * `options.webContents` lets turn-lifecycle call sites deliver on their own
  * sender (the same window the turn events stream to); without it the active
  * agent's window is resolved from the electron registry.
+ *
+ * Idle sessions (manual `/compact` — no ActiveAgent owns a turn identity)
+ * emit through a per-session synthetic identity via `sendSessionEvent`, so
+ * the widget lifecycle works outside any turn. Silent only while a turn is
+ * starting: the send-time synchronous compaction must not mint a synthetic
+ * turnId the renderer could bind to before the real turn's first event.
  */
 export function emitCompactionProgress(
   sessionId: string,
@@ -140,10 +176,6 @@ export function emitCompactionProgress(
     estimatedTokens?: number | null;
   },
 ): void {
-  const active = activeAgents.get(sessionId);
-  if (!active || active.finalized) return;
-  const wc = options?.webContents ?? webContentsForWindowId(active.windowId);
-  if (!wc) return;
   if (phase === 'complete' || phase === 'failed') {
     compactionProgressEpochs.set(sessionId, (compactionProgressEpochs.get(sessionId) ?? 0) + 1);
   }
@@ -156,7 +188,16 @@ export function emitCompactionProgress(
     ...(options?.streamText !== undefined ? { streamText: options.streamText } : {}),
     ...(options?.estimatedTokens !== undefined ? { estimatedTokens: options.estimatedTokens } : {}),
   };
-  sendTurnEvent(wc, active, IPC_CHANNELS.CHAT_COMPACTION_PROGRESS, payload);
+  const active = activeAgents.get(sessionId);
+  if (active && !active.finalized) {
+    const wc = options?.webContents ?? webContentsForWindowId(active.windowId);
+    if (!wc) return;
+    sendTurnEvent(wc, active, IPC_CHANNELS.CHAT_COMPACTION_PROGRESS, payload);
+    return;
+  }
+  const identity = idleCompactionIdentity(sessionId, phase === 'complete' || phase === 'failed');
+  if (!identity) return;
+  sendSessionEvent(null, sessionId, IPC_CHANNELS.CHAT_COMPACTION_PROGRESS, { ...identity, ...payload });
 }
 
 /**
@@ -178,6 +219,7 @@ export function clearCompactionState(sessionId: string): void {
   clearCompactionPausesForSession(sessionId);
   triggerCalibrationHydrated.delete(sessionId);
   selectiveRunsInFlight.delete(sessionId);
+  idleCompactionEventIds.delete(sessionId);
   compactionProgressEpochs.set(sessionId, (compactionProgressEpochs.get(sessionId) ?? 0) + 1);
   for (const key of [...compactionRetryTried]) {
     if (key === sessionId || key.startsWith(`${sessionId}:`)) compactionRetryTried.delete(key);
@@ -203,8 +245,9 @@ export const COMPACTION_STREAM_EMIT_INTERVAL_MS = 100;
 /**
  * Throttled live-progress emitter for the compaction widget: forwards the
  * compactor's accumulated LLM output as `compaction_progress` events with
- * phase `'compacting'`. No-ops when the session has no active agent, so it is
- * safe to pass unconditionally as `onTextDelta`. A trailing flush guarantees
+ * phase `'compacting'`. Routes through `emitCompactionProgress`, so idle
+ * sessions (manual `/compact`) get the widget too; safe to pass
+ * unconditionally as `onTextDelta`. A trailing flush guarantees
  * the final accumulated text always lands even when deltas arrive in bursts.
  * Bound to the compaction epoch at creation: once this compaction reaches a
  * terminal phase (or the session's compaction state is cleared and a later
@@ -220,8 +263,6 @@ export function createCompactionStreamEmitter(sessionId: string): (accumulatedTe
     trailingTimer = null;
     lastEmitAt = Date.now();
     if ((compactionProgressEpochs.get(sessionId) ?? 0) !== boundEpoch) return;
-    const active = activeAgents.get(sessionId);
-    if (!active || active.finalized) return;
     let estimatedTokens: number | null = null;
     try {
       const tpc = getCompactionTrigger(sessionId).state.tokensPerChar;
@@ -231,16 +272,10 @@ export function createCompactionStreamEmitter(sessionId: string): (accumulatedTe
     } catch {
       // trigger unavailable (test env) — char count remains the display
     }
-    const wc = webContentsForWindowId(active.windowId);
-    if (wc) {
-      sendTurnEvent(wc, active, IPC_CHANNELS.CHAT_COMPACTION_PROGRESS, {
-        type: 'compaction_progress',
-        agentScopeId: MAIN_AGENT_SCOPE_ID,
-        phase: 'compacting',
-        streamText: latest,
-        estimatedTokens,
-      });
-    }
+    emitCompactionProgress(sessionId, 'compacting', undefined, {
+      streamText: latest,
+      estimatedTokens,
+    });
   };
   return (accumulatedText: string): void => {
     latest = accumulatedText;
@@ -777,20 +812,22 @@ export async function tryCompactSynchronously(
   accountingStore: ProviderAccountingStore,
   chainId: string | null,
   turnId: string,
-): Promise<{ didApply: boolean; updatedMessages?: Message[]; transcriptMessages?: Message[] }> {
+  opts?: { manual?: boolean },
+): Promise<{ didApply: boolean; updatedMessages?: Message[]; transcriptMessages?: Message[]; reason?: string }> {
   const trigger = getCompactionTrigger(sessionId);
   const cfg = runtime.config.compaction?.main;
-  if (!cfg) return { didApply: false };
+  if (!cfg) return { didApply: false, reason: 'compaction-disabled' };
   // Models without a configured context window never compact proactively:
   // fabricating an assumed window here diverged from the mid-turn usage path,
-  // which is disabled when the limit is unknown.
-  if (contextTokens == null || !Number.isFinite(contextTokens) || contextTokens <= 0) return { didApply: false };
-  if (trigger.state.pendingPrepare) return { didApply: false };
+  // which is disabled when the limit is unknown. Manual compaction shares the
+  // rule — without a window there is no preserve budget to compute.
+  if (contextTokens == null || !Number.isFinite(contextTokens) || contextTokens <= 0) return { didApply: false, reason: 'no-context-window' };
+  if (trigger.state.pendingPrepare) return { didApply: false, reason: 'prepare-in-flight' };
   // A selective run orphaned by a discarded pending may still be streaming;
   // starting another here would duplicate the compactor LLM call. The backoff
   // is deliberately NOT consulted here — the overflow-retry caller treats
   // compaction as an emergency recovery path and must bypass the cooldown.
-  if (isSelectiveRunInFlight(sessionId)) return { didApply: false };
+  if (isSelectiveRunInFlight(sessionId)) return { didApply: false, reason: 'selective-in-flight' };
   // One exempt set per attempt: the gate's selectCut, the selective runner,
   // and every apply below consume the same resolved set.
   const exemptIds = mainExemptIds(messages, cfg);
@@ -804,8 +841,9 @@ export async function tryCompactSynchronously(
       tokensPerChar: trigger.state.tokensPerChar ?? null,
       triggerState: trigger.state,
       exemptIds,
+      ...(opts?.manual ? { manual: true } : {}),
     });
-    if (decision.kind === 'no-op') return { didApply: false };
+    if (decision.kind === 'no-op') return { didApply: false, reason: decision.reason };
     const { cut, flaggedIds, estimatedInput, tokensPerChar } = decision;
     const chains = getSessionManager().getSession(sessionId)?.chains ?? [];
     if (decision.kind === 'reclaim-only') {
@@ -1185,4 +1223,95 @@ export function handleUsageCompaction(
   } catch (err) {
     console.debug('[compaction] usage trigger failed (non-fatal):', err);
   }
+}
+
+// ── Manual compaction (/compact) ─────────────────────────────────────────────
+
+/**
+ * User-initiated compaction on an idle session (`/compact`). Assembles the
+ * inputs `startChatTurn` normally owns (history, runtime, selection, context
+ * window, compactor attribution), consumes any pending a prior turn left
+ * behind, then runs the synchronous compaction with the manual gate profile:
+ * threshold/hysteresis and `min_compactable_tokens` are bypassed, the reclaim
+ * short-circuit never answers, and calibrate-or-skip still applies.
+ *
+ * Refuses with `busy` while a turn is streaming or starting — the mid-turn
+ * pause machinery owns compaction during a live turn. Post-apply broadcasts
+ * ride the existing SESSION_COMPACTION / SESSION_UPDATED events the durable
+ * persist path emits, so an idle renderer reloads without extra plumbing.
+ */
+export async function compactSessionNow(
+  sessionId: string,
+  runtime: ProjectRuntime,
+  selection: ModelSelection,
+): Promise<ChatCompactResult> {
+  const active = activeAgents.get(sessionId);
+  if ((active && !active.finalized) || sessionsStarting.has(sessionId)) {
+    return { status: 'busy', sessionId };
+  }
+  if (!runtime.config.compaction?.main) {
+    return { status: 'nothing_to_compact', sessionId, detail: 'Compaction is disabled for this project.' };
+  }
+  await hydrateTriggerCalibration(sessionId);
+  let messages: Message[];
+  try {
+    messages = getChatHistory(sessionId) ?? historyFromSession(sessionId);
+  } catch (error) {
+    return {
+      status: 'error',
+      error: `Could not load conversation history: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  // A pending left behind by an interrupted turn IS the requested compaction
+  // half-prepared — consume and apply it before starting a fresh prepare.
+  const pendingApplied = await applyPendingCompactionIfAny(sessionId, messages, runtime);
+  if (pendingApplied.applied) return { status: 'compacted', sessionId };
+  if (pendingApplied.updatedMessages) messages = pendingApplied.updatedMessages;
+
+  let contextTokens: number | null;
+  try {
+    const execution = await getProviderRuntime().resolveExecution(selection);
+    contextTokens = execution.model.limits?.contextTokens ?? null;
+  } catch (error) {
+    return {
+      status: 'error',
+      error: `Provider unavailable for compaction: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  let accountingStore: ProviderAccountingStore;
+  try {
+    accountingStore = getProviderAccountingStore();
+  } catch (error) {
+    return {
+      status: 'error',
+      error: `Accounting store unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  // Attribute the compactor LLM attempt to the session's latest chain when one
+  // exists; otherwise it lands chain-less like other out-of-turn work.
+  let chainId: string | null = null;
+  try {
+    const chains = getSessionManager().getSession(sessionId)?.chains ?? [];
+    chainId = chains.length > 0 ? chains[chains.length - 1]!.id : null;
+  } catch {
+    // attribution is best-effort
+  }
+  // Widget feedback on the idle session: preparing opens the compaction
+  // widget; every non-applying exit below emits the terminal phase so the
+  // widget can never stay stuck on 'preparing' (tryCompact's success
+  // branches emit 'complete' themselves via completeCompactionWidget).
+  emitCompactionProgress(sessionId, 'preparing', 'Compacting context', {
+    mode: runtime.config.compaction.main.mode,
+  });
+  const result = await tryCompactSynchronously(
+    sessionId, messages, runtime, selection, contextTokens, accountingStore, chainId, randomUUID(),
+    { manual: true },
+  );
+  if (result.didApply) return { status: 'compacted', sessionId };
+  emitCompactionProgress(
+    sessionId,
+    'failed',
+    result.reason ? `Compaction skipped — ${result.reason}` : 'Compaction produced no change',
+  );
+  return { status: 'nothing_to_compact', sessionId, ...(result.reason ? { detail: result.reason } : {}) };
 }

--- a/electron/src/main/ipc/chat/send.ts
+++ b/electron/src/main/ipc/chat/send.ts
@@ -59,6 +59,7 @@ import {
   canEmitStreamEvents,
   isCurrentAgent,
   nextAgentGeneration,
+  sessionOperationGateTail,
   sessionsStarting,
   type ActiveAgent,
 } from './state';
@@ -111,6 +112,18 @@ export async function startChatTurn(
   clearCompactionPause(sessionId, MAIN_AGENT_SCOPE_ID);
   if (sessionsStarting.has(sessionId)) {
     return { status: 'error', error: 'A turn is already starting for this session.', kind: 'session_busy' };
+  }
+  // A manual compaction (/compact) may still be persisting on this idle
+  // session — its entry busy check ran before this send claimed the
+  // turn-start slot. Wait the operation gate out (no yield when nothing is
+  // gated), then re-check: another send may have claimed the slot while we
+  // waited.
+  const operationGate = sessionOperationGateTail(sessionId);
+  if (operationGate) {
+    await operationGate;
+    if (sessionsStarting.has(sessionId)) {
+      return { status: 'error', error: 'A turn is already starting for this session.', kind: 'session_busy' };
+    }
   }
   sessionsStarting.add(sessionId);
   const existing = activeAgents.get(sessionId);

--- a/electron/src/main/ipc/chat/state.ts
+++ b/electron/src/main/ipc/chat/state.ts
@@ -129,6 +129,40 @@ export function nextAgentGeneration(sessionId: string): number {
   return gen;
 }
 
+/**
+ * Per-session operation gate serializing manual compaction (`/compact`)
+ * against turn starts. A manual compaction runs its whole body — busy check
+ * through compaction persistence and the terminal widget event — under the
+ * gate; `startChatTurn` waits out an in-flight gate before claiming the
+ * turn-start slot. The opposite direction is covered by the compaction entry
+ * busy check (activeAgents/sessionsStarting). Entries self-clean: the map
+ * holds only the unsettled tail of the per-session chain.
+ */
+const sessionOperationGates = new Map<string, Promise<void>>();
+
+/** Run `operation` after any in-flight gated operation for this session. */
+export function runWithSessionOperationGate<T>(
+  sessionId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = sessionOperationGates.get(sessionId) ?? Promise.resolve();
+  const run = previous.then(operation, operation);
+  const tail = run.then(
+    () => {},
+    () => {},
+  );
+  sessionOperationGates.set(sessionId, tail);
+  void tail.then(() => {
+    if (sessionOperationGates.get(sessionId) === tail) sessionOperationGates.delete(sessionId);
+  });
+  return run;
+}
+
+/** The unsettled gated operation for this session, if any (never rejects). */
+export function sessionOperationGateTail(sessionId: string): Promise<void> | null {
+  return sessionOperationGates.get(sessionId) ?? null;
+}
+
 /** Whether a session still has a cancellable main-agent turn. */
 export function hasLiveMainTurn(sessionId: string): boolean {
   const active = activeAgents.get(sessionId);

--- a/electron/src/main/ipc/payload-schemas.ts
+++ b/electron/src/main/ipc/payload-schemas.ts
@@ -34,6 +34,10 @@ export const chatStopSchema = z.object({
   sessionId: z.string().uuid(),
 });
 
+export const chatCompactSchema = z.object({
+  sessionId: z.string().uuid().optional(),
+});
+
 export const subagentSnapshotSchema = z.object({
   sessionId: z.string().uuid(),
 }).strict();

--- a/electron/src/main/llm/compaction/pipeline.ts
+++ b/electron/src/main/llm/compaction/pipeline.ts
@@ -131,6 +131,26 @@ export interface CompactionCutConfig {
 }
 
 /**
+ * Preserve-budget base for one evaluation: `preserve_percent` scales against
+ * CURRENT usage, not the model window — clamped at the window so an
+ * over-window estimate cannot inflate the base. Falls back to the window when
+ * no current estimate exists (the pre-usage behavior).
+ */
+export function preserveBaseTokens(
+  currentInputTokens: number | null | undefined,
+  contextTokens: number,
+): number {
+  if (
+    typeof currentInputTokens === 'number'
+    && Number.isFinite(currentInputTokens)
+    && currentInputTokens > 0
+  ) {
+    return Math.min(currentInputTokens, contextTokens);
+  }
+  return contextTokens;
+}
+
+/**
  * Cut selection with a calibrated estimator and the R31/R32/R33 exempt user
  * ids resolved from config — the shared math for fire points that need a cut
  * without the threshold gate (the overflow-retry exhaustion check).
@@ -141,6 +161,8 @@ export function calibratedCut(
     readonly config: CompactionCutConfig;
     readonly contextTokens: number;
     readonly tokensPerChar: number;
+    /** Current estimated/observed input tokens; preserve scales against this. */
+    readonly currentInputTokens?: number | null;
   },
 ): CutResult {
   const tokensPerChar = clampTokensPerChar(opts.tokensPerChar);
@@ -148,7 +170,9 @@ export function calibratedCut(
   const charsByMessage = new Map<Message, number>();
   for (let i = 0; i < messages.length; i += 1) charsByMessage.set(messages[i]!, cache.chars[i]!);
   return selectCut(messages, {
-    preserveTokens: Math.floor(resolvePreservePercent(opts.config) * opts.contextTokens),
+    preserveTokens: Math.floor(
+      resolvePreservePercent(opts.config) * preserveBaseTokens(opts.currentInputTokens, opts.contextTokens),
+    ),
     tokenEstimator: cachedCharEstimator(charsByMessage, tokensPerChar),
     exemptIds: resolveUserExemptIds(messages, {
       keepLast: opts.config.keep_last_user_messages ?? null,
@@ -179,6 +203,14 @@ export interface CompactionGateInput {
   readonly contextTokens: number;
   /** Trigger state the hysteresis/pending gates read. Never mutated here. */
   readonly triggerState?: TriggerState;
+  /**
+   * Explicit user request (`/compact`): bypasses the threshold/hysteresis gate
+   * and the `min_compactable_tokens` floor, and never takes the reclaim
+   * short-circuit (the user asked for a compaction, so a summarizer/selective
+   * run always prepares; reclaim flags still merge into the apply). The
+   * uncalibrated gate, the empty-range check, and exempt ids still apply.
+   */
+  readonly manual?: boolean;
   /** Pre-resolved exempt user ids; defaults to `resolveUserExemptIds` from config. */
   readonly exemptIds?: ReadonlySet<string>;
   /** Pre-computed char cache; defaults to a fresh single pass over `messages`. */
@@ -247,7 +279,7 @@ export function runCompactionGate(input: CompactionGateInput): CompactionGateDec
       : null;
   const estimatedInput = observed ?? Math.ceil(cache.total * tokensPerChar);
 
-  if (estimatedInput < contextTokens) {
+  if (!input.manual && estimatedInput < contextTokens) {
     const ratio = estimatedInput / contextTokens;
     if (ratio + 1e-9 < config.threshold) {
       const baseline = state.postCompactionInputTokens;
@@ -271,7 +303,9 @@ export function runCompactionGate(input: CompactionGateInput): CompactionGateDec
   const charsByMessage = new Map<Message, number>();
   for (let i = 0; i < messages.length; i += 1) charsByMessage.set(messages[i]!, cache.chars[i]!);
   const cut = selectCut(messages, {
-    preserveTokens: Math.floor(resolvePreservePercent(config) * contextTokens),
+    preserveTokens: Math.floor(
+      resolvePreservePercent(config) * preserveBaseTokens(estimatedInput, contextTokens),
+    ),
     tokenEstimator: cachedCharEstimator(charsByMessage, tokensPerChar),
     exemptIds,
   });
@@ -282,13 +316,21 @@ export function runCompactionGate(input: CompactionGateInput): CompactionGateDec
   let rangeChars = 0;
   for (let i = range.start; i < range.end; i += 1) rangeChars += cache.chars[i] ?? 0;
   const compactableTokens = Math.ceil(rangeChars * tokensPerChar);
-  if (compactableTokens < config.min_compactable_tokens) {
+  if (!input.manual && compactableTokens < config.min_compactable_tokens) {
     return { kind: 'no-op', reason: 'below-floor', tokensPerChar };
   }
 
   let flaggedIds: string[] = [];
   if (config.mechanical_reclaim) {
     flaggedIds = mechanicalReclaim(messages, range).flaggedIds;
+  }
+
+  // Manual requests skip the trigger evaluation entirely: threshold and
+  // hysteresis were user-supplied intent, the floor does not apply, and the
+  // reclaim short-circuit must not answer a compaction request with flags
+  // alone. Reclaim flags computed above still merge into the apply.
+  if (input.manual) {
+    return { kind: 'prepare', reason: 'manual', cut, flaggedIds, compactableTokens, estimatedInput, tokensPerChar };
   }
 
   const decision = evaluateTriggerWithReclaim({

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -23,6 +23,7 @@ import type {
   ChatCancelMessage,
   ChatQueueNextRequest,
   ChatStopMessage,
+  ChatCompactResult,
   ChatSnapshotMessage,
   ChatChunkEvent,
   ChatThinkingEvent,
@@ -343,6 +344,9 @@ const orchidAPI: OrchidAPI = {
 
     stop: (message: ChatStopMessage) =>
       invoke(IPC_CHANNELS.CHAT_STOP, message),
+
+    compact: (message?: ChatCancelMessage) =>
+      invoke<ChatCompactResult>(IPC_CHANNELS.CHAT_COMPACT, message ?? {}),
 
     snapshot: (message?: ChatSnapshotMessage) =>
       invoke(IPC_CHANNELS.CHAT_SNAPSHOT, message ?? {}),

--- a/electron/src/renderer/commands/registry.ts
+++ b/electron/src/renderer/commands/registry.ts
@@ -215,6 +215,21 @@ export const COMMANDS: (Command & { execute: (ctx: CommandContext) => Promise<vo
       ctx.onClose();
     },
   },
+  {
+    name: '/compact',
+    description: 'Compact the current session context',
+    category: 'commands',
+    execute: async (ctx) => {
+      ctx.onClose();
+      try {
+        const result = await ctx.onCompact();
+        void result;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        ctx.onNotify(`Compaction failed: ${msg}`, 'error');
+      }
+    },
+  },
 ];
 
 // ── Sub-picker data builders ─────────────────────────────────────────────────

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -995,6 +995,25 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
     }
   }, [refreshIndex]);
 
+  // /compact — user-initiated compaction of the active session. Main refuses
+  // while a turn is streaming; the status maps to a toast and the renderer
+  // reloads the session on SESSION_COMPACTION like an automatic compaction.
+  const handleCompact = useCallback(async () => {
+    if (!window.orchid?.chat?.compact) {
+      throw new Error('Compaction IPC is not available');
+    }
+    const result = await window.orchid.chat.compact();
+    if (result.status === 'compacted') {
+      notify('Context compacted.', 'info');
+    } else if (result.status === 'busy') {
+      notify('Session is busy — compact after the current turn finishes.', 'warning');
+    } else if (result.status === 'nothing_to_compact') {
+      notify(result.detail ? `Nothing to compact (${result.detail}).` : 'Nothing to compact.', 'info');
+    } else if (result.status === 'error') {
+      throw new Error(result.error);
+    }
+  }, [notify]);
+
   useInspectorHydration({
     enabled: sidebarOpen,
     workspaceKey: workspaceCwd,
@@ -1064,6 +1083,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
     onPickProjectDir: handlePickProjectDir,
     onIndexRAG: handleIndexRAG,
     onIndexAST: handleIndexAST,
+    onCompact: handleCompact,
     onClearRAG: async () => {
       try {
         if (window.orchid?.rag?.clear) {
@@ -1089,6 +1109,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
     handlePickProjectDir,
     handleIndexRAG,
     handleIndexAST,
+    handleCompact,
     refreshIndex,
     notify,
   ]);

--- a/electron/src/renderer/components/Preferences/CompactionTab.tsx
+++ b/electron/src/renderer/components/Preferences/CompactionTab.tsx
@@ -201,7 +201,7 @@ export function CompactionTab({ compaction, onChange }: CompactionTabProps) {
           <FormField
             label="Preserve Percent"
             htmlFor={`${prefix}-preserve-percent`}
-            hint="Fraction of the context window kept verbatim (never compacted). The newest messages fill this budget from the end; everything older is summarized. 0.25 = keep the most recent 25%."
+            hint="Fraction of the CURRENT context usage kept verbatim (never compacted), clamped to the context window. The newest messages fill this budget from the end; everything older is summarized. 0.25 = keep the most recent 25% of what is in use."
             className="config-field"
           >
             <TextInput

--- a/electron/src/renderer/components/ProjectConfigView.tsx
+++ b/electron/src/renderer/components/ProjectConfigView.tsx
@@ -184,7 +184,7 @@ const TAB_SECTIONS: Partial<Record<ProjectTab, ProjectConfigSection[]>> = {
       fields: [
         { key: 'compaction.main.mode', label: 'Mode (main)', kind: 'select', options: ['simple', 'selective'] },
         { key: 'compaction.main.threshold', label: 'Threshold (main)', kind: 'number', min: 0.1, max: 0.95, step: 0.05 },
-        { key: 'compaction.main.preserve_percent', label: 'Preserve Percent (main)', kind: 'number', min: 0.05, max: 0.9, step: 0.05 },
+        { key: 'compaction.main.preserve_percent', label: 'Preserve Percent (main)', kind: 'number', min: 0.05, max: 0.9, step: 0.05, hint: 'Fraction of current context usage kept verbatim (clamped to the window).' },
         { key: 'compaction.main.min_compactable_tokens', label: 'Min Compactable Tokens (main)', kind: 'integer', min: 0, max: 1_000_000 },
         { key: 'compaction.main.mechanical_reclaim', label: 'Mechanical Reclaim (main)', kind: 'boolean' },
         { key: 'compaction.main.hysteresis_delta', label: 'Hysteresis Delta (main)', kind: 'number', min: 0, max: 0.5, step: 0.05, hint: COMPACTION_HYSTERESIS_HINT },
@@ -197,7 +197,7 @@ const TAB_SECTIONS: Partial<Record<ProjectTab, ProjectConfigSection[]>> = {
       fields: [
         { key: 'compaction.subagents.mode', label: 'Mode (subagents)', kind: 'select', options: ['simple', 'selective'] },
         { key: 'compaction.subagents.threshold', label: 'Threshold (subagents)', kind: 'number', min: 0.1, max: 0.95, step: 0.05 },
-        { key: 'compaction.subagents.preserve_percent', label: 'Preserve Percent (subagents)', kind: 'number', min: 0.05, max: 0.9, step: 0.05 },
+        { key: 'compaction.subagents.preserve_percent', label: 'Preserve Percent (subagents)', kind: 'number', min: 0.05, max: 0.9, step: 0.05, hint: 'Fraction of current context usage kept verbatim (clamped to the window).' },
         { key: 'compaction.subagents.min_compactable_tokens', label: 'Min Compactable Tokens (subagents)', kind: 'integer', min: 0, max: 1_000_000 },
         { key: 'compaction.subagents.mechanical_reclaim', label: 'Mechanical Reclaim (subagents)', kind: 'boolean' },
         { key: 'compaction.subagents.hysteresis_delta', label: 'Hysteresis Delta (subagents)', kind: 'number', min: 0, max: 0.5, step: 0.05, hint: COMPACTION_HYSTERESIS_HINT },

--- a/electron/src/renderer/hooks/useChat.ts
+++ b/electron/src/renderer/hooks/useChat.ts
@@ -220,6 +220,7 @@ export function acceptChatEvent(
   affinity: ChatEventAffinity,
   event: { sessionId: string; turnId: string; sequence: number },
   isSending: boolean,
+  rebindTurnWhenIdle = false,
 ): boolean {
   if (affinity.selectedSessionId && event.sessionId !== affinity.selectedSessionId) return false;
   if (!affinity.selectedSessionId && affinity.streamSessionId && event.sessionId !== affinity.streamSessionId) return false;
@@ -227,7 +228,16 @@ export function acceptChatEvent(
     if (!isSending) return false;
     affinity.streamSessionId = event.sessionId;
   }
-  if (affinity.streamTurnId && affinity.streamTurnId !== event.turnId) return false;
+  if (affinity.streamTurnId && affinity.streamTurnId !== event.turnId) {
+    // A manual /compact emits progress outside any turn with its own synthetic
+    // turnId. While the renderer holds no live stream the mismatch rebinds
+    // (with a fresh sequence watermark); while streaming, a mismatched turnId
+    // is a foreign or stale event and stays rejected.
+    if (!(rebindTurnWhenIdle && !isSending)) return false;
+    affinity.streamTurnId = event.turnId;
+    affinity.lastSequence = event.sequence;
+    return true;
+  }
   if (affinity.streamTurnId === event.turnId && event.sequence <= affinity.lastSequence) return false;
   affinity.streamTurnId = event.turnId;
   affinity.lastSequence = event.sequence;
@@ -464,8 +474,13 @@ export function useChat(
     }
   }, [activeSessionId, isSwitchingSession]);
 
-  const acceptsEvent = useCallback((event: Pick<ChatTurnEventAction, 'sessionId' | 'turnId' | 'sequence'>) =>
-    acceptChatEvent(affinityRef.current.value, event, isSendingRef.current), []);
+  const acceptsEvent = useCallback(
+    (
+      event: Pick<ChatTurnEventAction, 'sessionId' | 'turnId' | 'sequence'>,
+      opts?: { readonly rebindTurnWhenIdle?: boolean },
+    ) => acceptChatEvent(affinityRef.current.value, event, isSendingRef.current, opts?.rebindTurnWhenIdle),
+    [],
+  );
   const cancelStreamFrame = useCallback(() => {
     if (streamFrameIdRef.current == null) return;
     window.cancelAnimationFrame(streamFrameIdRef.current);
@@ -514,13 +529,13 @@ export function useChat(
       isSendingRef.current = false;
     }
   }, [dispatchProjection, flushStreamFrame]);
-  const deliverEvent = useCallback((event: ChatTurnEventAction) => {
+  const deliverEvent = useCallback((event: ChatTurnEventAction, opts?: { readonly rebindTurnWhenIdle?: boolean }) => {
     // Actor idle/interrupted snapshots can straddle the terminal event. They
     // must not end the renderer turn or claim affinity for the next queued
     // turn; done/error owns the terminal handoff and authoritative messages.
     if ('state' in event && (event.state === 'idle' || event.state === 'interrupted')) return;
     if (bufferHydrationEvent(event)) return;
-    if (acceptsEvent(event)) applyLiveEvent(event);
+    if (acceptsEvent(event, opts)) applyLiveEvent(event);
   }, [acceptsEvent, applyLiveEvent, bufferHydrationEvent]);
 
   // Subscribe to IPC events
@@ -546,7 +561,10 @@ export function useChat(
     const unsubToolStart = window.orchid.chat.onToolCallStart?.((event: ChatToolCallStartEvent) => deliverEvent(normalize(event))) ?? (() => {});
     const unsubToolDelta = window.orchid.chat.onToolCallDelta?.((event: ChatToolCallDeltaEvent) => queueFrameEvent(normalize(event))) ?? (() => {});
     const unsubToolUpdate = window.orchid.chat.onToolCallUpdate?.((event: ChatToolCallUpdateEvent) => deliverEvent(normalize(event))) ?? (() => {});
-    const unsubCompactionProgress = window.orchid.chat.onCompactionProgress?.((event: CompactionProgressEvent) => deliverEvent(normalize(event))) ?? (() => {});
+    // Manual /compact runs outside any turn with a synthetic turnId — the
+    // rebind flag lets idle compaction progress rebind turn affinity instead
+    // of being rejected as a foreign turn.
+    const unsubCompactionProgress = window.orchid.chat.onCompactionProgress?.((event: CompactionProgressEvent) => deliverEvent(normalize(event), { rebindTurnWhenIdle: true })) ?? (() => {});
 
     return () => {
       cancelStreamFrame();

--- a/electron/src/shared/types/ipc-boundary.ts
+++ b/electron/src/shared/types/ipc-boundary.ts
@@ -441,6 +441,8 @@ export interface CommandContext {
   onIndexAST: () => Promise<void>;
   /** Clear RAG index. */
   onClearRAG: () => Promise<void>;
+  /** Compact the active session's context (user-initiated /compact). */
+  onCompact: () => Promise<void>;
   /** Show a notification message. */
   onNotify: (message: string, severity?: 'info' | 'warning' | 'error') => void;
   /** Close the command palette. */

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -1134,6 +1134,18 @@ export type ChatSendResult =
       error: string;
     };
 
+/** Result of chat:compact — a user-initiated `/compact` on an idle session. */
+export type ChatCompactResult =
+  | { status: 'compacted'; sessionId: string }
+  | { status: 'busy'; sessionId: string }
+  | {
+      status: 'nothing_to_compact';
+      sessionId: string;
+      /** Gate reason ('empty-compactable-range', 'uncalibrated', …). */
+      detail?: string;
+    }
+  | { status: 'error'; error: string };
+
 // ── Updater API ──────────────────────────────────────────────────────────────
 
 /** Detailed download progress emitted on updater:progress. */
@@ -1303,6 +1315,8 @@ export interface OrchidAPI {
     queueNext: (request: ChatQueueNextRequest) => Promise<void>;
     /** Immediately stop exactly one session without staged Esc confirmation. */
     stop: (message: ChatStopMessage) => Promise<{ status: string }>;
+    /** User-initiated compaction (/compact) on an idle session. */
+    compact: (message?: ChatCancelMessage) => Promise<ChatCompactResult>;
     /** Read coherent persisted history and in-flight state without changing selection. */
     snapshot: (message?: ChatSnapshotMessage) => Promise<ChatSessionSnapshot | null>;
     onChunk: (callback: (event: ChatChunkEvent) => void) => () => void;
@@ -1573,6 +1587,7 @@ export const IPC_CHANNELS = {
   CHAT_TOOL_CALL_DELTA: 'chat:tool_call_delta',
   CHAT_TOOL_CALL_UPDATE: 'chat:tool_call_update',
   CHAT_COMPACTION_PROGRESS: 'chat:compaction_progress',
+  CHAT_COMPACT: 'chat:compact',
 
   SUBAGENTS_SNAPSHOT: 'subagents:snapshot',
   SUBAGENTS_DETAIL: 'subagents:detail',
@@ -1747,6 +1762,7 @@ export const ALLOWED_INVOKE_CHANNELS = [
   IPC_CHANNELS.CHAT_QUEUE_NEXT,
   IPC_CHANNELS.CHAT_STOP,
   IPC_CHANNELS.CHAT_SNAPSHOT,
+  IPC_CHANNELS.CHAT_COMPACT,
   IPC_CHANNELS.SUBAGENTS_SNAPSHOT,
   IPC_CHANNELS.SUBAGENTS_DETAIL,
   IPC_CHANNELS.CONFIG_GET,

--- a/electron/tests/integration/command-palette.test.ts
+++ b/electron/tests/integration/command-palette.test.ts
@@ -109,8 +109,8 @@ afterEach(() => {
 // ─── Command Registry ────────────────────────────────────────────────────────
 
 describe('Command Registry', () => {
-  it('all 12 commands are registered', () => {
-    expect(COMMANDS).toHaveLength(12);
+  it('all 13 commands are registered', () => {
+    expect(COMMANDS).toHaveLength(13);
   });
 
   it('all command names are defined', () => {

--- a/electron/tests/parity/commands.test.ts
+++ b/electron/tests/parity/commands.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { COMMANDS } from '../../src/renderer/commands/registry';
 
-// ── Expected commands (12 total) ───────────────────────────────────────────
+// ── Expected commands (13 total) ───────────────────────────────────────────
 
 const EXPECTED_COMMANDS = [
   { name: '/new', category: 'commands' },
@@ -22,13 +22,14 @@ const EXPECTED_COMMANDS = [
   { name: '/rag index', category: 'commands' },
   { name: '/ast index', category: 'commands' },
   { name: '/rag clear', category: 'commands' },
+  { name: '/compact', category: 'commands' },
 ];
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe('Command Parity', () => {
-  it('all 12 commands are registered', () => {
-    expect(COMMANDS).toHaveLength(12);
+  it('all 13 commands are registered', () => {
+    expect(COMMANDS).toHaveLength(13);
   });
 
   it('all expected command names are present', () => {

--- a/electron/tests/unit/compaction-pipeline.test.ts
+++ b/electron/tests/unit/compaction-pipeline.test.ts
@@ -34,6 +34,7 @@ import {
   clampTokensPerChar,
   computeMessageCharCache,
   deriveTokensPerChar,
+  preserveBaseTokens,
   runCompactionGate,
   type CompactableRange,
   type MessageCharCache,
@@ -191,6 +192,130 @@ describe('deriveTokensPerChar / clampTokensPerChar', () => {
 
   it('floors the char-cache total so tiny histories never divide by zero', () => {
     expect(computeMessageCharCache([])).toEqual({ chars: [], total: 1 });
+  });
+});
+
+// ── Preserve base (current usage, clamped to the window) ─────────────────────
+
+describe('preserveBaseTokens', () => {
+  it('scales the preserve base to current usage and clamps at the window', () => {
+    expect(preserveBaseTokens(4_000, 10_000)).toBe(4_000);
+    expect(preserveBaseTokens(12_000, 10_000)).toBe(10_000);
+  });
+
+  it('falls back to the window when no usable current estimate exists', () => {
+    expect(preserveBaseTokens(null, 10_000)).toBe(10_000);
+    expect(preserveBaseTokens(0, 10_000)).toBe(10_000);
+    expect(preserveBaseTokens(Number.NaN, 10_000)).toBe(10_000);
+    expect(preserveBaseTokens(undefined, 10_000)).toBe(10_000);
+  });
+});
+
+describe('runCompactionGate — preserve budget scales with current usage', () => {
+  it('compacts more when current usage is below the window', () => {
+    // Same history, fixed calibration; only the observed input differs. Both
+    // sit above the 0.5 threshold, so both prepare — but the 6k observation
+    // shrinks the preserve budget (0.25 × 6k < 0.25 × 10k), leaving a larger
+    // compactable range than the 10k observation.
+    const atWindow = runCompactionGate(gateInput({ inputTokens: 10_000, tokensPerChar: 0.2 }));
+    const belowWindow = runCompactionGate(gateInput({ inputTokens: 6_000, tokensPerChar: 0.2 }));
+    expect(atWindow.kind).toBe('prepare');
+    expect(belowWindow.kind).toBe('prepare');
+    if (atWindow.kind === 'no-op' || belowWindow.kind === 'no-op') throw new Error('expected action decisions');
+    expect(belowWindow.cut.compactableRange.end).toBeGreaterThanOrEqual(atWindow.cut.compactableRange.end);
+    expect(belowWindow.compactableTokens).toBeGreaterThan(atWindow.compactableTokens);
+  });
+
+  it('keeps the window base when the estimate is over-window (overflow clamp)', () => {
+    // Fixed calibration so only the preserve base varies with the observation.
+    const atWindow = runCompactionGate(gateInput({ inputTokens: 10_000, tokensPerChar: 0.2 }));
+    const overWindow = runCompactionGate(gateInput({ inputTokens: 25_000, tokensPerChar: 0.2 }));
+    if (atWindow.kind === 'no-op' || overWindow.kind === 'no-op') throw new Error('expected action decisions');
+    expect(overWindow.cut.cutIndex).toBe(atWindow.cut.cutIndex);
+    expect(overWindow.cut.compactableRange).toEqual(atWindow.cut.compactableRange);
+  });
+});
+
+// ── Manual mode (/compact) ───────────────────────────────────────────────────
+
+describe('runCompactionGate — manual mode', () => {
+  it('bypasses the threshold gate entirely', () => {
+    const below = runCompactionGate(gateInput({ inputTokens: 1_000 }));
+    expect(below).toMatchObject({ kind: 'no-op', reason: 'below-threshold' });
+    const manual = runCompactionGate(gateInput({ inputTokens: 1_000, manual: true }));
+    expect(manual).toMatchObject({ kind: 'prepare', reason: 'manual' });
+  });
+
+  it('bypasses armed hysteresis without accrual', () => {
+    const armed: TriggerState = {
+      hysteresisArmed: true,
+      pendingPrepare: false,
+      postCompactionInputTokens: 7_950,
+    };
+    expect(runCompactionGate(gateInput({ triggerState: armed }))).toMatchObject({ kind: 'no-op', reason: 'hysteresis-armed' });
+    expect(runCompactionGate(gateInput({ triggerState: armed, manual: true }))).toMatchObject({ kind: 'prepare', reason: 'manual' });
+  });
+
+  it('ignores the min_compactable_tokens floor', () => {
+    // Small history + low floor-failing range: auto no-ops below-floor, manual prepares.
+    const smallHistory = [
+      makeMsg('u-0', 'request 0', MessageRole.USER),
+      makeMsg('a-0', 'y'.repeat(4_000), MessageRole.ASSISTANT),
+      makeMsg('u-1', 'request 1', MessageRole.USER),
+      makeMsg('a-1', 'y'.repeat(4_000), MessageRole.ASSISTANT),
+    ];
+    const config = { ...scopeConfig('compactor'), min_compactable_tokens: 1_000_000 };
+    expect(runCompactionGate(gateInput({ messages: smallHistory, config }))).toMatchObject({ kind: 'no-op', reason: 'below-floor' });
+    expect(runCompactionGate(gateInput({ messages: smallHistory, config, manual: true }))).toMatchObject({ kind: 'prepare', reason: 'manual' });
+  });
+
+  it('never takes the reclaim short-circuit — reclaim flags merge into a prepare', () => {
+    const toolCall = (id: string, callId: string): Message => ({
+      ...makeMsg(id, 'do it', MessageRole.ASSISTANT),
+      type: MessageType.TOOL_CALL,
+      tool_calls: [{ id: callId, type: 'function', function: { name: 'read', arguments: '{"file_path":"a"}' } }],
+    });
+    const toolResult = (id: string, callId: string): Message => ({
+      ...makeMsg(id, 'duplicate output', MessageRole.TOOL),
+      type: MessageType.TOOL_RESULT,
+      tool_call_id: callId,
+      name: 'read',
+    });
+    const messages = [
+      makeMsg('u-0', 'request 0', MessageRole.USER),
+      toolCall('a-0', 'tc-1'),
+      toolResult('t-1', 'tc-1'),
+      makeMsg('a-1', 'y'.repeat(8_000), MessageRole.ASSISTANT),
+      toolCall('a-2', 'tc-2'),
+      toolResult('t-2', 'tc-2'),
+      makeMsg('u-1', 'request 1', MessageRole.USER),
+      makeMsg('a-3', 'y'.repeat(8_000), MessageRole.ASSISTANT),
+    ];
+    const config = { ...scopeConfig('compactor'), mechanical_reclaim: true };
+    const auto = runCompactionGate(gateInput({ messages, config }));
+    expect(auto.kind).toBe('prepare');
+    if (auto.kind !== 'prepare') throw new Error('expected prepare');
+    const manual = runCompactionGate(gateInput({ messages, config, manual: true }));
+    expect(manual).toMatchObject({ kind: 'prepare', reason: 'manual' });
+    if (manual.kind !== 'prepare') throw new Error('expected prepare');
+    // Both carry the reclaim flags; manual just never downgrades to reclaim-only.
+    expect(manual.flaggedIds).toContain('t-1');
+    expect(manual.flaggedIds).toEqual(auto.flaggedIds);
+  });
+
+  it('still respects the uncalibrated gate and the empty-range guard', () => {
+    expect(runCompactionGate(gateInput({ inputTokens: null, manual: true }))).toMatchObject({ kind: 'no-op', reason: 'uncalibrated' });
+    const singleChain = [makeMsg('u-0', 'request 0', MessageRole.USER), makeMsg('a-0', 'y'.repeat(10), MessageRole.ASSISTANT)];
+    expect(runCompactionGate(gateInput({ messages: singleChain, manual: true }))).toMatchObject({ kind: 'no-op', reason: 'empty-compactable-range' });
+  });
+
+  it('still respects exempt user-message pinning', () => {
+    const config = { ...scopeConfig('compactor'), keep_last_user_messages: 1 };
+    const decision = runCompactionGate(gateInput({ config, manual: true }));
+    expect(decision.kind).toBe('prepare');
+    if (decision.kind === 'no-op') throw new Error('expected an action decision');
+    const rangeIds = bulkyHistory().slice(decision.cut.compactableRange.start, decision.cut.compactableRange.end).map((m) => m.id);
+    expect(rangeIds).not.toContain('u-5');
   });
 });
 

--- a/electron/tests/unit/compaction-stream-emitter.test.ts
+++ b/electron/tests/unit/compaction-stream-emitter.test.ts
@@ -12,20 +12,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ActiveAgent } from '../../src/main/ipc/chat/state';
 import type { ChatStreamSegmentSnapshot } from '../../src/shared/types/ipc';
 
-const { activeAgents, sendTurnEvent, webContentsForWindowId, selectCutMock, compactableModelSliceMock, runCompactionAttemptMock } = vi.hoisted(() => ({
+const { activeAgents, sessionsStarting, sendTurnEvent, sendSessionEvent, webContentsForWindowId, selectCutMock, compactableModelSliceMock, runCompactionAttemptMock } = vi.hoisted(() => ({
   activeAgents: new Map<string, unknown>(),
+  sessionsStarting: new Set<string>(),
   sendTurnEvent: vi.fn(),
+  sendSessionEvent: vi.fn(),
   webContentsForWindowId: vi.fn(() => ({})),
   selectCutMock: vi.fn(),
   compactableModelSliceMock: vi.fn(),
   runCompactionAttemptMock: vi.fn(),
 }));
 
-vi.mock('../../src/main/ipc/chat/state', () => ({ activeAgents }));
+vi.mock('../../src/main/ipc/chat/state', () => ({ activeAgents, sessionsStarting }));
 vi.mock('../../src/main/ipc/chat/events', () => ({
   sendTurnEvent,
+  sendSessionEvent,
   webContentsForWindowId,
-  sendSessionEvent: vi.fn(),
   buildSessionUpdatedEvent: vi.fn(),
   canSend: vi.fn(() => true),
 }));
@@ -132,7 +134,9 @@ function compactingPayload(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.useFakeTimers();
   activeAgents.clear();
+  sessionsStarting.clear();
   sendTurnEvent.mockClear();
+  sendSessionEvent.mockClear();
   webContentsForWindowId.mockClear();
   webContentsForWindowId.mockReturnValue({});
   try {
@@ -195,10 +199,44 @@ describe('emitCompactionProgress', () => {
     expect(payload).not.toHaveProperty('toolResult');
   });
 
-  it('no-ops without an active agent, a finalized agent, or a target window', () => {
-    emitCompactionProgress(SESSION_ID, 'preparing');
-    expect(sendTurnEvent).not.toHaveBeenCalled();
+  it('emits through a synthetic idle identity when no active agent exists (manual /compact)', () => {
+    emitCompactionProgress(SESSION_ID, 'preparing', 'Compacting context');
+    emitCompactionProgress(SESSION_ID, 'compacting', 'Applying summary');
+    emitCompactionProgress(SESSION_ID, 'complete');
 
+    expect(sendTurnEvent).not.toHaveBeenCalled();
+    expect(sendSessionEvent).toHaveBeenCalledTimes(3);
+    const first = sendSessionEvent.mock.calls[0]!;
+    const second = sendSessionEvent.mock.calls[1]!;
+    const terminal = sendSessionEvent.mock.calls[2]!;
+    for (const call of [first, second, terminal]) {
+      expect(call[0]).toBeNull();
+      expect(call[1]).toBe(SESSION_ID);
+      expect(call[2]).toBe(IPC_CHANNELS.CHAT_COMPACTION_PROGRESS);
+    }
+    // One stable synthetic turnId with a monotonic sequence across the lifecycle.
+    expect((first[3] as Record<string, unknown>).turnId).toBe((second[3] as Record<string, unknown>).turnId);
+    expect((terminal[3] as Record<string, unknown>).turnId).toBe((first[3] as Record<string, unknown>).turnId);
+    expect((first[3] as Record<string, unknown>).sequence).toBe(1);
+    expect((second[3] as Record<string, unknown>).sequence).toBe(2);
+    expect((terminal[3] as Record<string, unknown>).sequence).toBe(3);
+
+    // Terminal drops the identity: the next idle compaction mints a fresh one.
+    emitCompactionProgress(SESSION_ID, 'preparing');
+    const afterTerminal = sendSessionEvent.mock.calls[3]!;
+    expect((afterTerminal[3] as Record<string, unknown>).turnId).not.toBe((first[3] as Record<string, unknown>).turnId);
+    expect((afterTerminal[3] as Record<string, unknown>).sequence).toBe(1);
+  });
+
+  it('stays silent without an active agent while a turn is starting (send-time sync compaction)', () => {
+    sessionsStarting.add(SESSION_ID);
+    emitCompactionProgress(SESSION_ID, 'preparing');
+    emitCompactionProgress(SESSION_ID, 'complete');
+    expect(sendTurnEvent).not.toHaveBeenCalled();
+    expect(sendSessionEvent).not.toHaveBeenCalled();
+  });
+
+  it('no-ops for a finalized agent or a missing target window', () => {
     activeAgents.set(SESSION_ID, makeActive({ finalized: true }));
     emitCompactionProgress(SESSION_ID, 'preparing');
     expect(sendTurnEvent).not.toHaveBeenCalled();
@@ -351,11 +389,25 @@ describe('createCompactionStreamEmitter', () => {
     expect(sendTurnEvent).not.toHaveBeenCalled();
   });
 
-  it('ignores deltas for a session with no active agent', () => {
+  it('delivers idle-session deltas through the synthetic identity (manual /compact widget)', () => {
     const emit = createCompactionStreamEmitter('missing');
     emit('text');
     vi.advanceTimersByTime(COMPACTION_STREAM_EMIT_INTERVAL_MS + 1);
     expect(sendTurnEvent).not.toHaveBeenCalled();
+    expect(sendSessionEvent).toHaveBeenCalledTimes(1);
+    expect(sendSessionEvent).toHaveBeenLastCalledWith(
+      null,
+      'missing',
+      IPC_CHANNELS.CHAT_COMPACTION_PROGRESS,
+      compactingPayload({ streamText: 'text', estimatedTokens: null }),
+    );
+
+    // Deltas stay silent while a turn is starting — the send-time sync
+    // compaction window must not mint a synthetic turnId.
+    sessionsStarting.add('missing');
+    emit('more text');
+    vi.advanceTimersByTime(COMPACTION_STREAM_EMIT_INTERVAL_MS + 1);
+    expect(sendSessionEvent).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/electron/tests/unit/use-chat-affinity.test.ts
+++ b/electron/tests/unit/use-chat-affinity.test.ts
@@ -130,6 +130,32 @@ describe('useChat event affinity', () => {
     expect(acceptChatEvent(state, { sessionId: 'session-a', turnId: 'turn-a', sequence: 1 }, false)).toBe(false);
   });
 
+  it('rejects a foreign turnId without the idle-rebind flag (default event policy)', () => {
+    const state = affinity('session-a');
+    state.streamTurnId = 'turn-a';
+    state.lastSequence = 5;
+    expect(acceptChatEvent(state, { sessionId: 'session-a', turnId: 'manual-1', sequence: 1 }, false)).toBe(false);
+  });
+
+  it('rebinds to a manual compaction turnId when idle, with a fresh sequence watermark', () => {
+    const state = affinity('session-a');
+    state.streamTurnId = 'turn-a';
+    state.lastSequence = 50;
+
+    // Idle: the manual /compact synthetic turn rebinds even at a lower sequence.
+    expect(acceptChatEvent(state, { sessionId: 'session-a', turnId: 'manual-1', sequence: 1 }, false, true)).toBe(true);
+    expect(state.streamTurnId).toBe('manual-1');
+    expect(state.lastSequence).toBe(1);
+    expect(acceptChatEvent(state, { sessionId: 'session-a', turnId: 'manual-1', sequence: 2 }, false, true)).toBe(true);
+    expect(acceptChatEvent(state, { sessionId: 'session-a', turnId: 'manual-1', sequence: 2 }, false, true)).toBe(false);
+
+    // While streaming, the mismatched turnId stays foreign even with the flag.
+    const streaming = affinity('session-a');
+    streaming.streamTurnId = 'turn-live';
+    streaming.lastSequence = 3;
+    expect(acceptChatEvent(streaming, { sessionId: 'session-a', turnId: 'manual-1', sequence: 1 }, true, true)).toBe(false);
+  });
+
   it('binds draft events only while a send is in progress', () => {
     const idleDraft = affinity(null);
     expect(acceptChatEvent(idleDraft, { sessionId: 'session-a', turnId: 'turn-a', sequence: 1 }, false)).toBe(false);


### PR DESCRIPTION
Manual compaction: new /compact slash command runs the full compaction pipeline on an idle session via chat:compact IPC, bypassing the threshold/hysteresis gate and min_compactable_tokens floor while keeping calibrate-or-skip, empty-range, and exempt-pinning guards. Idle compactions emit widget progress through a synthetic event identity (stable turnId + monotonic sequence) so the compaction widget works outside any turn; the renderer rebinds idle turn affinity for compaction events only, and emissions stay silent while a turn is starting so the send-time sync compaction cannot poison turn affinity.

Preserve base: preserve_percent now scales against current context usage (clamped to the window) instead of the model's maximum, so compaction keeps a proportional slice of what is actually in use. The existing hysteresis cap still holds at the worst case (current = window); the subagent overflow-retry exhaustion check passes its post-compaction input to the cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/compact` command to manually compact the active chat session.
  * Manual compaction now works while sessions are idle and reports progress in real time.
  * Added clear status notifications for successful, busy, unavailable, or unnecessary compaction attempts.
  * Improved context preservation calculations based on current usage.

* **Documentation**
  * Clarified compaction preservation settings and behavior in preferences and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->