### PR TITLE
fix(ux): resolve issues 148, 154, 157, 158, 163

### DIFF
--- a/electron/src/main/session/activity.ts
+++ b/electron/src/main/session/activity.ts
@@ -3,6 +3,7 @@ import type {
   SessionActivityPhase,
   SessionExecutionState,
 } from '../../shared/types/ipc-boundary';
+import { compareSessionActivity } from '../../shared/utils/session-activity-order';
 
 export type SessionActivityUpdate = Partial<
   Omit<SessionActivity, 'sessionId' | 'updatedAt'>
@@ -10,18 +11,6 @@ export type SessionActivityUpdate = Partial<
   state?: SessionExecutionState;
   phase?: SessionActivityPhase;
 };
-
-const PRIORITY: Record<SessionExecutionState, number> = {
-  needs_attention: 0,
-  working: 1,
-  waiting: 2,
-  idle: 3,
-};
-
-/** Unknown turn starts sort last, not oldest, within the working/waiting bucket. */
-function startedAtSortValue(activity: SessionActivity): number {
-  return activity.startedAt ?? Number.POSITIVE_INFINITY;
-}
 
 function emptyActivity(sessionId: string, now: number): SessionActivity {
   return {
@@ -96,22 +85,7 @@ export class SessionActivityStore {
         activity.unread ||
         activity.backgroundProcessCount > 0,
       )
-      .sort((a, b) => {
-        const priority = PRIORITY[a.state] - PRIORITY[b.state];
-        if (priority !== 0) return priority;
-        if (a.state === 'working' || a.state === 'waiting') {
-          // Detail updates bump `updatedAt` on every streamed event; order by
-          // turn start so active rows hold their position for the whole turn.
-          // Oldest start first: longest-running work keeps the bucket top and
-          // newly started work enters below it instead of displacing rows.
-          const aStart = startedAtSortValue(a);
-          const bStart = startedAtSortValue(b);
-          if (aStart !== bStart) return aStart - bStart;
-        } else if (a.unread !== b.unread) {
-          return a.unread ? -1 : 1;
-        }
-        return b.updatedAt - a.updatedAt;
-      });
+      .sort(compareSessionActivity);
   }
 
   clear(): void {

--- a/electron/src/main/session/activity.ts
+++ b/electron/src/main/session/activity.ts
@@ -18,6 +18,11 @@ const PRIORITY: Record<SessionExecutionState, number> = {
   idle: 3,
 };
 
+/** Unknown turn starts sort last, not oldest, within the working/waiting bucket. */
+function startedAtSortValue(activity: SessionActivity): number {
+  return activity.startedAt ?? Number.POSITIVE_INFINITY;
+}
+
 function emptyActivity(sessionId: string, now: number): SessionActivity {
   return {
     sessionId,
@@ -94,8 +99,16 @@ export class SessionActivityStore {
       .sort((a, b) => {
         const priority = PRIORITY[a.state] - PRIORITY[b.state];
         if (priority !== 0) return priority;
-        if (a.state === 'idle' && b.state === 'idle') {
-          if (a.unread !== b.unread) return a.unread ? -1 : 1;
+        if (a.state === 'working' || a.state === 'waiting') {
+          // Detail updates bump `updatedAt` on every streamed event; order by
+          // turn start so active rows hold their position for the whole turn.
+          // Oldest start first: longest-running work keeps the bucket top and
+          // newly started work enters below it instead of displacing rows.
+          const aStart = startedAtSortValue(a);
+          const bStart = startedAtSortValue(b);
+          if (aStart !== bStart) return aStart - bStart;
+        } else if (a.unread !== b.unread) {
+          return a.unread ? -1 : 1;
         }
         return b.updatedAt - a.updatedAt;
       });

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useChat } from '../hooks/useChat';
+import { useChat, type UntrustedProjectSendFailure } from '../hooks/useChat';
 import { useSession } from '../hooks/useSession';
 import { useBackgroundCommands } from '../hooks/useBackgroundCommands';
 import { useInspectorHydration } from '../hooks/useInspectorHydration';
@@ -188,11 +188,40 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
 
   // Trusted-projects prompt: explicit interactions (bind result, send failure,
   // badge click) call openFor; granting re-resolves workspace + gated services.
+  // A send that failed the trust gate is stashed here so granting replays it
+  // (issue #148) and declining restores it to the composer instead of losing it.
+  const pendingTrustSendRef = useRef<UntrustedProjectSendFailure | null>(null);
+  /** Late-bound handleSend for the grant replay; handleSend is defined below. */
+  const handleSendRef = useRef<((message: string) => Promise<boolean>) | null>(null);
+  /** One-shot composer draft restore (trust decline). */
+  const [restoreDraft, setRestoreDraft] = useState<{ text: string } | null>(null);
+  const handleRestoreDraftConsumed = useCallback(() => setRestoreDraft(null), []);
+  const draftRestore = useMemo(
+    () => (restoreDraft ? { text: restoreDraft.text, consumed: handleRestoreDraftConsumed } : null),
+    [restoreDraft, handleRestoreDraftConsumed],
+  );
   const trustPrompt = useTrustPrompt({
     onGranted: () => {
       void session.getWorkspace();
       void refreshMCP();
       void refreshIndex();
+      // Replay the trust-gated send. Clear first so a replay that fails again
+      // re-stashes fresh instead of double-firing the stash.
+      const pending = pendingTrustSendRef.current;
+      if (!pending) return;
+      pendingTrustSendRef.current = null;
+      // Superseded: another session owns the view now (the dialog is modal, so
+      // this only happens through programmatic session switches). Drop the
+      // stash silently rather than firing the message into an unrelated
+      // session — the sidebar selected another session deliberately.
+      if ((pending.options.sessionId ?? null) !== (session.activeSession?.id ?? null)) {
+        return;
+      }
+      void handleSendRef.current?.(pending.message)?.then((sent) => {
+        // Replay was gated (provider/workspace changed mid-dialog): put the
+        // message back in the composer instead of dropping it.
+        if (!sent) setRestoreDraft({ text: pending.message });
+      });
     },
   });
 
@@ -216,9 +245,12 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
   const chat = useChat(session.activeSession?.id ?? null, {
     persistedSessionUsage: sessionUsage.total,
     latestPersistedUsage: sessionUsage.latest,
-    onUntrustedProject: () => {
+    onUntrustedProject: (failure) => {
       const cwd = session.workspace?.cwd ?? session.activeSession?.cwd;
-      if (cwd) trustPrompt.openFor(cwd);
+      if (!cwd) return;
+      // Stash the failed send so grant/decline can replay or restore it.
+      pendingTrustSendRef.current = failure;
+      trustPrompt.openFor(cwd);
     },
   });
 
@@ -645,6 +677,32 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
     [session, messageQueue.clearQueue],
   );
 
+  // Project delete removes every session in the group. Sequential so each
+  // delete's working-set snapshot reflects the previous one; one failure must
+  // not abort the rest.
+  const handleProjectDelete = useCallback(
+    async (project: { label: string; sessionIds: readonly string[] }) => {
+      if (project.sessionIds.includes(session.activeSession?.id ?? '')) {
+        messageQueue.clearQueue();
+      }
+      let failures = 0;
+      for (const id of project.sessionIds) {
+        try {
+          await session.deleteSession(id);
+        } catch {
+          failures += 1;
+        }
+      }
+      if (failures > 0) {
+        notify(
+          `Deleted ${project.sessionIds.length - failures} of ${project.sessionIds.length} sessions in ${project.label}; ${failures} failed.`,
+          'error',
+        );
+      }
+    },
+    [session, messageQueue.clearQueue, notify],
+  );
+
   const handleSessionRename = useCallback(
     async (id: string, name: string) => {
       try {
@@ -815,6 +873,9 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
     ],
   );
 
+  // Late-bind handleSend for the trust-grant replay (declared above via ref).
+  handleSendRef.current = handleSend;
+
   const handleRetry = useCallback(async () => {
     // Re-send the last user message after an error
     const lastUser = [...chat.messages]
@@ -890,6 +951,14 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
   const handleOpenProviders = useCallback(() => {
     emitOrchidEvent('orchid:open-settings', { tab: 'providers' });
   }, []);
+  // Declining trust (button, Escape, backdrop click) restores the gated
+  // message to the composer instead of losing it.
+  const handleTrustDecline = useCallback(() => {
+    const pending = pendingTrustSendRef.current;
+    pendingTrustSendRef.current = null;
+    if (pending) setRestoreDraft({ text: pending.message });
+    trustPrompt.decline();
+  }, [trustPrompt.decline]);
   const handleFocusSectionConsumed = useCallback(() => {
     setInspectorFocusSection(null);
   }, []);
@@ -1156,6 +1225,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
         onSessionCreate={handleSessionCreateClick}
         onProjectSessionCreate={handleProjectSessionCreateClick}
         onProjectSelect={handleProjectSelect}
+        onProjectDelete={handleProjectDelete}
         onSessionDelete={handleSessionDelete}
         onSessionDeleteError={handleSessionDeleteError}
         deletingSessionIds={session.pendingDeleteIds}
@@ -1327,6 +1397,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
           onOpenProviders={handleOpenProviders}
           onPickProjectDir={handlePickProjectDirClick}
           isViewActive={!isVisible || contentMode === 'subagents'}
+          draftRestore={draftRestore}
         />
         <DeferredSurface isVisible={isVisible}>
           <Footer
@@ -1426,7 +1497,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
         busy={trustPrompt.busy}
         error={trustPrompt.error}
         onGrant={() => void trustPrompt.grant()}
-        onDecline={trustPrompt.decline}
+        onDecline={handleTrustDecline}
       />
     </div>
   );

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useChat, type UntrustedProjectSendFailure } from '../hooks/useChat';
+import { useChat } from '../hooks/useChat';
 import { useSession } from '../hooks/useSession';
 import { useBackgroundCommands } from '../hooks/useBackgroundCommands';
 import { useInspectorHydration } from '../hooks/useInspectorHydration';
@@ -26,6 +26,7 @@ import { useMessageQueue } from '../hooks/useMessageQueue';
 import { useQueueAutoFire } from '../hooks/useQueueAutoFire';
 import { useResponsiveShell } from '../hooks/use-responsive-shell';
 import { useTrustPrompt } from '../hooks/useTrustPrompt';
+import { useTrustSendReplay, type UseTrustSendReplayReturn } from '../hooks/useTrustSendReplay';
 import {
   providerModelOptionDisplayName,
   providerModelOptionKey,
@@ -188,42 +189,26 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
 
   // Trusted-projects prompt: explicit interactions (bind result, send failure,
   // badge click) call openFor; granting re-resolves workspace + gated services.
-  // A send that failed the trust gate is stashed here so granting replays it
-  // (issue #148) and declining restores it to the composer instead of losing it.
-  const pendingTrustSendRef = useRef<UntrustedProjectSendFailure | null>(null);
-  /** Late-bound handleSend for the grant replay; handleSend is defined below. */
-  const handleSendRef = useRef<((message: string) => Promise<boolean>) | null>(null);
-  /** One-shot composer draft restore (trust decline). */
-  const [restoreDraft, setRestoreDraft] = useState<{ text: string } | null>(null);
-  const handleRestoreDraftConsumed = useCallback(() => setRestoreDraft(null), []);
-  const draftRestore = useMemo(
-    () => (restoreDraft ? { text: restoreDraft.text, consumed: handleRestoreDraftConsumed } : null),
-    [restoreDraft, handleRestoreDraftConsumed],
-  );
+  // useTrustSendReplay owns the #148 stash/replay/restore flow for gated sends
+  // (the ref bridges onGranted to the hook declared just below it).
+  const trustSendRef = useRef<UseTrustSendReplayReturn | null>(null);
   const trustPrompt = useTrustPrompt({
     onGranted: () => {
       void session.getWorkspace();
       void refreshMCP();
       void refreshIndex();
-      // Replay the trust-gated send. Clear first so a replay that fails again
-      // re-stashes fresh instead of double-firing the stash.
-      const pending = pendingTrustSendRef.current;
-      if (!pending) return;
-      pendingTrustSendRef.current = null;
-      // Superseded: another session owns the view now (the dialog is modal, so
-      // this only happens through programmatic session switches). Drop the
-      // stash silently rather than firing the message into an unrelated
-      // session — the sidebar selected another session deliberately.
-      if ((pending.options.sessionId ?? null) !== (session.activeSession?.id ?? null)) {
-        return;
-      }
-      void handleSendRef.current?.(pending.message)?.then((sent) => {
-        // Replay was gated (provider/workspace changed mid-dialog): put the
-        // message back in the composer instead of dropping it.
-        if (!sent) setRestoreDraft({ text: pending.message });
-      });
+      // Replay the trust-gated send (if any).
+      trustSendRef.current?.onGranted();
     },
   });
+  const trustSend = useTrustSendReplay({
+    openFor: trustPrompt.openFor,
+    decline: trustPrompt.decline,
+    restoreBatch: messageQueue.restoreBatch,
+    cwd: workspaceCwd,
+    activeSessionId: session.activeSession?.id ?? null,
+  });
+  trustSendRef.current = trustSend;
 
   const sessionUsage = useMemo(() => {
     const usages = session.activeSession?.chains.map(sumChainUsage) ?? [];
@@ -245,13 +230,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
   const chat = useChat(session.activeSession?.id ?? null, {
     persistedSessionUsage: sessionUsage.total,
     latestPersistedUsage: sessionUsage.latest,
-    onUntrustedProject: (failure) => {
-      const cwd = session.workspace?.cwd ?? session.activeSession?.cwd;
-      if (!cwd) return;
-      // Stash the failed send so grant/decline can replay or restore it.
-      pendingTrustSendRef.current = failure;
-      trustPrompt.openFor(cwd);
-    },
+    onUntrustedProject: trustSend.onUntrustedProject,
   });
 
   useEffect(() => {
@@ -686,16 +665,20 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
         messageQueue.clearQueue();
       }
       let failures = 0;
+      let lastError: unknown = null;
       for (const id of project.sessionIds) {
         try {
           await session.deleteSession(id);
-        } catch {
+        } catch (err) {
           failures += 1;
+          lastError = err;
+          console.error(`Project delete failed for session ${id}:`, err);
         }
       }
       if (failures > 0) {
+        const reason = lastError instanceof Error ? ` (${lastError.message})` : '';
         notify(
-          `Deleted ${project.sessionIds.length - failures} of ${project.sessionIds.length} sessions in ${project.label}; ${failures} failed.`,
+          `Deleted ${project.sessionIds.length - failures} of ${project.sessionIds.length} sessions in ${project.label}; ${failures} failed${reason}.`,
           'error',
         );
       }
@@ -874,7 +857,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
   );
 
   // Late-bind handleSend for the trust-grant replay (declared above via ref).
-  handleSendRef.current = handleSend;
+  trustSend.sendRef.current = handleSend;
 
   const handleRetry = useCallback(async () => {
     // Re-send the last user message after an error
@@ -902,7 +885,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
   useQueueAutoFire(
     chat.status,
     messageQueue.consumeNext,
-    messageQueue.restoreBatch,
+    trustSend.restoreQueueBatch,
     messageQueue.editingId,
     handleSend,
   );
@@ -951,14 +934,6 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
   const handleOpenProviders = useCallback(() => {
     emitOrchidEvent('orchid:open-settings', { tab: 'providers' });
   }, []);
-  // Declining trust (button, Escape, backdrop click) restores the gated
-  // message to the composer instead of losing it.
-  const handleTrustDecline = useCallback(() => {
-    const pending = pendingTrustSendRef.current;
-    pendingTrustSendRef.current = null;
-    if (pending) setRestoreDraft({ text: pending.message });
-    trustPrompt.decline();
-  }, [trustPrompt.decline]);
   const handleFocusSectionConsumed = useCallback(() => {
     setInspectorFocusSection(null);
   }, []);
@@ -1397,7 +1372,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
           onOpenProviders={handleOpenProviders}
           onPickProjectDir={handlePickProjectDirClick}
           isViewActive={!isVisible || contentMode === 'subagents'}
-          draftRestore={draftRestore}
+          draftRestore={trustSend.draftRestore}
         />
         <DeferredSurface isVisible={isVisible}>
           <Footer
@@ -1497,7 +1472,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
         busy={trustPrompt.busy}
         error={trustPrompt.error}
         onGrant={() => void trustPrompt.grant()}
-        onDecline={handleTrustDecline}
+        onDecline={trustSend.onDecline}
       />
     </div>
   );

--- a/electron/src/renderer/components/InputArea.tsx
+++ b/electron/src/renderer/components/InputArea.tsx
@@ -65,6 +65,12 @@ interface InputAreaProps {
   onOpenProviders?: () => void;
   /** ChatView keeps this subtree mounted while the Subagent View owns focus. */
   isViewActive?: boolean;
+  /**
+   * One-shot composer text restore (e.g. a trust-gated send the user
+   * declined). The text replaces the input once; `consumed()` reports back so
+   * the owner drops the restore and cannot fire it twice.
+   */
+  draftRestore?: { text: string; consumed: () => void } | null;
 }
 
 type SubPicker = '/theme' | '/personality' | '/model' | '/sessions' | null;
@@ -110,6 +116,7 @@ export const InputArea = memo(function InputArea({
   modelSelected = true,
   onOpenProviders,
   isViewActive = false,
+  draftRestore = null,
 }: InputAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   /** Blocks rapid double-Enter before parent status re-renders to streaming. */
@@ -384,6 +391,14 @@ export const InputArea = memo(function InputArea({
   useEffect(() => {
     resizeTextarea();
   }, [input, resizeTextarea]);
+
+  // One-shot draft restore: apply the stashed text, then tell the owner it
+  // landed so the same restore cannot re-fire on later re-renders.
+  useEffect(() => {
+    if (!draftRestore) return;
+    setInput(draftRestore.text);
+    draftRestore.consumed();
+  }, [draftRestore]);
 
   // Cancel pending rAF on unmount
   useEffect(() => {

--- a/electron/src/renderer/components/LeftSidebar.tsx
+++ b/electron/src/renderer/components/LeftSidebar.tsx
@@ -24,6 +24,7 @@ import {
   filterSessionsByQuery,
   groupSessionsByProject,
   normalizeWorkspaceKey,
+  type ProjectDeleteTarget,
   previewProjectSessions,
   PROJECT_SESSION_PREVIEW_LIMIT,
   truncatePathDisplay,
@@ -75,15 +76,10 @@ interface LeftSidebarProps {
   /** Start a new draft explicitly bound to one visible project group. */
   onProjectSessionCreate?: (projectDir: string) => void;
   /**
-   * Delete every session in a project group. Receives the group label,
-   * canonical path (null for "Other / Unknown"), and all session ids — the
-   * group itself is derived and disappears once empty.
+   * Delete every session in a project group. Receives the group label and all
+   * session ids — the group itself is derived and disappears once empty.
    */
-  onProjectDelete?: (project: {
-    label: string;
-    path: string | null;
-    sessionIds: readonly string[];
-  }) => void | Promise<unknown>;
+  onProjectDelete?: (project: ProjectDeleteTarget) => void | Promise<unknown>;
   /** A project pick starts a draft instead of moving the selected session. */
   projectPickerCreatesDraft?: boolean;
   /** Global work across every project/window. Optional for ConfigView reuse. */
@@ -436,7 +432,10 @@ function UnboundEmptyState({
 
 // ── Always-visible project groups ───────────────────────────────────────────
 
-// Collapsed project groups persist across restarts via localStorage.
+// Collapsed project groups persist across restarts via localStorage. The set
+// lives in a module-level store shared by every mounted ProjectSessionList
+// (ChatView stays mounted under Config/Analytics overlays, which render their
+// own sidebars) so two instances can never clobber each other's writes.
 const COLLAPSED_PROJECTS_KEY = 'orchid-sidebar-collapsed-projects';
 
 function loadCollapsedProjects(): Set<string> {
@@ -460,6 +459,20 @@ function saveCollapsedProjects(keys: ReadonlySet<string>): void {
   }
 }
 
+const collapsedProjectsStoreListeners = new Set<(next: ReadonlySet<string>) => void>();
+const collapsedProjectsStore = {
+  current: loadCollapsedProjects(),
+  subscribe(listener: (next: ReadonlySet<string>) => void): () => void {
+    collapsedProjectsStoreListeners.add(listener);
+    return () => collapsedProjectsStoreListeners.delete(listener);
+  },
+  update(next: Set<string>): void {
+    collapsedProjectsStore.current = next;
+    saveCollapsedProjects(next);
+    for (const listener of collapsedProjectsStoreListeners) listener(next);
+  },
+};
+
 interface ProjectSessionListProps {
   state: SessionListState;
   projectGroups: Array<{
@@ -481,11 +494,7 @@ interface ProjectSessionListProps {
   isUnbound: boolean;
   onPickProjectDir?: () => void;
   onProjectSessionCreate?: (projectDir: string) => void;
-  onProjectDelete?: (project: {
-    label: string;
-    path: string | null;
-    sessionIds: readonly string[];
-  }) => void | Promise<unknown>;
+  onProjectDelete?: (project: ProjectDeleteTarget) => void | Promise<unknown>;
   isSearching: boolean;
 }
 
@@ -513,22 +522,20 @@ function ProjectSessionList({
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
     () => new Set(),
   );
-  const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(
-    loadCollapsedProjects,
-  );
   const [deleteConfirmKey, setDeleteConfirmKey] = useState<string | null>(null);
+  const [collapsedProjects, setCollapsedProjects] = useState<ReadonlySet<string>>(
+    () => collapsedProjectsStore.current,
+  );
+  useEffect(
+    () => collapsedProjectsStore.subscribe(setCollapsedProjects),
+    [],
+  );
   const toggleCollapsed = useCallback((key: string) => {
-    setCollapsedProjects((previous) => {
-      const next = new Set(previous);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
+    const next = new Set(collapsedProjectsStore.current);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    collapsedProjectsStore.update(next);
   }, []);
-  // Write through so the collapsed set survives app restarts.
-  useEffect(() => {
-    saveCollapsedProjects(collapsedProjects);
-  }, [collapsedProjects]);
   const activityBySession = useMemo(
     () => new Map(activities.map((activity) => [activity.sessionId, activity])),
     [activities],
@@ -627,7 +634,14 @@ function ProjectSessionList({
       : projectOnlySelection
         ? `${listId}-project-${selectedProjectKey}`
         : undefined;
+  const deleteConfirmProject = deleteConfirmKey == null
+    ? null
+    : projectGroups.find((group) => group.key === deleteConfirmKey) ?? null;
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    // Portaled overlays (delete-confirm dialog) still bubble through the React
+    // tree to this handler; keys typed inside them must not drive the listbox.
+    if (deleteConfirmProject != null) return;
+    if (!listRef.current?.contains(event.target as Node)) return;
     onListKeyDown(event);
     if (event.defaultPrevented) return;
     const current = flatSessions[activeIndex];
@@ -642,9 +656,6 @@ function ProjectSessionList({
   };
 
   let sessionIndex = 0;
-  const deleteConfirmProject = deleteConfirmKey == null
-    ? null
-    : projectGroups.find((group) => group.key === deleteConfirmKey) ?? null;
   return (
     <div
       ref={listRef}
@@ -848,7 +859,6 @@ function ProjectSessionList({
                   setDeleteConfirmKey(null);
                   void onProjectDelete?.({
                     label: target.label,
-                    path: target.path,
                     sessionIds: target.sessions.map((session) => session.id),
                   });
                 }}

--- a/electron/src/renderer/components/LeftSidebar.tsx
+++ b/electron/src/renderer/components/LeftSidebar.tsx
@@ -30,6 +30,7 @@ import {
 } from '../utils/session-workspace';
 import { Icon } from './Icon';
 import { Button } from './ui/Button';
+import { DialogSurface } from './ui/DialogSurface';
 import { IconButton } from './ui/IconButton';
 import { SectionHeader } from './ui/SectionHeader';
 import { StateMessage } from './ui/StateMessage';
@@ -73,6 +74,16 @@ interface LeftSidebarProps {
   onPickProjectDir?: () => void;
   /** Start a new draft explicitly bound to one visible project group. */
   onProjectSessionCreate?: (projectDir: string) => void;
+  /**
+   * Delete every session in a project group. Receives the group label,
+   * canonical path (null for "Other / Unknown"), and all session ids — the
+   * group itself is derived and disappears once empty.
+   */
+  onProjectDelete?: (project: {
+    label: string;
+    path: string | null;
+    sessionIds: readonly string[];
+  }) => void | Promise<unknown>;
   /** A project pick starts a draft instead of moving the selected session. */
   projectPickerCreatesDraft?: boolean;
   /** Global work across every project/window. Optional for ConfigView reuse. */
@@ -113,6 +124,7 @@ export const LeftSidebar = memo(function LeftSidebar({
   onProjectSelect,
   onPickProjectDir,
   onProjectSessionCreate,
+  onProjectDelete,
   projectPickerCreatesDraft = false,
   activities = [],
   onStopSession,
@@ -277,6 +289,7 @@ export const LeftSidebar = memo(function LeftSidebar({
             isUnbound={isUnbound}
             onPickProjectDir={onPickProjectDir}
             onProjectSessionCreate={onProjectSessionCreate}
+            onProjectDelete={onProjectDelete}
             isSearching={query.trim().length > 0}
           />
         )}
@@ -423,6 +436,30 @@ function UnboundEmptyState({
 
 // ── Always-visible project groups ───────────────────────────────────────────
 
+// Collapsed project groups persist across restarts via localStorage.
+const COLLAPSED_PROJECTS_KEY = 'orchid-sidebar-collapsed-projects';
+
+function loadCollapsedProjects(): Set<string> {
+  try {
+    const stored = localStorage.getItem(COLLAPSED_PROJECTS_KEY);
+    const parsed = stored ? JSON.parse(stored) : null;
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((key): key is string => typeof key === 'string'));
+    }
+  } catch {
+    // Missing or corrupted storage — start with nothing collapsed.
+  }
+  return new Set();
+}
+
+function saveCollapsedProjects(keys: ReadonlySet<string>): void {
+  try {
+    localStorage.setItem(COLLAPSED_PROJECTS_KEY, JSON.stringify([...keys]));
+  } catch {
+    // Non-fatal
+  }
+}
+
 interface ProjectSessionListProps {
   state: SessionListState;
   projectGroups: Array<{
@@ -444,6 +481,11 @@ interface ProjectSessionListProps {
   isUnbound: boolean;
   onPickProjectDir?: () => void;
   onProjectSessionCreate?: (projectDir: string) => void;
+  onProjectDelete?: (project: {
+    label: string;
+    path: string | null;
+    sessionIds: readonly string[];
+  }) => void | Promise<unknown>;
   isSearching: boolean;
 }
 
@@ -463,6 +505,7 @@ function ProjectSessionList({
   isUnbound,
   onPickProjectDir,
   onProjectSessionCreate,
+  onProjectDelete,
   isSearching,
 }: ProjectSessionListProps) {
   const listId = useId();
@@ -471,8 +514,21 @@ function ProjectSessionList({
     () => new Set(),
   );
   const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(
-    () => new Set(),
+    loadCollapsedProjects,
   );
+  const [deleteConfirmKey, setDeleteConfirmKey] = useState<string | null>(null);
+  const toggleCollapsed = useCallback((key: string) => {
+    setCollapsedProjects((previous) => {
+      const next = new Set(previous);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+  // Write through so the collapsed set survives app restarts.
+  useEffect(() => {
+    saveCollapsedProjects(collapsedProjects);
+  }, [collapsedProjects]);
   const activityBySession = useMemo(
     () => new Map(activities.map((activity) => [activity.sessionId, activity])),
     [activities],
@@ -586,6 +642,9 @@ function ProjectSessionList({
   };
 
   let sessionIndex = 0;
+  const deleteConfirmProject = deleteConfirmKey == null
+    ? null
+    : projectGroups.find((group) => group.key === deleteConfirmKey) ?? null;
   return (
     <div
       ref={listRef}
@@ -631,12 +690,7 @@ function ProjectSessionList({
                     onProjectSelect(project.path);
                     return;
                   }
-                  setCollapsedProjects((previous) => {
-                    const next = new Set(previous);
-                    if (next.has(project.key)) next.delete(project.key);
-                    else next.add(project.key);
-                    return next;
-                  });
+                  toggleCollapsed(project.key);
                 }}
                 aria-expanded={!project.isCollapsed}
                 aria-controls={`${listId}-sessions-${project.key}`}
@@ -652,12 +706,7 @@ function ProjectSessionList({
                   role="presentation"
                   onClick={(event) => {
                     event.stopPropagation();
-                    setCollapsedProjects((previous) => {
-                      const next = new Set(previous);
-                      if (next.has(project.key)) next.delete(project.key);
-                      else next.add(project.key);
-                      return next;
-                    });
+                    toggleCollapsed(project.key);
                   }}
                 >
                   <Icon
@@ -689,6 +738,19 @@ function ProjectSessionList({
                 >
                   <Icon name="plus" size={13} />
                 </Button>
+              )}
+              {onProjectDelete && (
+                <IconButton
+                  label={`Delete all sessions in ${project.label}`}
+                  icon="trash"
+                  size="xs"
+                  iconSize={13}
+                  className="session-project-delete"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setDeleteConfirmKey(project.key);
+                  }}
+                />
               )}
             </div>
             <div
@@ -748,6 +810,55 @@ function ProjectSessionList({
           </div>
         );
       })}
+
+      <DialogSurface
+        isOpen={deleteConfirmProject != null}
+        onClose={() => setDeleteConfirmKey(null)}
+        labelledBy={`${listId}-project-delete-title`}
+        describedBy={`${listId}-project-delete-desc`}
+        variant="modal"
+      >
+        {deleteConfirmProject && (
+          <div className="flex flex-col gap-3">
+            <h2
+              id={`${listId}-project-delete-title`}
+              className="text-lg font-semibold"
+            >
+              Delete {deleteConfirmProject.sessions.length} session
+              {deleteConfirmProject.sessions.length === 1 ? '' : 's'} in{' '}
+              {deleteConfirmProject.label}?
+            </h2>
+            <p
+              id={`${listId}-project-delete-desc`}
+              className="text-sm text-base-content/70"
+            >
+              Every session in this project is permanently deleted, including
+              history, todos, and subagent chains. Running sessions are stopped
+              first.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button size="sm" onClick={() => setDeleteConfirmKey(null)}>
+                Cancel
+              </Button>
+              <Button
+                variant="error"
+                size="sm"
+                onClick={() => {
+                  const target = deleteConfirmProject;
+                  setDeleteConfirmKey(null);
+                  void onProjectDelete?.({
+                    label: target.label,
+                    path: target.path,
+                    sessionIds: target.sessions.map((session) => session.id),
+                  });
+                }}
+              >
+                Delete project sessions
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogSurface>
     </div>
   );
 }

--- a/electron/src/renderer/components/Providers/ConnectionWizard.tsx
+++ b/electron/src/renderer/components/Providers/ConnectionWizard.tsx
@@ -589,7 +589,7 @@ export function ConnectionWizard({
                 </FormField>
               </Panel>
 
-              {!existingConnection && (
+              {!existingConnection && (selectedDefinition?.supportedProtocols ?? []).length > 1 && (
                 <Panel as="section" className="config-fieldset flex flex-col gap-3">
                   <SectionHeader title="Protocol" />
                   <label className="label" htmlFor="provider-wizard-protocol">

--- a/electron/src/renderer/hooks/useChat.ts
+++ b/electron/src/renderer/hooks/useChat.ts
@@ -157,13 +157,26 @@ export interface ChatSendOptions {
   draftGeneration?: number;
 }
 
+/**
+ * Failed-send context for an `untrusted_project` gate rejection. The mount
+ * point stashes it so the message can be replayed after a trust grant or
+ * restored into the composer when the user declines.
+ */
+export interface UntrustedProjectSendFailure {
+  /** Trimmed message that the trust gate rejected. */
+  message: string;
+  /** Original send options (session/model/draft generation). */
+  options: ChatSendOptions;
+}
+
 export interface UseChatOptions {
   /**
    * Invoked when chat:send fails with `untrusted_project`. When present the
    * structured failure opens the trust dialog instead of pushing a raw error
-   * bubble; when absent the generic error behavior is kept.
+   * bubble; when absent the generic error behavior is kept. Receives the
+   * failed send context so the mount point can stash and replay it.
    */
-  onUntrustedProject?: () => void;
+  onUntrustedProject?: (payload: UntrustedProjectSendFailure) => void;
   /** Durable session total derived from chain summaries, including unloaded pages. */
   persistedSessionUsage?: Usage | null;
   /** Newest durable turn usage, including its context snapshot when available. */
@@ -417,7 +430,7 @@ export function useChat(
   const [messages, setMessages] = useState<Message[]>([]);
   // Ref-mirror the optional callback so `send` keeps a stable identity and a
   // new closure from the caller never rebuilds every streaming token.
-  const onUntrustedProjectRef = useRef<(() => void) | undefined>(options.onUntrustedProject);
+  const onUntrustedProjectRef = useRef<((payload: UntrustedProjectSendFailure) => void) | undefined>(options.onUntrustedProject);
   onUntrustedProjectRef.current = options.onUntrustedProject;
   const [projectionState, dispatchProjectionState] = useReducer(reduceProjectionState, { projection: null, revision: 0 });
   const [isSwitchingSession, setIsSwitchingSession] = useState(false);
@@ -654,7 +667,7 @@ export function useChat(
           if (result.kind === 'untrusted_project' && onUntrustedProjectRef.current) {
             dispatchProjection({ type: 'clear_stream', status: 'idle' });
             setMessages((prev) => dropOptimisticUserMessageIfLast(prev, userMessage.id));
-            onUntrustedProjectRef.current();
+            onUntrustedProjectRef.current({ message: trimmed, options: options ?? {} });
             return false;
           }
           dispatchProjection({ type: 'clear_stream', status: 'error' });

--- a/electron/src/renderer/hooks/useTrustPrompt.ts
+++ b/electron/src/renderer/hooks/useTrustPrompt.ts
@@ -31,6 +31,22 @@ export interface UseTrustPromptOptions {
   onGranted?: (cwd: string) => void;
 }
 
+/** How an `openFor` attempt resolved once its lookup settled. */
+export type TrustPromptOpenOutcome =
+  | 'opened'
+  | 'already-trusted'
+  | 'lookup-failed';
+
+export interface TrustPromptOpenCallbacks {
+  /**
+   * Called exactly once per attempt that was not superseded by a newer
+   * `openFor`. `'opened'` means a dialog will resolve the flow; the other
+   * outcomes mean no dialog is showing, so callers that parked state on the
+   * attempt (e.g. a stashed gated send) must resolve it themselves.
+   */
+  onOutcome?: (outcome: TrustPromptOpenOutcome) => void;
+}
+
 export interface UseTrustPromptReturn {
   /** Open dialog state, or null when no prompt is showing. */
   pending: TrustPromptPending | null;
@@ -39,7 +55,7 @@ export interface UseTrustPromptReturn {
   /** Short user-facing message for the latest trust failure; null when none. */
   error: string | null;
   /** Resolve trust for a directory and open the dialog when not trusted. */
-  openFor: (cwd: string) => void;
+  openFor: (cwd: string, callbacks?: TrustPromptOpenCallbacks) => void;
   /** Persist trust for the pending directory, close, then run onGranted. */
   grant: () => Promise<void>;
   /** Close without granting; the workspace stays bound-untrusted. */
@@ -69,25 +85,33 @@ export function useTrustPrompt(options: UseTrustPromptOptions = {}): UseTrustPro
   const onGrantedRef = useRef(options.onGranted);
   onGrantedRef.current = options.onGranted;
 
-  const openFor = useCallback((cwd: string) => {
+  const openFor = useCallback((cwd: string, callbacks?: TrustPromptOpenCallbacks) => {
     setError(null);
     const trimmed = cwd.trim();
     if (!trimmed) return;
-    if (!window.orchid?.projectTrust?.get) return;
+    if (!window.orchid?.projectTrust?.get) {
+      callbacks?.onOutcome?.('lookup-failed');
+      return;
+    }
     const generation = ++openGenerationRef.current;
     window.orchid.projectTrust
       .get({ cwd: trimmed })
       .then((info) => {
-        // A newer request superseded this one, or trust is already granted.
+        // A newer request superseded this one; its outcome owns the surface.
         if (generation !== openGenerationRef.current) return;
-        if (info.state === 'trusted') return;
+        if (info.state === 'trusted') {
+          callbacks?.onOutcome?.('already-trusted');
+          return;
+        }
         setPending({ cwd: trimmed, info });
+        callbacks?.onOutcome?.('opened');
       })
       .catch((err) => {
         console.error('Failed to resolve project trust:', err);
         // A newer request superseded this one; its outcome owns the surface.
         if (generation !== openGenerationRef.current) return;
         setError(LOOKUP_ERROR_MESSAGE);
+        callbacks?.onOutcome?.('lookup-failed');
       });
   }, []);
 

--- a/electron/src/renderer/hooks/useTrustSendReplay.ts
+++ b/electron/src/renderer/hooks/useTrustSendReplay.ts
@@ -1,0 +1,178 @@
+/**
+ * useTrustSendReplay — orchestration for trust-gated sends (issue #148).
+ *
+ * A send rejected by the `untrusted_project` gate is stashed here and has
+ * exactly one owner until the trust flow resolves it:
+ * - dialog opens  → grant replays it into the session that owns the view
+ *                   (double-grant and superseded-session guarded); a replay
+ *                   that is gated again returns to the composer
+ *                 → decline restores it to the composer (same superseded guard)
+ * - openFor resolves without a dialog (`already-trusted` / `lookup-failed`)
+ *   → the stash is dropped and the text restored immediately: the gate state
+ *   is uncertain, so the message must never sit parked invisibly for a later,
+ *   unrelated grant to replay.
+ *
+ * The stash also suppresses queue auto-fire restores of its own message
+ * (`restoreQueueBatch`): resurrecting the queue copy would auto-fire it again
+ * after the stash replays — a double send.
+ */
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import type { UntrustedProjectSendFailure } from './useChat';
+import type { QueuedMessage } from './useMessageQueue';
+import type { TrustPromptOpenCallbacks } from './useTrustPrompt';
+
+export interface UseTrustSendReplayParams {
+  /** Trust-prompt surface: open the dialog for a gated directory. */
+  openFor: (cwd: string, callbacks?: TrustPromptOpenCallbacks) => void;
+  /** Trust-prompt surface: close the dialog without granting. */
+  decline: () => void;
+  /** Queue restore to wrap (useMessageQueue.restoreBatch). */
+  restoreBatch: (batch: readonly QueuedMessage[], owner?: string | null) => void;
+  /** Gated project directory (workspace cwd, falling back to the session's). */
+  cwd: string | null;
+  /** Session owning the composer; guards stale replays/restores. */
+  activeSessionId: string | null;
+}
+
+export interface DraftRestore {
+  text: string;
+  consumed: () => void;
+}
+
+export interface UseTrustSendReplayReturn {
+  /** chat-level callback: stash the failed send and open the trust dialog. */
+  onUntrustedProject: (failure: UntrustedProjectSendFailure) => void;
+  /** Trust granted: replay the stash into the session that owns the view. */
+  onGranted: () => void;
+  /** Trust declined: restore the stash to the composer and close the dialog. */
+  onDecline: () => void;
+  /** One-shot composer restore; InputArea reports consumption. */
+  draftRestore: DraftRestore | null;
+  /** Late-bound send bridge; the mount point assigns its handleSend into it. */
+  sendRef: RefObject<((message: string) => Promise<boolean>) | null>;
+  /**
+   * Queue-restore wrapper: a batch whose joined text is the stashed message
+   * is not resurrected — the stash now owns that message (grant replays it,
+   * decline restores it), so a restored queue copy would double-send.
+   */
+  restoreQueueBatch: (batch: readonly QueuedMessage[], owner?: string | null) => void;
+}
+
+/** Same join as useMessageQueue.selectBatch — how a consumed batch is sent. */
+const BATCH_JOIN = '\n\n';
+
+function batchIsStashedMessage(batch: readonly QueuedMessage[], stashed: string): boolean {
+  return batch.length > 0 && batch.map((m) => m.text).join(BATCH_JOIN) === stashed;
+}
+
+/**
+ * Stash/replay/restore controller for trust-gated sends. Mount points wire
+ * their `useTrustPrompt` surface in, hand `onUntrustedProject` to `useChat`,
+ * route grant/decline through the returned handlers, and pass `draftRestore`
+ * to the composer.
+ */
+export function useTrustSendReplay({
+  openFor,
+  decline,
+  restoreBatch,
+  cwd,
+  activeSessionId,
+}: UseTrustSendReplayParams): UseTrustSendReplayReturn {
+  const pendingTrustSendRef = useRef<UntrustedProjectSendFailure | null>(null);
+  /** Late-bound handleSend for the grant replay; assigned by the mount point. */
+  const sendRef = useRef<((message: string) => Promise<boolean>) | null>(null);
+  /** One-shot composer draft restore (decline / unresolved openFor). */
+  const [restoreDraft, setRestoreDraft] = useState<{ text: string } | null>(null);
+
+  // Refs so the stable callbacks below always see the latest render's values.
+  const openForRef = useRef(openFor);
+  openForRef.current = openFor;
+  const declineRef = useRef(decline);
+  declineRef.current = decline;
+  const restoreBatchRef = useRef(restoreBatch);
+  restoreBatchRef.current = restoreBatch;
+  const cwdRef = useRef(cwd);
+  cwdRef.current = cwd;
+  const activeSessionIdRef = useRef(activeSessionId);
+  activeSessionIdRef.current = activeSessionId;
+
+  const restoreToComposer = useCallback((failure: UntrustedProjectSendFailure) => {
+    pendingTrustSendRef.current = null;
+    setRestoreDraft({ text: failure.message });
+  }, []);
+
+  const onUntrustedProject = useCallback((failure: UntrustedProjectSendFailure) => {
+    const gated = cwdRef.current?.trim() ?? '';
+    if (!gated) {
+      // No resolvable project directory — the dialog can never open, so the
+      // message goes straight back to the composer instead of being lost.
+      restoreToComposer(failure);
+      return;
+    }
+    // Stash first: the stash owns the message until the trust flow resolves it.
+    pendingTrustSendRef.current = failure;
+    openForRef.current(gated, {
+      onOutcome: (outcome) => {
+        if (outcome === 'opened') return;
+        // No dialog will resolve this stash. The gate state is uncertain
+        // (already-trusted and still gated, or the lookup failed) — restore
+        // the message instead of leaving it parked for a later, unrelated
+        // grant to replay. A newer stash may have replaced this one already.
+        const pending = pendingTrustSendRef.current;
+        if (pending === failure) restoreToComposer(pending);
+      },
+    });
+  }, [restoreToComposer]);
+
+  const onGranted = useCallback(() => {
+    // Clear first so a replay that fails again re-stashes fresh instead of
+    // double-firing the stash (this is also the double-grant guard).
+    const pending = pendingTrustSendRef.current;
+    if (!pending) return;
+    pendingTrustSendRef.current = null;
+    // Superseded: another session owns the view now (the dialog is modal, so
+    // this only happens through programmatic session switches). Drop the
+    // stash silently rather than firing the message into an unrelated
+    // session — the sidebar selected another session deliberately.
+    if ((pending.options.sessionId ?? null) !== (activeSessionIdRef.current ?? null)) {
+      return;
+    }
+    void sendRef.current?.(pending.message)?.then((sent) => {
+      // Replay was gated (provider/workspace changed mid-dialog): put the
+      // message back in the composer instead of dropping it.
+      if (!sent) setRestoreDraft({ text: pending.message });
+    });
+  }, []);
+
+  const onDecline = useCallback(() => {
+    const pending = pendingTrustSendRef.current;
+    pendingTrustSendRef.current = null;
+    // Mirror the grant path's superseded guard: restoring into a different
+    // session's composer would leak the message across sessions.
+    if (pending && (pending.options.sessionId ?? null) === (activeSessionIdRef.current ?? null)) {
+      setRestoreDraft({ text: pending.message });
+    }
+    declineRef.current();
+  }, []);
+
+  const restoreQueueBatch = useCallback((batch: readonly QueuedMessage[], owner?: string | null) => {
+    if (batchIsStashedMessage(batch, pendingTrustSendRef.current?.message ?? '')) return;
+    restoreBatchRef.current(batch, owner);
+  }, []);
+
+  const handleRestoreDraftConsumed = useCallback(() => setRestoreDraft(null), []);
+  const draftRestore = useMemo(
+    () => (restoreDraft ? { text: restoreDraft.text, consumed: handleRestoreDraftConsumed } : null),
+    [restoreDraft, handleRestoreDraftConsumed],
+  );
+
+  return {
+    onUntrustedProject,
+    onGranted,
+    onDecline,
+    draftRestore,
+    sendRef,
+    restoreQueueBatch,
+  };
+}

--- a/electron/src/renderer/styles/shell.css
+++ b/electron/src/renderer/styles/shell.css
@@ -701,6 +701,17 @@
     flex: 0 0 auto;
   }
 
+  .session-project-delete {
+    flex: 0 0 auto;
+    opacity: 0;
+    transition: opacity var(--transition-fast, 120ms cubic-bezier(0.4, 0, 0.2, 1));
+  }
+
+  .session-project-header:hover .session-project-delete,
+  .session-project-delete:focus-visible {
+    opacity: 1;
+  }
+
   .session-project-expand {
     justify-content: flex-start;
     margin: 1px 7px 4px;

--- a/electron/src/renderer/utils/session-activity-state.ts
+++ b/electron/src/renderer/utils/session-activity-state.ts
@@ -1,4 +1,5 @@
 import type { SessionActivity } from '../../shared/types/ipc-boundary';
+import { compareSessionActivity } from '../../shared/utils/session-activity-order';
 import { sessionActivityPresentation } from './session-activity-presentation';
 
 export type SessionActivityMap = ReadonlyMap<string, SessionActivity>;
@@ -66,35 +67,15 @@ export function reconcileSessionActivitySnapshot(
   return next;
 }
 
-/** Visible activities ordered by urgency and turn-start stability. */
+/**
+ * Visible activities in the one shared ordering (`compareSessionActivity`),
+ * also used by `SessionActivityStore.list()`: state urgency first, then
+ * turn-start stability for active rows, unread-first, and recency.
+ */
 export function orderedSessionActivities(
   current: SessionActivityMap,
 ): SessionActivity[] {
-  const priority: Record<SessionActivity['state'], number> = {
-    needs_attention: 0,
-    working: 1,
-    waiting: 2,
-    idle: 3,
-  };
-  // Unknown turn starts sort last, not oldest, within the working/waiting bucket.
-  const startedAtSortValue = (activity: SessionActivity): number =>
-    activity.startedAt ?? Number.POSITIVE_INFINITY;
   return [...current.values()]
     .filter((activity) => sessionActivityPresentation(activity).visible)
-    .sort((a, b) => {
-      const statePriority = priority[a.state] - priority[b.state];
-      if (statePriority !== 0) return statePriority;
-      if (a.state === 'working' || a.state === 'waiting') {
-        // Mirror SessionActivityStore.list(): active rows order by turn start
-        // so streamed detail bumps never reshuffle them between snapshot and
-        // broadcast. Oldest start first; equal or unknown starts fall through
-        // to recency.
-        const aStart = startedAtSortValue(a);
-        const bStart = startedAtSortValue(b);
-        if (aStart !== bStart) return aStart - bStart;
-      } else if (a.unread !== b.unread) {
-        return a.unread ? -1 : 1;
-      }
-      return b.updatedAt - a.updatedAt;
-    });
+    .sort(compareSessionActivity);
 }

--- a/electron/src/renderer/utils/session-activity-state.ts
+++ b/electron/src/renderer/utils/session-activity-state.ts
@@ -66,7 +66,7 @@ export function reconcileSessionActivitySnapshot(
   return next;
 }
 
-/** Visible activities ordered by urgency and recency. */
+/** Visible activities ordered by urgency and turn-start stability. */
 export function orderedSessionActivities(
   current: SessionActivityMap,
 ): SessionActivity[] {
@@ -76,12 +76,25 @@ export function orderedSessionActivities(
     waiting: 2,
     idle: 3,
   };
+  // Unknown turn starts sort last, not oldest, within the working/waiting bucket.
+  const startedAtSortValue = (activity: SessionActivity): number =>
+    activity.startedAt ?? Number.POSITIVE_INFINITY;
   return [...current.values()]
     .filter((activity) => sessionActivityPresentation(activity).visible)
     .sort((a, b) => {
       const statePriority = priority[a.state] - priority[b.state];
       if (statePriority !== 0) return statePriority;
-      if (a.unread !== b.unread) return a.unread ? -1 : 1;
+      if (a.state === 'working' || a.state === 'waiting') {
+        // Mirror SessionActivityStore.list(): active rows order by turn start
+        // so streamed detail bumps never reshuffle them between snapshot and
+        // broadcast. Oldest start first; equal or unknown starts fall through
+        // to recency.
+        const aStart = startedAtSortValue(a);
+        const bStart = startedAtSortValue(b);
+        if (aStart !== bStart) return aStart - bStart;
+      } else if (a.unread !== b.unread) {
+        return a.unread ? -1 : 1;
+      }
       return b.updatedAt - a.updatedAt;
     });
 }

--- a/electron/src/renderer/utils/session-workspace.ts
+++ b/electron/src/renderer/utils/session-workspace.ts
@@ -103,6 +103,14 @@ export interface ProjectActivityCounts {
 /** Number of recent sessions visible before a project group is expanded. */
 export const PROJECT_SESSION_PREVIEW_LIMIT = 5;
 
+/** Payload for deleting every session in a project group. */
+export interface ProjectDeleteTarget {
+  /** Group display label, for confirm copy and failure summaries. */
+  label: string;
+  /** Every session id in the group — deletion set for the caller's loop. */
+  sessionIds: readonly string[];
+}
+
 /**
  * Return the newest project sessions for a compact sidebar group, or every
  * session after the user explicitly expands that project.

--- a/electron/src/shared/utils/session-activity-order.ts
+++ b/electron/src/shared/utils/session-activity-order.ts
@@ -1,0 +1,50 @@
+/**
+ * Session activity ordering — the one comparator shared by the main-process
+ * `SessionActivityStore.list()` and the renderer's
+ * `orderedSessionActivities()` so IPC snapshots and live broadcasts can never
+ * disagree on row order.
+ */
+import type {
+  SessionActivity,
+  SessionExecutionState,
+} from '../types/ipc-boundary';
+
+/** Lower number sorts first. */
+export const SESSION_ACTIVITY_STATE_PRIORITY: Record<SessionExecutionState, number> = {
+  needs_attention: 0,
+  working: 1,
+  waiting: 2,
+  idle: 3,
+};
+
+/**
+ * Order two session activities by urgency:
+ *
+ * 1. State priority (`SESSION_ACTIVITY_STATE_PRIORITY`): needs_attention,
+ *    then working, waiting, idle.
+ * 2. Working/waiting pairs tie-break by `startedAt` ascending with unknown
+ *    starts last. Detail updates bump `updatedAt` on every streamed event, so
+ *    ordering by turn start gives active rows a stable queue position while
+ *    the turn runs: longest-running work keeps the bucket top and newly
+ *    started work enters below instead of displacing rows mid-turn.
+ * 3. Other same-state pairs tie-break unread-first.
+ * 4. Final tie-break: most recent `updatedAt`.
+ */
+export function compareSessionActivity(
+  a: SessionActivity,
+  b: SessionActivity,
+): number {
+  const statePriority =
+    SESSION_ACTIVITY_STATE_PRIORITY[a.state] -
+    SESSION_ACTIVITY_STATE_PRIORITY[b.state];
+  if (statePriority !== 0) return statePriority;
+  if (a.state === 'working' || a.state === 'waiting') {
+    // Unknown turn starts sort last, not oldest, within the bucket.
+    const aStart = a.startedAt ?? Number.POSITIVE_INFINITY;
+    const bStart = b.startedAt ?? Number.POSITIVE_INFINITY;
+    if (aStart !== bStart) return aStart - bStart;
+  } else if (a.unread !== b.unread) {
+    return a.unread ? -1 : 1;
+  }
+  return b.updatedAt - a.updatedAt;
+}

--- a/electron/tests/integration/provider-onboarding.test.ts
+++ b/electron/tests/integration/provider-onboarding.test.ts
@@ -193,6 +193,8 @@ describe('provider onboarding and disconnected UX', () => {
 
     expect(wizard).toContain('{!existingConnection && (');
     expect(wizard).toContain('Connection protocol');
+    // The picker appears only when the definition actually offers a protocol choice.
+    expect(wizard).toContain('(selectedDefinition?.supportedProtocols ?? []).length > 1');
     expect(wizard).not.toContain('Initial model');
     expect(wizard).toContain('Edit connection');
     expect(wizard).toContain('Save changes');

--- a/electron/tests/unit/connection-wizard.test.tsx
+++ b/electron/tests/unit/connection-wizard.test.tsx
@@ -120,4 +120,12 @@ describe('connection wizard protocol picker', () => {
     // The definition's first protocol stays the default selection.
     expect(select.value).toBe('openai-responses');
   });
+
+  it('omits the protocol panel in edit mode even for multi-protocol providers', () => {
+    renderWizard({ existingConnection: CONNECTION });
+
+    expect(screen.queryByLabelText('Connection protocol')).toBeNull();
+    expect(screen.queryByText('Protocol')).toBeNull();
+    expect(screen.queryByText(/Protocol is fixed after creation/)).toBeNull();
+  });
 });

--- a/electron/tests/unit/connection-wizard.test.tsx
+++ b/electron/tests/unit/connection-wizard.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+/** Connection wizard protocol gating: a picker exists only when a provider offers a choice. */
+import type { ComponentProps } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionWizard } from '../../src/renderer/components/Providers/ConnectionWizard';
+import type {
+  ProviderConnectionView,
+  ProviderDefinitionView,
+} from '../../src/shared/types/ipc';
+
+function definition(overrides: Partial<ProviderDefinitionView> = {}): ProviderDefinitionView {
+  return {
+    id: 'orchid-multi',
+    displayName: 'Orchid Multi',
+    supportedAuthMethods: ['api-key'],
+    supportedProtocols: ['openai-compatible', 'openai-responses'],
+    allowsCustomModels: false,
+    lifecycle: 'active',
+    available: true,
+    unavailableReason: null,
+    supportsDiscovery: false,
+    supportsQuota: false,
+    models: [{
+      id: 'orchid-text',
+      displayName: 'Orchid Text',
+      protocol: 'openai-compatible',
+      lifecycle: 'active',
+      source: 'catalog',
+      capabilities: { inputModalities: ['text'], outputModalities: ['text'], tools: true, reasoning: false },
+      limits: null,
+    }],
+    ...overrides,
+  };
+}
+
+const CONNECTION: ProviderConnectionView = {
+  id: 'conn-1',
+  providerId: 'orchid-multi',
+  providerDisplayName: 'Orchid Multi',
+  name: 'Orchid Multi',
+  protocol: 'openai-compatible',
+  authMethod: 'api-key',
+  credentialKind: 'stored',
+  environmentVariable: null,
+  modelIds: ['orchid-text'],
+  customModels: [],
+  health: 'ready',
+  activeTurnCount: 0,
+  endpoint: null,
+  allowInsecureHttp: false,
+};
+
+function renderWizard(overrides: Partial<ComponentProps<typeof ConnectionWizard>> = {}) {
+  const mutation = { connection: CONNECTION, message: null };
+  const onCreate = vi.fn(async () => mutation);
+  const props: ComponentProps<typeof ConnectionWizard> = {
+    isOpen: true,
+    definitions: [definition()],
+    secureStorage: { available: true, backend: 'test', reason: null },
+    onClose: vi.fn(),
+    onCreate,
+    onSubmitApiKey: vi.fn(async () => mutation),
+    onValidate: vi.fn(async () => mutation),
+    ...overrides,
+  };
+  return { props, ...render(<ConnectionWizard {...props} />) };
+}
+
+afterEach(() => cleanup());
+
+describe('connection wizard protocol picker', () => {
+  it('omits the protocol panel when the provider supports a single protocol', () => {
+    renderWizard({ definitions: [definition({ supportedProtocols: ['openai-compatible'] })] });
+
+    expect(screen.queryByLabelText('Connection protocol')).toBeNull();
+    expect(screen.queryByText('Protocol')).toBeNull();
+    expect(screen.queryByText(/Protocol is fixed after creation/)).toBeNull();
+  });
+
+  it('still creates the connection with the definition default protocol when the picker is hidden', async () => {
+    const { props } = renderWizard({
+      definitions: [definition({
+        supportedProtocols: ['anthropic-messages'],
+        models: [{
+          id: 'orchid-text',
+          displayName: 'Orchid Text',
+          protocol: 'anthropic-messages',
+          lifecycle: 'active',
+          source: 'catalog',
+          capabilities: { inputModalities: ['text'], outputModalities: ['text'], tools: true, reasoning: false },
+          limits: null,
+        }],
+      })],
+    });
+
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create connection' }));
+
+    await waitFor(() => expect(props.onCreate).toHaveBeenCalledTimes(1));
+    expect(props.onCreate).toHaveBeenCalledWith(expect.objectContaining({
+      providerId: 'orchid-multi',
+      protocol: 'anthropic-messages',
+      modelIds: ['orchid-text'],
+    }));
+  });
+
+  it('renders one option per supported protocol when several exist', () => {
+    renderWizard({
+      definitions: [definition({
+        supportedProtocols: ['openai-responses', 'openai-compatible'],
+      })],
+    });
+
+    const select = screen.getByLabelText('Connection protocol') as HTMLSelectElement;
+    expect([...select.options].map((option) => option.value)).toEqual([
+      'openai-responses',
+      'openai-compatible',
+    ]);
+    // The definition's first protocol stays the default selection.
+    expect(select.value).toBe('openai-responses');
+  });
+});

--- a/electron/tests/unit/session-activity-presentation.test.tsx
+++ b/electron/tests/unit/session-activity-presentation.test.tsx
@@ -186,3 +186,85 @@ describe('session activity reconciliation', () => {
     ]);
   });
 });
+
+describe('session activity ordering', () => {
+  it('keeps two working sessions in stable order while one streams detail updates', () => {
+    const earlier = activity({
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      state: 'working',
+      startedAt: 100,
+      updatedAt: 150,
+    });
+    const later = activity({
+      sessionId: '22222222-2222-4222-8222-222222222222',
+      state: 'working',
+      startedAt: 200,
+      updatedAt: 250,
+    });
+    let current = new Map([
+      [earlier.sessionId, earlier],
+      [later.sessionId, later],
+    ]);
+
+    for (const updatedAt of [300, 400, 500]) {
+      current = mergeSessionActivity(current, activity({
+        sessionId: later.sessionId,
+        state: 'working',
+        startedAt: 200,
+        updatedAt,
+      }));
+      expect(orderedSessionActivities(current).map((item) => item.sessionId))
+        .toEqual([earlier.sessionId, later.sessionId]);
+    }
+  });
+
+  it('orders working and waiting rows by oldest turn start with unknown starts last', () => {
+    const current = new Map([
+      ['working-newest-start', activity({
+        sessionId: 'working-newest-start', state: 'working', startedAt: 300, updatedAt: 500,
+      })],
+      ['working-oldest-start', activity({
+        sessionId: 'working-oldest-start', state: 'working', startedAt: 100, updatedAt: 100,
+      })],
+      ['working-unknown-start', activity({
+        sessionId: 'working-unknown-start', state: 'working', startedAt: null, updatedAt: 700,
+      })],
+      ['waiting-newest-start', activity({
+        sessionId: 'waiting-newest-start', state: 'waiting', startedAt: 400, updatedAt: 400,
+      })],
+      ['waiting-oldest-start', activity({
+        sessionId: 'waiting-oldest-start', state: 'waiting', startedAt: 200, updatedAt: 600,
+      })],
+    ]);
+
+    // Oldest-start-first mirrors SessionActivityStore.list(): the longest
+    // running row keeps the top of its bucket across streamed detail bumps.
+    expect(orderedSessionActivities(current).map((item) => item.sessionId)).toEqual([
+      'working-oldest-start',
+      'working-newest-start',
+      'working-unknown-start',
+      'waiting-oldest-start',
+      'waiting-newest-start',
+    ]);
+  });
+
+  it('keeps idle rows ordered unread-first then by recency', () => {
+    const current = new Map([
+      ['idle-stale-unread', activity({
+        sessionId: 'idle-stale-unread', unread: true, updatedAt: 100,
+      })],
+      ['idle-fresh-unread', activity({
+        sessionId: 'idle-fresh-unread', unread: true, updatedAt: 500,
+      })],
+      ['idle-fresh-seen', activity({
+        sessionId: 'idle-fresh-seen', backgroundProcessCount: 1, updatedAt: 900,
+      })],
+    ]);
+
+    expect(orderedSessionActivities(current).map((item) => item.sessionId)).toEqual([
+      'idle-fresh-unread',
+      'idle-stale-unread',
+      'idle-fresh-seen',
+    ]);
+  });
+});

--- a/electron/tests/unit/session-activity.test.ts
+++ b/electron/tests/unit/session-activity.test.ts
@@ -93,4 +93,52 @@ describe('SessionActivityStore', () => {
     expect(first.updatedAt).toBe(100);
     expect(second.updatedAt).toBe(101);
   });
+
+  it('keeps two working sessions in stable order while one streams detail updates', () => {
+    const store = new SessionActivityStore();
+    const earlier = '11111111-1111-4111-8111-111111111111';
+    const later = '22222222-2222-4222-8222-222222222222';
+    store.update(earlier, { state: 'working', startedAt: 100 }, 100);
+    store.update(later, { state: 'working', startedAt: 200 }, 200);
+
+    for (let now = 300; now <= 900; now += 100) {
+      store.update(later, { detail: `Streaming detail ${now}` }, now);
+      expect(store.list().map((item) => item.sessionId)).toEqual([earlier, later]);
+    }
+  });
+
+  it('orders working and waiting rows by oldest turn start with unknown starts last', () => {
+    const store = new SessionActivityStore();
+    store.update('working-newest-start', { state: 'working', startedAt: 300 }, 500);
+    store.update('working-oldest-start', { state: 'working', startedAt: 100 }, 100);
+    store.update('working-unknown-start', { state: 'working', startedAt: null }, 700);
+    store.update('waiting-newest-start', { state: 'waiting', startedAt: 400 }, 400);
+    store.update('waiting-oldest-start', { state: 'waiting', startedAt: 200 }, 600);
+
+    // Oldest-start-first is a deliberate queue-position choice: the row that
+    // has been running longest keeps the top of its bucket, and newly started
+    // work enters below instead of displacing rows mid-turn.
+    expect(store.list().map((item) => item.sessionId)).toEqual([
+      'working-oldest-start',
+      'working-newest-start',
+      'working-unknown-start',
+      'waiting-oldest-start',
+      'waiting-newest-start',
+    ]);
+  });
+
+  it('keeps idle rows ordered unread-first then by recency', () => {
+    const store = new SessionActivityStore();
+    store.update('idle-stale-unread', { state: 'idle', unread: true }, 100);
+    store.update('idle-fresh-seen', {
+      state: 'idle', unread: false, backgroundProcessCount: 1,
+    }, 900);
+    store.update('idle-fresh-unread', { state: 'idle', unread: true }, 500);
+
+    expect(store.list().map((item) => item.sessionId)).toEqual([
+      'idle-fresh-unread',
+      'idle-stale-unread',
+      'idle-fresh-seen',
+    ]);
+  });
 });

--- a/electron/tests/unit/session-activity.test.ts
+++ b/electron/tests/unit/session-activity.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { SessionActivityStore } from '../../src/main/session/activity';
+import { orderedSessionActivities } from '../../src/renderer/utils/session-activity-state';
+import type {
+  SessionActivity,
+  SessionExecutionState,
+} from '../../src/shared/types/ipc-boundary';
 
 describe('SessionActivityStore', () => {
   it('tracks independent execution state and unread completion per session', () => {
@@ -140,5 +145,114 @@ describe('SessionActivityStore', () => {
       'idle-stale-unread',
       'idle-fresh-seen',
     ]);
+  });
+
+  it('orders needs_attention rows unread-first before recency', () => {
+    const store = new SessionActivityStore();
+    // The unread row is older, so pure recency would place it second.
+    store.update('attention-stale-unread', {
+      state: 'needs_attention', unread: true,
+    }, 100);
+    store.update('attention-fresh-seen', { state: 'needs_attention' }, 900);
+
+    expect(store.list().map((item) => item.sessionId)).toEqual([
+      'attention-stale-unread',
+      'attention-fresh-seen',
+    ]);
+  });
+});
+
+describe('session activity ordering parity', () => {
+  it('orders identical fixtures identically through list() and orderedSessionActivities()', () => {
+    const store = new SessionActivityStore();
+    // Insertion order deliberately differs from display order, and no two
+    // visible rows tie under the comparator, so each surface's output is
+    // fully determined by the shared comparator rather than sort stability.
+    const fixtures: Array<
+      Partial<SessionActivity> & {
+        sessionId: string;
+        state: SessionExecutionState;
+        updatedAt: number;
+      }
+    > = [
+      { sessionId: 'idle-invisible', state: 'idle', updatedAt: 950 },
+      {
+        sessionId: 'bg-only-fresh', state: 'idle',
+        updatedAt: 900, backgroundProcessCount: 2,
+      },
+      { sessionId: 'idle-stale-unread', state: 'idle', updatedAt: 100, unread: true },
+      { sessionId: 'idle-fresh-unread', state: 'idle', updatedAt: 500, unread: true },
+      {
+        sessionId: 'waiting-newest-start', state: 'waiting',
+        startedAt: 400, updatedAt: 400,
+      },
+      {
+        sessionId: 'waiting-oldest-start', state: 'waiting',
+        startedAt: 200, updatedAt: 600,
+      },
+      {
+        sessionId: 'working-equal-start-a', state: 'working',
+        startedAt: 250, updatedAt: 300,
+      },
+      {
+        sessionId: 'working-equal-start-b', state: 'working',
+        startedAt: 250, updatedAt: 800,
+      },
+      {
+        sessionId: 'working-unknown-start', state: 'working',
+        startedAt: null, updatedAt: 700,
+      },
+      {
+        sessionId: 'working-newest-start', state: 'working',
+        startedAt: 300, updatedAt: 500,
+      },
+      {
+        sessionId: 'working-oldest-start', state: 'working',
+        startedAt: 100, updatedAt: 100,
+      },
+      {
+        sessionId: 'attention-stale-unread', state: 'needs_attention',
+        updatedAt: 100, unread: true,
+      },
+      { sessionId: 'attention-fresh-seen', state: 'needs_attention', updatedAt: 900 },
+    ];
+
+    for (const fixture of fixtures) {
+      store.update(fixture.sessionId, {
+        state: fixture.state,
+        startedAt: fixture.startedAt ?? null,
+        unread: fixture.unread ?? false,
+        backgroundProcessCount: fixture.backgroundProcessCount ?? 0,
+      }, fixture.updatedAt);
+    }
+
+    // Feed the exact stored objects through the renderer projection so both
+    // surfaces see identical activity records.
+    const rendererState = new Map(
+      fixtures.map((fixture) => {
+        const stored = store.get(fixture.sessionId);
+        if (!stored) throw new Error(`missing stored activity: ${fixture.sessionId}`);
+        return [stored.sessionId, stored];
+      }),
+    );
+
+    const storeOrder = store.list().map((item) => item.sessionId);
+    // Both surfaces drop the invisible idle row and apply the same comparator.
+    expect(storeOrder).toEqual([
+      'attention-stale-unread',
+      'attention-fresh-seen',
+      'working-oldest-start',
+      'working-equal-start-b',
+      'working-equal-start-a',
+      'working-newest-start',
+      'working-unknown-start',
+      'waiting-oldest-start',
+      'waiting-newest-start',
+      'idle-fresh-unread',
+      'idle-stale-unread',
+      'bg-only-fresh',
+    ]);
+    expect(orderedSessionActivities(rendererState).map((item) => item.sessionId))
+      .toEqual(storeOrder);
   });
 });

--- a/electron/tests/unit/session-workspace-sidebar.test.ts
+++ b/electron/tests/unit/session-workspace-sidebar.test.ts
@@ -1,8 +1,12 @@
+// @vitest-environment jsdom
 /**
  * Project-scoped session sidebar helpers — U6.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createElement } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { SessionActivity, SessionSummary } from '../../src/shared/types/ipc-boundary';
+import { LeftSidebar } from '../../src/renderer/components/LeftSidebar';
 import {
   normalizeWorkspaceKey,
   pathsEqual,
@@ -210,5 +214,154 @@ describe('truncatePathDisplay', () => {
     const out = truncatePathDisplay(long, 20);
     expect(out.startsWith('…/')).toBe(true);
     expect(out.length).toBeLessThanOrEqual(20);
+  });
+});
+
+// ── Collapsed-project persistence (issue #163) ───────────────────────────────
+
+describe('collapsed project persistence', () => {
+  const storageKey = 'orchid-sidebar-collapsed-projects';
+
+  function renderSidebar(sessions: SessionSummary[]) {
+    return render(
+      createElement(LeftSidebar, {
+        isCollapsed: false,
+        onToggle: () => {},
+        sessionListState: { status: 'ready', sessions },
+        activeSessionId: null,
+        onSessionSelect: () => {},
+        onSessionCreate: () => {},
+        onSessionDelete: () => {},
+        onRefreshSessions: () => {},
+        onOpenSettings: () => {},
+      }),
+    );
+  }
+
+  function projectToggle(label: string): HTMLElement {
+    return screen.getByRole('button', { name: new RegExp(label) });
+  }
+
+  const sessions = [
+    summary({ id: 'a1', name: 'Alpha chat', cwd: '/proj/alpha', updatedAt: 2 }),
+    summary({ id: 'b1', name: 'Beta chat', cwd: '/proj/beta', updatedAt: 1 }),
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it('keeps a collapsed group collapsed across a remount (restart)', () => {
+    renderSidebar(sessions);
+    expect(projectToggle('alpha').getAttribute('aria-expanded')).toBe('true');
+    expect(projectToggle('beta').getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(projectToggle('alpha'));
+    expect(projectToggle('alpha').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Alpha chat')).toBeNull();
+    expect(localStorage.getItem(storageKey)).toBe(JSON.stringify(['/proj/alpha']));
+
+    // Unmount + remount simulates an app restart: state rehydrates from storage.
+    cleanup();
+    renderSidebar(sessions);
+    expect(projectToggle('alpha').getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Alpha chat')).toBeNull();
+    expect(projectToggle('beta').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Beta chat')).toBeTruthy();
+
+    // The restored group can still be expanded again (write-through updates).
+    fireEvent.click(projectToggle('alpha'));
+    expect(projectToggle('alpha').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Alpha chat')).toBeTruthy();
+    expect(localStorage.getItem(storageKey)).toBe(JSON.stringify([]));
+  });
+
+  it('starts fully expanded when storage is missing or corrupted', () => {
+    localStorage.setItem(storageKey, '{not-json');
+    renderSidebar(sessions);
+    expect(projectToggle('alpha').getAttribute('aria-expanded')).toBe('true');
+    expect(projectToggle('beta').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Alpha chat')).toBeTruthy();
+  });
+});
+
+// ── Project delete (issue #158) ──────────────────────────────────────────────
+
+describe('project delete', () => {
+  const deleteSessions = [
+    summary({ id: 'a1', name: 'Alpha one', cwd: '/proj/alpha', updatedAt: 2 }),
+    summary({ id: 'a2', name: 'Alpha two', cwd: '/proj/alpha', updatedAt: 1 }),
+    summary({ id: 'b1', name: 'Beta chat', cwd: '/proj/beta', updatedAt: 3 }),
+  ];
+
+  function renderWithDelete(onProjectDelete: (project: {
+    label: string;
+    path: string | null;
+    sessionIds: readonly string[];
+  }) => void) {
+    return render(
+      createElement(LeftSidebar, {
+        isCollapsed: false,
+        onToggle: () => {},
+        sessionListState: { status: 'ready', sessions: deleteSessions },
+        activeSessionId: null,
+        onSessionSelect: () => {},
+        onSessionCreate: () => {},
+        onSessionDelete: () => {},
+        onRefreshSessions: () => {},
+        onOpenSettings: () => {},
+        onProjectDelete,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it('confirms and reports every session id in the group', () => {
+    const deleted: Array<readonly string[]> = [];
+    renderWithDelete((project) => {
+      deleted.push(project.sessionIds);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete all sessions in alpha' }));
+    expect(screen.getByText(/Delete 2 sessions in alpha\?/)).toBeTruthy();
+
+    // Cancel first — nothing deleted.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(deleted).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete all sessions in alpha' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete project sessions' }));
+    expect(deleted).toHaveLength(1);
+    expect([...deleted[0]!].sort()).toEqual(['a1', 'a2']);
+  });
+
+  it('does not render delete controls without a handler', () => {
+    render(
+      createElement(LeftSidebar, {
+        isCollapsed: false,
+        onToggle: () => {},
+        sessionListState: { status: 'ready', sessions: deleteSessions },
+        activeSessionId: null,
+        onSessionSelect: () => {},
+        onSessionCreate: () => {},
+        onSessionDelete: () => {},
+        onRefreshSessions: () => {},
+        onOpenSettings: () => {},
+      }),
+    );
+    expect(screen.queryByRole('button', { name: 'Delete all sessions in alpha' })).toBeNull();
   });
 });

--- a/electron/tests/unit/session-workspace-sidebar.test.ts
+++ b/electron/tests/unit/session-workspace-sidebar.test.ts
@@ -301,7 +301,6 @@ describe('project delete', () => {
 
   function renderWithDelete(onProjectDelete: (project: {
     label: string;
-    path: string | null;
     sessionIds: readonly string[];
   }) => void) {
     return render(
@@ -346,6 +345,32 @@ describe('project delete', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete project sessions' }));
     expect(deleted).toHaveLength(1);
     expect([...deleted[0]!].sort()).toEqual(['a1', 'a2']);
+  });
+
+  it('uses singular copy for a one-session group', () => {
+    const deleted: Array<readonly string[]> = [];
+    render(
+      createElement(LeftSidebar, {
+        isCollapsed: false,
+        onToggle: () => {},
+        sessionListState: { status: 'ready', sessions: [deleteSessions[2]!] },
+        activeSessionId: null,
+        onSessionSelect: () => {},
+        onSessionCreate: () => {},
+        onSessionDelete: () => {},
+        onRefreshSessions: () => {},
+        onOpenSettings: () => {},
+        onProjectDelete: (project) => {
+          deleted.push(project.sessionIds);
+        },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete all sessions in beta' }));
+    expect(screen.getByText(/Delete 1 session in beta\?/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete project sessions' }));
+    expect(deleted).toHaveLength(1);
+    expect([...deleted[0]!]).toEqual(['b1']);
   });
 
   it('does not render delete controls without a handler', () => {

--- a/electron/tests/unit/trust-send-replay.test.tsx
+++ b/electron/tests/unit/trust-send-replay.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * Trust-gated send replay — GitHub issue #148.
+ *
+ * A send rejected by the main-process trust gate must not lose the typed
+ * message: ChatView stashes the failed send, replays it after a trust grant
+ * (only while the stashed session still owns the view), and restores it to
+ * the composer on decline. Hook-level payload coverage lives in
+ * use-trust-prompt.test.ts; this file covers the composer-restore behavior
+ * and the ChatView wiring contract.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { InputArea } from '../../src/renderer/components/InputArea';
+
+const RENDERER = path.resolve(__dirname, '../../src/renderer');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(RENDERER, rel), 'utf8');
+}
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderComposer(draftRestore?: { text: string; consumed: () => void } | null) {
+  const onSend = vi.fn(async () => {});
+  render(
+    <InputArea
+      sessionId={null}
+      status="idle"
+      model=""
+      onSend={onSend}
+      onCancel={vi.fn(async () => {})}
+      draftRestore={draftRestore ?? null}
+    />,
+  );
+  return { onSend };
+}
+
+describe('InputArea draft restore (trust decline)', () => {
+  it('applies the stashed text once and reports consumption', () => {
+    const consumed = vi.fn();
+    renderComposer({ text: 'gated message', consumed });
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('gated message');
+    expect(consumed).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the restored text editable and sendable', () => {
+    const consumed = vi.fn();
+    const { onSend } = renderComposer({ text: 'gated message', consumed });
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'gated message, edited' } });
+    expect(textarea.value).toBe('gated message, edited');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    expect(onSend).toHaveBeenCalledWith('gated message, edited');
+  });
+
+  it('keeps the composer untouched when no restore is pending', () => {
+    renderComposer(null);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('');
+  });
+});
+
+describe('ChatView trust send replay wiring (#148)', () => {
+  it('stashes the failed send before opening the trust prompt', () => {
+    const src = read('components/ChatView.tsx');
+    const start = src.indexOf('onUntrustedProject: (failure) =>');
+    const handler = src.slice(start, start + 400);
+    expect(handler).toContain('pendingTrustSendRef.current = failure;');
+    expect(handler.indexOf('pendingTrustSendRef.current = failure;'))
+      .toBeLessThan(handler.indexOf('trustPrompt.openFor(cwd)'));
+  });
+
+  it('replays the stash on grant: cleared first, dropped when the session moved', () => {
+    const src = read('components/ChatView.tsx');
+    const start = src.indexOf('onGranted: () =>');
+    const granted = src.slice(start, start + 1200);
+    // Double-grant guard: the stash is cleared before the replay fires.
+    expect(granted.indexOf('pendingTrustSendRef.current = null;'))
+      .toBeLessThan(granted.indexOf('handleSendRef.current'));
+    // Superseded guard: replay only while the stashed session still owns the view.
+    expect(granted).toMatch(
+      /pending\.options\.sessionId \?\? null\)[\s\S]*!==[\s\S]*session\.activeSession\?\.id \?\? null/,
+    );
+    expect(granted).toContain('handleSendRef.current?.(pending.message)');
+    // A gated replay restores the message to the composer instead of losing it.
+    expect(granted).toMatch(/if \(!sent\) setRestoreDraft\(\{ text: pending\.message \}\)/);
+  });
+
+  it('restores the stash to the composer on decline instead of losing it', () => {
+    const src = read('components/ChatView.tsx');
+    const declineStart = src.indexOf('const handleTrustDecline = useCallback');
+    const decline = src.slice(
+      declineStart,
+      src.indexOf('const handleFocusSectionConsumed', declineStart),
+    );
+    expect(decline).toContain('pendingTrustSendRef.current = null;');
+    expect(decline).toContain('setRestoreDraft({ text: pending.message })');
+    expect(decline).toContain('trustPrompt.decline()');
+    // The dialog routes declines through the restore wrapper, and the
+    // composer receives the one-shot draft restore.
+    expect(src).toContain('onDecline={handleTrustDecline}');
+    expect(src).toContain('draftRestore={draftRestore}');
+    // handleSend is defined after the grant callback; the ref closes the gap.
+    expect(src).toContain('handleSendRef.current = handleSend;');
+  });
+});

--- a/electron/tests/unit/trust-send-replay.test.tsx
+++ b/electron/tests/unit/trust-send-replay.test.tsx
@@ -3,23 +3,20 @@
  * Trust-gated send replay — GitHub issue #148.
  *
  * A send rejected by the main-process trust gate must not lose the typed
- * message: ChatView stashes the failed send, replays it after a trust grant
- * (only while the stashed session still owns the view), and restores it to
- * the composer on decline. Hook-level payload coverage lives in
- * use-trust-prompt.test.ts; this file covers the composer-restore behavior
- * and the ChatView wiring contract.
+ * message: useTrustSendReplay stashes the failed send, replays it after a
+ * trust grant (only while the stashed session still owns the view), restores
+ * it to the composer on decline, and resolves the stash immediately when the
+ * trust dialog never opens (already-trusted / lookup-failed). Hook-level
+ * payload coverage lives in use-trust-prompt.test.ts; this file covers the
+ * orchestration behavior and the composer-restore wiring.
  */
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { InputArea } from '../../src/renderer/components/InputArea';
-
-const RENDERER = path.resolve(__dirname, '../../src/renderer');
-
-function read(rel: string): string {
-  return fs.readFileSync(path.join(RENDERER, rel), 'utf8');
-}
+import { useTrustSendReplay, type UseTrustSendReplayReturn } from '../../src/renderer/hooks/useTrustSendReplay';
+import type { UntrustedProjectSendFailure } from '../../src/renderer/hooks/useChat';
+import type { QueuedMessage } from '../../src/renderer/hooks/useMessageQueue';
+import type { TrustPromptOpenCallbacks } from '../../src/renderer/hooks/useTrustPrompt';
 
 beforeEach(() => {
   Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
@@ -83,47 +80,251 @@ describe('InputArea draft restore (trust decline)', () => {
   });
 });
 
-describe('ChatView trust send replay wiring (#148)', () => {
-  it('stashes the failed send before opening the trust prompt', () => {
-    const src = read('components/ChatView.tsx');
-    const start = src.indexOf('onUntrustedProject: (failure) =>');
-    const handler = src.slice(start, start + 400);
-    expect(handler).toContain('pendingTrustSendRef.current = failure;');
-    expect(handler.indexOf('pendingTrustSendRef.current = failure;'))
-      .toBeLessThan(handler.indexOf('trustPrompt.openFor(cwd)'));
+// ── useTrustSendReplay orchestration ─────────────────────────────────────────
+
+function failure(message: string, sessionId?: string): UntrustedProjectSendFailure {
+  return { message, options: sessionId ? { sessionId } : {} };
+}
+
+function queued(id: string, text: string): QueuedMessage {
+  return { id, text, trigger: 'next-request', createdAt: 1 };
+}
+
+interface HarnessOptions {
+  cwd?: string | null;
+  activeSessionId?: string | null;
+  sendResult?: boolean;
+}
+
+function renderTrustSendReplay(options: HarnessOptions = {}) {
+  const send = vi.fn(async () => options.sendResult ?? true);
+  const openFor = vi.fn();
+  const decline = vi.fn();
+  const restoreBatch = vi.fn();
+  const initial = { cwd: options.cwd ?? '/proj', activeSessionId: options.activeSessionId ?? 'session-a' };
+  const { result, rerender } = renderHook(
+    (props: { cwd: string | null; activeSessionId: string | null }) =>
+      useTrustSendReplay({
+        openFor,
+        decline,
+        restoreBatch,
+        cwd: props.cwd,
+        activeSessionId: props.activeSessionId,
+      }),
+    { initialProps: initial },
+  );
+  // Late-bind the send bridge the way ChatView binds handleSend.
+  result.current.sendRef.current = send;
+  const rerenderWith = (overrides: Partial<{ cwd: string | null; activeSessionId: string | null }>) => {
+    rerender({ ...initial, ...overrides });
+    result.current.sendRef.current = send;
+  };
+  return { result: result as { current: UseTrustSendReplayReturn }, rerenderWith, send, openFor, decline, restoreBatch };
+}
+
+/** Stash a gated send and resolve openFor with the given outcome. */
+function stash(result: { current: UseTrustSendReplayReturn }, openFor: ReturnType<typeof vi.fn>, options?: {
+  message?: string;
+  sessionId?: string;
+  outcome?: 'opened' | 'already-trusted' | 'lookup-failed';
+}) {
+  const message = options?.message ?? 'gated message';
+  act(() => {
+    result.current.onUntrustedProject(failure(message, options?.sessionId ?? 'session-a'));
+  });
+  expect(openFor).toHaveBeenCalledTimes(1);
+  const callbacks = openFor.mock.calls[0]?.[1] as TrustPromptOpenCallbacks | undefined;
+  expect(callbacks?.onOutcome).toBeInstanceOf(Function);
+  act(() => {
+    callbacks?.onOutcome?.(options?.outcome ?? 'opened');
+  });
+}
+
+describe('useTrustSendReplay — gated-send stash (#148)', () => {
+  it('stashes the failed send and opens the trust prompt for the workspace cwd', () => {
+    const harness = renderTrustSendReplay();
+    act(() => {
+      harness.result.current.onUntrustedProject(failure('hello', 'session-a'));
+    });
+    expect(harness.openFor).toHaveBeenCalledTimes(1);
+    expect(harness.openFor).toHaveBeenCalledWith('/proj', expect.objectContaining({ onOutcome: expect.any(Function) }));
+    // While the dialog is resolving the flow, the composer stays untouched.
+    expect(harness.result.current.draftRestore).toBeNull();
   });
 
-  it('replays the stash on grant: cleared first, dropped when the session moved', () => {
-    const src = read('components/ChatView.tsx');
-    const start = src.indexOf('onGranted: () =>');
-    const granted = src.slice(start, start + 1200);
-    // Double-grant guard: the stash is cleared before the replay fires.
-    expect(granted.indexOf('pendingTrustSendRef.current = null;'))
-      .toBeLessThan(granted.indexOf('handleSendRef.current'));
-    // Superseded guard: replay only while the stashed session still owns the view.
-    expect(granted).toMatch(
-      /pending\.options\.sessionId \?\? null\)[\s\S]*!==[\s\S]*session\.activeSession\?\.id \?\? null/,
-    );
-    expect(granted).toContain('handleSendRef.current?.(pending.message)');
-    // A gated replay restores the message to the composer instead of losing it.
-    expect(granted).toMatch(/if \(!sent\) setRestoreDraft\(\{ text: pending\.message \}\)/);
+  it('keeps the stash parked when the dialog opened', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'hello' });
+    expect(harness.result.current.draftRestore).toBeNull();
+    expect(harness.send).not.toHaveBeenCalled();
   });
 
-  it('restores the stash to the composer on decline instead of losing it', () => {
-    const src = read('components/ChatView.tsx');
-    const declineStart = src.indexOf('const handleTrustDecline = useCallback');
-    const decline = src.slice(
-      declineStart,
-      src.indexOf('const handleFocusSectionConsumed', declineStart),
-    );
-    expect(decline).toContain('pendingTrustSendRef.current = null;');
-    expect(decline).toContain('setRestoreDraft({ text: pending.message })');
-    expect(decline).toContain('trustPrompt.decline()');
-    // The dialog routes declines through the restore wrapper, and the
-    // composer receives the one-shot draft restore.
-    expect(src).toContain('onDecline={handleTrustDecline}');
-    expect(src).toContain('draftRestore={draftRestore}');
-    // handleSend is defined after the grant callback; the ref closes the gap.
-    expect(src).toContain('handleSendRef.current = handleSend;');
+  it('restores the message immediately when no cwd can be resolved', () => {
+    const harness = renderTrustSendReplay();
+    harness.rerenderWith({ cwd: null });
+    act(() => {
+      harness.result.current.onUntrustedProject(failure('hello', 'session-a'));
+    });
+    expect(harness.openFor).not.toHaveBeenCalled();
+    expect(harness.result.current.draftRestore?.text).toBe('hello');
+  });
+
+  it.each(['already-trusted', 'lookup-failed'] as const)(
+    'drops the stash and restores the composer when openFor resolves %s',
+    (outcome) => {
+      const harness = renderTrustSendReplay();
+      stash(harness.result, harness.openFor, { message: 'hello', outcome });
+      // Not parked invisibly: the text is back in the composer…
+      expect(harness.result.current.draftRestore?.text).toBe('hello');
+      // …and a later unrelated grant has nothing to replay.
+      act(() => {
+        harness.result.current.onGranted();
+      });
+      expect(harness.send).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('useTrustSendReplay — grant replay', () => {
+  it('replays the stashed message into the same session', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'hello' });
+    act(() => {
+      harness.result.current.onGranted();
+    });
+    expect(harness.send).toHaveBeenCalledTimes(1);
+    expect(harness.send).toHaveBeenCalledWith('hello');
+    expect(harness.result.current.draftRestore).toBeNull();
+  });
+
+  it('drops the stash when the active session changed before the grant', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'hello', sessionId: 'session-a' });
+    harness.rerenderWith({ activeSessionId: 'session-b' });
+    act(() => {
+      harness.result.current.onGranted();
+    });
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(harness.result.current.draftRestore).toBeNull();
+  });
+
+  it('does not double-send on a double grant', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'hello' });
+    act(() => {
+      harness.result.current.onGranted();
+    });
+    act(() => {
+      harness.result.current.onGranted();
+    });
+    expect(harness.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the composer text once when the replay is gated again', async () => {
+    const harness = renderTrustSendReplay({ sendResult: false });
+    stash(harness.result, harness.openFor, { message: 'hello' });
+    await act(async () => {
+      harness.result.current.onGranted();
+    });
+    expect(harness.send).toHaveBeenCalledTimes(1);
+    const restore = harness.result.current.draftRestore;
+    expect(restore?.text).toBe('hello');
+    expect(typeof restore?.consumed).toBe('function');
+    // One-shot: consuming clears it and a repeat does not re-arm.
+    act(() => {
+      restore?.consumed();
+    });
+    expect(harness.result.current.draftRestore).toBeNull();
+    act(() => {
+      harness.result.current.onGranted();
+    });
+    expect(harness.result.current.draftRestore).toBeNull();
+    expect(harness.send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useTrustSendReplay — decline restore', () => {
+  it('restores the text once when the stashed session still owns the view', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'hello', sessionId: 'session-a' });
+    act(() => {
+      harness.result.current.onDecline();
+    });
+    expect(harness.decline).toHaveBeenCalledTimes(1);
+    expect(harness.result.current.draftRestore?.text).toBe('hello');
+    // Stash is spent: a second decline does not re-arm the composer restore.
+    act(() => {
+      harness.result.current.draftRestore?.consumed();
+      harness.result.current.onDecline();
+    });
+    expect(harness.result.current.draftRestore).toBeNull();
+    expect(harness.decline).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the stash silently when the active session changed before the decline', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'hello', sessionId: 'session-a' });
+    harness.rerenderWith({ activeSessionId: 'session-b' });
+    act(() => {
+      harness.result.current.onDecline();
+    });
+    expect(harness.result.current.draftRestore).toBeNull();
+    // The dialog itself still closes.
+    expect(harness.decline).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useTrustSendReplay — queue restore wrapper (double-send guard)', () => {
+  it('skips the restore when the pending stash owns the batch message', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'queued message' });
+    act(() => {
+      harness.result.current.restoreQueueBatch([queued('qm-1', 'queued message')], 'session-a');
+    });
+    expect(harness.restoreBatch).not.toHaveBeenCalled();
+  });
+
+  it('matches multi-message batches by their joined send text', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'first\n\nsecond' });
+    act(() => {
+      harness.result.current.restoreQueueBatch(
+        [queued('qm-1', 'first'), queued('qm-2', 'second')],
+        'session-a',
+      );
+    });
+    expect(harness.restoreBatch).not.toHaveBeenCalled();
+  });
+
+  it('still restores batches the stash does not own', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'stashed' });
+    const other = [queued('qm-1', 'different message')];
+    act(() => {
+      harness.result.current.restoreQueueBatch(other, 'session-a');
+    });
+    expect(harness.restoreBatch).toHaveBeenCalledWith(other, 'session-a');
+  });
+
+  it('restores normally once the stash is resolved', () => {
+    const harness = renderTrustSendReplay();
+    stash(harness.result, harness.openFor, { message: 'queued message' });
+    act(() => {
+      harness.result.current.onDecline();
+    });
+    const batch = [queued('qm-1', 'queued message')];
+    act(() => {
+      harness.result.current.restoreQueueBatch(batch, 'session-a');
+    });
+    expect(harness.restoreBatch).toHaveBeenCalledWith(batch, 'session-a');
+  });
+
+  it('restores normally when no stash exists', () => {
+    const harness = renderTrustSendReplay();
+    const batch = [queued('qm-1', 'any message')];
+    act(() => {
+      harness.result.current.restoreQueueBatch(batch);
+    });
+    expect(harness.restoreBatch).toHaveBeenCalledWith(batch, undefined);
   });
 });

--- a/electron/tests/unit/use-trust-prompt.test.ts
+++ b/electron/tests/unit/use-trust-prompt.test.ts
@@ -216,6 +216,82 @@ describe('useTrustPrompt', () => {
     expect(result.current.busy).toBe(false);
   });
 
+  // ── openFor outcome callbacks ────────────────────────────────────────────
+
+  it('reports "opened" once the dialog actually opens', async () => {
+    installTrustBridge({ getState: 'untrusted' });
+    const onOutcome = vi.fn();
+    const { result } = renderHook(() => useTrustPrompt());
+
+    act(() => {
+      result.current.openFor('/proj', { onOutcome });
+    });
+
+    await waitFor(() => expect(result.current.pending).not.toBeNull());
+    expect(onOutcome).toHaveBeenCalledTimes(1);
+    expect(onOutcome).toHaveBeenCalledWith('opened');
+  });
+
+  it('reports "already-trusted" without opening the dialog', async () => {
+    installTrustBridge({ getState: 'trusted' });
+    const onOutcome = vi.fn();
+    const { result } = renderHook(() => useTrustPrompt());
+
+    act(() => {
+      result.current.openFor('/proj', { onOutcome });
+    });
+
+    await waitFor(() => expect(onOutcome).toHaveBeenCalledWith('already-trusted'));
+    expect(result.current.pending).toBeNull();
+    expect(onOutcome).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports "lookup-failed" when the trust lookup rejects', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    installTrustBridge({ getImpl: () => Promise.reject(new Error('ipc down')) });
+    const onOutcome = vi.fn();
+    const { result } = renderHook(() => useTrustPrompt());
+
+    act(() => {
+      result.current.openFor('/proj', { onOutcome });
+    });
+
+    await waitFor(() => expect(onOutcome).toHaveBeenCalledWith('lookup-failed'));
+    expect(result.current.pending).toBeNull();
+    expect(result.current.error).not.toBeNull();
+    expect(onOutcome).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire an outcome for a lookup superseded by a newer openFor', async () => {
+    let resolveFirst: ((info: ProjectTrustInfo) => void) | null = null;
+    const getImpl = vi.fn((message: { cwd: string }) => {
+      if (message.cwd === '/stale') {
+        return new Promise<ProjectTrustInfo>((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.resolve({ ...trustInfo('untrusted'), projectDir: message.cwd });
+    });
+    installTrustBridge({ getImpl });
+    const staleOutcome = vi.fn();
+    const freshOutcome = vi.fn();
+    const { result } = renderHook(() => useTrustPrompt());
+
+    act(() => {
+      result.current.openFor('/stale', { onOutcome: staleOutcome });
+      result.current.openFor('/fresh', { onOutcome: freshOutcome });
+    });
+    await waitFor(() => expect(freshOutcome).toHaveBeenCalledWith('opened'));
+
+    // The stale lookup resolves late; its outcome must stay silent so the
+    // fresh request owns the surface (and any parked state on it).
+    await act(async () => {
+      resolveFirst?.({ ...trustInfo('untrusted'), projectDir: '/stale' });
+    });
+    expect(staleOutcome).not.toHaveBeenCalled();
+    expect(result.current.pending?.cwd).toBe('/fresh');
+  });
+
   it('clears the error on the next openFor start and on decline', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     let failLookup = true;

--- a/electron/tests/unit/use-trust-prompt.test.ts
+++ b/electron/tests/unit/use-trust-prompt.test.ts
@@ -306,10 +306,50 @@ describe('useChat untrusted_project mapping', () => {
     expect(send).toHaveBeenCalledTimes(1);
     expect(started).toBe(false);
     expect(onUntrustedProject).toHaveBeenCalledTimes(1);
+    // The failed send context (trimmed message + options) travels with the
+    // callback so the mount point can stash and replay it after a grant.
+    expect(onUntrustedProject).toHaveBeenCalledWith({ message: 'hello', options: {} });
     // No raw error bubble; the optimistic user message was dropped.
     expect(result.current.error).toBeNull();
     expect(result.current.status).toBe('idle');
     expect(result.current.messages).toHaveLength(0);
+  });
+
+  it('hands onUntrustedProject the trimmed message and the original options object', async () => {
+    const { send } = installChatBridge(UNTRUSTED_RESULT);
+    const onUntrustedProject = vi.fn();
+    const { result } = renderHook(() => useChat('session-a', { onUntrustedProject }));
+    const options = { sessionId: 'session-a', model: { connectionId: 'c1', modelId: 'm1' } };
+
+    await act(async () => {
+      await result.current.send('  stash me  ', options);
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(onUntrustedProject).toHaveBeenCalledTimes(1);
+    const payload = onUntrustedProject.mock.calls[0]?.[0];
+    expect(payload.message).toBe('stash me');
+    // Same object identity — the stash must replay the exact original options.
+    expect(payload.options).toBe(options);
+  });
+
+  it('does not invoke onUntrustedProject when the send starts a turn', async () => {
+    const { send } = installChatBridge({
+      status: 'started',
+      sessionId: 'session-a',
+      turnId: 'turn-1',
+    });
+    const onUntrustedProject = vi.fn();
+    const { result } = renderHook(() => useChat('session-a', { onUntrustedProject }));
+
+    let started = false;
+    await act(async () => {
+      started = await result.current.send('hello');
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(started).toBe(true);
+    expect(onUntrustedProject).not.toHaveBeenCalled();
   });
 
   it('keeps the generic error behavior when no callback is provided', async () => {


### PR DESCRIPTION
## Summary

Five user-facing fixes from the issue tracker. The main-process trust gate and session-deletion semantics are untouched — every fix lives on the interaction side.

| Issue | Before | After |
|---|---|---|
| #157 | Sidebar activity rows reshuffled on every streamed event | Working/waiting rows hold a stable queue position for the whole turn, ordered by turn start |
| #154 | Connection wizard always showed a protocol dropdown with a single unchangeable option | Protocol panel appears only when the provider actually offers a choice |
| #158 | No way to delete a project — sessions had to be removed one by one | Hover-revealed trash on each project group deletes all its sessions behind a confirm dialog |
| #148 | A send blocked by the trust gate was lost; the user retyped after trusting | The message is stashed, auto-replayed after granting trust, or restored to the composer on decline |
| #163 | Collapsed project groups reset on every restart | Collapse state persists across restarts and stays consistent across every mounted sidebar |

Fixes #157
Fixes #154
Fixes #158
Fixes #148
Fixes #163

## Design notes

- **#157** — ordering tie-breaks move from `updatedAt` (bumped on every streamed detail event) to `startedAt` for working/waiting rows: the longest-running turn keeps the top of its bucket and nothing displaces mid-turn. Main (`SessionActivityStore.list()`) and renderer (`orderedSessionActivities()`) now sort through one shared comparator (`shared/utils/session-activity-order.ts`) with a fixture parity test, so the two surfaces cannot drift apart again.
- **#158** — projects are derived groupings (sessions grouped by cwd), so deleting "the project" means deleting its sessions through the existing per-session `session:delete` path: working-set reconciliation, running-turn force-stop, and cache teardown all come along unchanged. The group disappears once empty.
- **#148** — the stash lives entirely in renderer memory; the replay re-enters `chat:send`, so the main-process gate re-evaluates trust on every send (fail-closed stays fail-closed). A queued message that hits the gate becomes owned by the stash alone — the queue restore is suppressed — so it can never double-send. If the trust dialog never opens (already-trusted or lookup failure), the text returns to the composer instead of parking invisibly and firing on a later unrelated grant.

## Review

A ten-persona review pass (correctness, security, testing, maintainability, project-standards, performance, reliability, adversarial, agent-native, learnings) ran over the diff with independent per-finding validation. All 13 validated findings were fixed in 2ca3d636 — notably: keyboard events leaking from the portaled delete dialog into the sidebar listbox handler (unconfirmed deletes), dual-mounted sidebars clobbering each other's persisted collapse state, per-delete errors being swallowed in the delete loop, the decline path's missing superseded-session guard, and the trust orchestration being covered only by source-string greps (now behavioral tests on the extracted `useTrustSendReplay` hook).

## Test plan

- Full suite: 297 files / 4589 tests pass; typecheck, lint, and runtime-cycle check clean.
- New behavioral coverage: ordering stability + main/renderer parity, collapse persistence across remount, delete-confirm dialog (payload, singular copy, cancel path), wizard edit-mode panel absence, trust stash/replay/decline orchestration (19 hook tests), and `openFor` outcome callbacks.
