### PR TITLE
fix: Esc interrupt layers and running command widget (#145, #160)

### DIFF
--- a/electron/src/main/ipc/chat.ts
+++ b/electron/src/main/ipc/chat.ts
@@ -12,6 +12,8 @@ import { getSessionManager } from '../session/singleton';
 import { IPC_CHANNELS, type ChatSessionSnapshot, type ChatCompactResult } from '../../shared/types/ipc';
 import { ChainStatus, lastChainError } from '../../shared/types/chain';
 import { flattenSessionMessages } from '../../shared/types/session';
+import { MAIN_AGENT_SCOPE_ID } from '../../shared/types/agent-scope';
+import { isTerminalSubagentState } from '../agents/types';
 import { getProjectTrustState } from '../project/trust';
 import { getProjectRuntimeRegistry } from '../project/runtime';
 import { clearAllChatHistory } from './chat-history';
@@ -21,8 +23,11 @@ import { completeSessionActivity } from './session-activity';
 import {
   activeAgents,
   agentGenerations,
+  clearSubagentCancelConfirm,
+  consumeSubagentCancelConfirm,
   draftEnsureByWindow,
   sessionsStarting,
+  stageSubagentCancelConfirm,
 } from './chat/state';
 import { sendChatState, sendTurnEvent, webContentsForWindowId } from './chat/events';
 import { snapshotForAgent } from './chat/snapshot';
@@ -191,6 +196,49 @@ export function registerChatIPC(): void {
     return compactSessionNow(sessionId, runtime, selection);
   });
 
+  function sessionHasActiveSubagents(sessionId: string): boolean {
+    try {
+      return getSubagentManager()
+        .getStates(sessionId)
+        .some((record) => !isTerminalSubagentState(record.state));
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Third interrupt layer with no live main-agent turn: the main agent was
+   * cancelled (its ActiveAgent disposed after the interrupt reset window), but
+   * session-owned subagents still run. The first Esc stages the confirmation;
+   * the next Esc within the window cancels the subagents and their
+   * session-owned processes. After the window the next Esc re-stages,
+   * mirroring the interrupt machine's auto-reset. Keeps layer 3 reachable for
+   * as long as subagents run (issue #145).
+   */
+  function handleSubagentOnlyCancel(
+    sessionId: string,
+    windowId: string,
+  ): { status: string } {
+    if (!sessionHasActiveSubagents(sessionId)) {
+      clearSubagentCancelConfirm(sessionId);
+      return { status: 'no_active_stream' };
+    }
+    if (!consumeSubagentCancelConfirm(sessionId)) {
+      stageSubagentCancelConfirm(sessionId);
+      return { status: 'confirming_subagents' };
+    }
+    getBackgroundStore().terminateSession(sessionId);
+    getForegroundLiveRegistry().dropSession(sessionId);
+    const cancelled = getSubagentManager().cancelRunning(sessionId);
+    if (cancelled.length > 0) {
+      completeSessionActivity(
+        sessionId,
+        getSessionManager().getActive(windowId)?.id !== sessionId,
+      );
+    }
+    return { status: 'cancelled' };
+  }
+
   ipcMain.handle(IPC_CHANNELS.CHAT_CANCEL, async (event, payload: unknown) => {
     const webContents: WebContents = event.sender;
     const windowId = String(webContents.id);
@@ -199,7 +247,7 @@ export function registerChatIPC(): void {
     const sessionId = parsed.data.sessionId ?? getSessionManager().getActive(windowId)?.id;
     if (!sessionId) return { status: 'no_active_stream' };
     const existing = activeAgents.get(sessionId);
-    if (!existing) return { status: 'no_active_stream' };
+    if (!existing) return handleSubagentOnlyCancel(sessionId, windowId);
     const streamWebContents = webContentsForWindowId(existing.windowId) ?? webContents;
     const interruptState = existing.interruptActor.getSnapshot().value as
       | 'idle'
@@ -210,8 +258,12 @@ export function registerChatIPC(): void {
       return { status: 'confirming' };
     }
     if (interruptState === 'confirmAgent') {
-      getBackgroundStore().terminateSession(sessionId);
-      getForegroundLiveRegistry().dropSession(sessionId);
+      // Second Esc cancels only the main agent. Scope the process cleanup to
+      // the main agent's own commands: subagent-owned commands live under the
+      // same session id with their own scope ids and must survive until the
+      // third Esc confirms subagent cancellation (issue #145).
+      getBackgroundStore().terminateScope(sessionId, MAIN_AGENT_SCOPE_ID);
+      getForegroundLiveRegistry().dropScope(sessionId, MAIN_AGENT_SCOPE_ID);
       existing.agentCancelled = true;
       const context = existing.actor.getSnapshot().context as AgentContext;
       existing.actor.send({ type: 'CANCEL' });
@@ -247,6 +299,7 @@ export function registerChatIPC(): void {
       return { status: 'confirming_subagents' };
     }
     if (interruptState === 'confirmSubagents') {
+      clearSubagentCancelConfirm(sessionId);
       getBackgroundStore().terminateSession(sessionId);
       getForegroundLiveRegistry().dropSession(sessionId);
       getSubagentManager().cancelRunning(sessionId);

--- a/electron/src/main/ipc/chat/send.ts
+++ b/electron/src/main/ipc/chat/send.ts
@@ -57,6 +57,7 @@ import { emitSessionUpdated, sendChatState, sendTurnEvent } from './events';
 import {
   activeAgents,
   canEmitStreamEvents,
+  clearSubagentCancelConfirm,
   isCurrentAgent,
   nextAgentGeneration,
   sessionOperationGateTail,
@@ -394,6 +395,9 @@ export async function startChatTurn(
   };
   activeAgents.set(sessionId, activeAgent);
   sessionsStarting.delete(sessionId);
+  // A live main-agent turn owns the Esc phases again; drop any staged
+  // standalone subagent-cancel confirmation from a previously disposed turn.
+  clearSubagentCancelConfirm(sessionId);
 
   // A long-running first turn must not leave the session unnamed forever:
   // after the configured wait, name from the current in-flight history even

--- a/electron/src/main/ipc/chat/state.ts
+++ b/electron/src/main/ipc/chat/state.ts
@@ -170,6 +170,43 @@ export function hasLiveMainTurn(sessionId: string): boolean {
 }
 
 /**
+ * Staged subagent-only Esc confirmation (the third interrupt layer without a
+ * live main-agent turn). After the main agent is cancelled and its ActiveAgent
+ * disposed, session-owned subagents may still run; the first Esc stages this
+ * confirmation and the next one cancels them. The stage expires after the same
+ * window the interrupt machine uses, so a late Esc re-stages the confirmation
+ * instead of firing the destructive cancel.
+ */
+const SUBAGENT_CANCEL_CONFIRM_WINDOW_MS = 5000;
+
+const subagentCancelConfirms = new Map<string, { resetTimer: ReturnType<typeof setTimeout> }>();
+
+/** Stage (or re-stage) the subagent-cancel confirmation window for a session. */
+export function stageSubagentCancelConfirm(sessionId: string): void {
+  clearSubagentCancelConfirm(sessionId);
+  const resetTimer = setTimeout(() => {
+    subagentCancelConfirms.delete(sessionId);
+  }, SUBAGENT_CANCEL_CONFIRM_WINDOW_MS);
+  subagentCancelConfirms.set(sessionId, { resetTimer });
+}
+
+/** Consume a staged confirmation; false when none is within its window. */
+export function consumeSubagentCancelConfirm(sessionId: string): boolean {
+  const entry = subagentCancelConfirms.get(sessionId);
+  if (!entry) return false;
+  clearSubagentCancelConfirm(sessionId);
+  return true;
+}
+
+/** Drop a staged confirmation (new turn start, no running subagents, …). */
+export function clearSubagentCancelConfirm(sessionId: string): void {
+  const entry = subagentCancelConfirms.get(sessionId);
+  if (!entry) return;
+  clearTimeout(entry.resetTimer);
+  subagentCancelConfirms.delete(sessionId);
+}
+
+/**
  * Whether this agent may still stream IPC to the renderer.
  * Drops events from cancelled, finalized, replaced, or generation-stale agents.
  */

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -91,6 +91,15 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
   const workspaceCwdRef = useRef(workspaceCwd);
   workspaceCwdRef.current = workspaceCwd;
   const subagents = useSubagents(session.activeSession?.id ?? null);
+  /**
+   * Esc keeps the third interrupt layer reachable while the session owns
+   * queued/running subagents, even when no main-agent turn is live (#145).
+   * Memoized on the group arrays' contents so the composer prop stays stable.
+   */
+  const hasRunningSubagents = useMemo(
+    () => subagents.groups.running.length > 0 || subagents.groups.queued.length > 0,
+    [subagents.groups.running, subagents.groups.queued],
+  );
   const todos = useTodos(
     session.activeSession?.id ?? null,
     session.activeSession?.todoStore.tasks ?? null,
@@ -1372,6 +1381,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
           onOpenProviders={handleOpenProviders}
           onPickProjectDir={handlePickProjectDirClick}
           isViewActive={!isVisible || contentMode === 'subagents'}
+          hasRunningSubagents={hasRunningSubagents}
           draftRestore={trustSend.draftRestore}
         />
         <DeferredSurface isVisible={isVisible}>

--- a/electron/src/renderer/components/InputArea.tsx
+++ b/electron/src/renderer/components/InputArea.tsx
@@ -66,6 +66,11 @@ interface InputAreaProps {
   /** ChatView keeps this subtree mounted while the Subagent View owns focus. */
   isViewActive?: boolean;
   /**
+   * The session still owns queued/running subagents: Esc must reach the
+   * third interrupt layer even when no main-agent turn is live (issue #145).
+   */
+  hasRunningSubagents?: boolean;
+  /**
    * One-shot composer text restore (e.g. a trust-gated send the user
    * declined). The text replaces the input once; `consumed()` reports back so
    * the owner drops the restore and cannot fire it twice.
@@ -85,13 +90,15 @@ export type InputEscapeAction = 'cancel-question' | 'cancel-chat' | 'none';
 export function resolveInputEscapeAction(options: {
   hasActiveQuestion: boolean;
   canInterrupt: boolean;
+  /** Session still owns queued/running subagents (third interrupt layer). */
+  hasRunningSubagents: boolean;
   isSlashMode: boolean;
   isViewActive: boolean;
   settingsOpen: boolean;
 }): InputEscapeAction {
   if (options.isViewActive || options.settingsOpen) return 'none';
   if (options.hasActiveQuestion) return 'cancel-question';
-  if (!options.canInterrupt || options.isSlashMode) return 'none';
+  if ((!options.canInterrupt && !options.hasRunningSubagents) || options.isSlashMode) return 'none';
   return 'cancel-chat';
 }
 
@@ -116,6 +123,7 @@ export const InputArea = memo(function InputArea({
   modelSelected = true,
   onOpenProviders,
   isViewActive = false,
+  hasRunningSubagents = false,
   draftRestore = null,
 }: InputAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -420,6 +428,7 @@ export const InputArea = memo(function InputArea({
       const action = resolveInputEscapeAction({
         hasActiveQuestion,
         canInterrupt,
+        hasRunningSubagents,
         isSlashMode,
         isViewActive: false,
         settingsOpen: false,
@@ -435,7 +444,7 @@ export const InputArea = memo(function InputArea({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [askQuestion.cancelAll, canInterrupt, hasActiveQuestion, isSlashMode, isViewActive, onCancel]);
+  }, [askQuestion.cancelAll, canInterrupt, hasActiveQuestion, hasRunningSubagents, isSlashMode, isViewActive, onCancel]);
 
   const resetComposerHeight = useCallback(() => {
     if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);

--- a/electron/src/renderer/components/ToolResults/ToolResultShell.tsx
+++ b/electron/src/renderer/components/ToolResults/ToolResultShell.tsx
@@ -141,6 +141,7 @@ export function ToolResultShell({
       if (block.toolName === 'execute_command') {
         // Foreground live mirror keyed by the tool call id (block.id). The
         // canonical stdout/stderr result replaces this widget on completion.
+        // Embedded: the shell's disclosure is the only expand/collapse control.
         // Stop propagation so the widget's own controls never collapse the shell.
         const { command, description } = foregroundCommandInfo(block);
         return (
@@ -153,6 +154,7 @@ export function ToolResultShell({
               sessionId={sessionId}
               commandText={command}
               description={description}
+              embedded
             />
           </div>
         );

--- a/electron/src/renderer/components/ToolResults/registry.tsx
+++ b/electron/src/renderer/components/ToolResults/registry.tsx
@@ -64,8 +64,9 @@ const ExecuteCommandRenderer: ToolResultRenderer = ({ canonical, sessionId }) =>
   }
   // Liveness follows the process, not the tool call: a replayed background
   // result still renders the live widget, which freezes once the first
-  // snapshot reports the command exited or unavailable. Stop propagation so
-  // the widget's own controls never collapse the enclosing tool shell.
+  // snapshot reports the command exited or unavailable. Embedded: the tool
+  // shell's disclosure is the only expand/collapse control. Stop propagation
+  // so the widget's own controls never collapse the enclosing tool shell.
   return (
     <div
       onClick={(event) => event.stopPropagation()}
@@ -77,6 +78,7 @@ const ExecuteCommandRenderer: ToolResultRenderer = ({ canonical, sessionId }) =>
         commandText={bg.data.command}
         description={bg.data.description}
         expectedCreatedAt={bg.data.createdAt}
+        embedded
       />
     </div>
   );

--- a/electron/src/renderer/components/ToolWidgets/LiveCommandInline.tsx
+++ b/electron/src/renderer/components/ToolWidgets/LiveCommandInline.tsx
@@ -45,6 +45,12 @@ interface LiveCommandInlineProps {
    * unrelated live process.
    */
   expectedCreatedAt?: number;
+  /**
+   * Headerless mode for embedding inside a tool-result shell: the shell's
+   * disclosure owns expand/collapse, so the widget renders its body only —
+   * no bordered card, no second toggle header (issue #160).
+   */
+  embedded?: boolean;
 }
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -67,6 +73,7 @@ export function LiveCommandInline({
   commandText,
   description,
   expectedCreatedAt,
+  embedded = false,
 }: LiveCommandInlineProps) {
   const [expanded, setExpanded] = useState(false);
   const [inputValue, setInputValue] = useState('');
@@ -82,9 +89,10 @@ export function LiveCommandInline({
   }, []);
 
   // Keep lifecycle status current while collapsed, but refresh the output tail
-  // only while the command body is visible.
+  // only while the command body is visible. Embedded widgets mount only when
+  // the enclosing shell expands, so their body is always visible.
   const { output, exitCode, isRunning, isAvailable, interactive, owner, refresh } =
-    useLiveCommandOutput(target, sessionId, true, expanded, expectedCreatedAt);
+    useLiveCommandOutput(target, sessionId, true, embedded || expanded, expectedCreatedAt);
 
   // Build title: prefer the description, falling back to the raw command —
   // mirrors commandTitle() in tool-title.ts.
@@ -167,6 +175,70 @@ export function LiveCommandInline({
     refresh();
   }, [commandId, sessionId, refresh]);
 
+  const bodyContent = (
+    <>
+      {commandText && description && description !== commandText && (
+        <pre className="orchid-live-command-cmd">$ {commandText}</pre>
+      )}
+      <pre className="orchid-live-command-pre">
+        {displayOutput || (!isAvailable
+          ? isBackground
+            ? '(background command is no longer available)'
+            : '(command output is no longer available)'
+          : isRunning ? '(waiting for output...)' : '(no output)')}
+      </pre>
+      {!isRunning && exitCode !== null && (
+        <div className="orchid-live-command-exit">
+          Process exited with code {exitCode}
+        </div>
+      )}
+      {isBackground && (showInput || showStop || showRelease) && (
+        <div className="orchid-live-command-controls">
+          {showInput ? (
+            <form
+              className="orchid-live-command-input-row"
+              onSubmit={(event) => void handleSendInput(event)}
+            >
+              <TextInput
+                size="xs"
+                className="orchid-live-command-input"
+                value={inputValue}
+                placeholder="Send a line of input"
+                aria-label={`Send input to ${commandText || 'command'}`}
+                aria-describedby={inputHint ? hintId : undefined}
+                onChange={(event) => setInputValue(event.target.value)}
+              />
+              <Button type="submit" size="xs" variant="primary">
+                Send
+              </Button>
+            </form>
+          ) : (
+            <span className="flex-1" aria-hidden="true" />
+          )}
+          {showRelease && (
+            <Button size="xs" variant="ghost" onClick={() => void handleRelease()}>
+              Release
+            </Button>
+          )}
+          {showStop && (
+            <Button size="xs" variant="error" onClick={() => void handleStop()}>
+              Stop
+            </Button>
+          )}
+        </div>
+      )}
+      {inputHint && (
+        <div id={hintId} className="orchid-live-command-hint" role="status" aria-live="polite">{inputHint}</div>
+      )}
+    </>
+  );
+
+  // Embedded: the enclosing tool-result shell owns the disclosure header, so
+  // render only the body — never a second toggle (issue #160).
+  if (embedded) {
+    return <div className="orchid-live-command-embedded">{bodyContent}</div>;
+  }
+
   return (
     <div className="orchid-live-command">
       <button
@@ -190,59 +262,7 @@ export function LiveCommandInline({
       </button>
       <CollapsibleRegion open={expanded} id={panelId}>
         <div className="orchid-live-command-body">
-          {commandText && description && description !== commandText && (
-            <pre className="orchid-live-command-cmd">$ {commandText}</pre>
-          )}
-          <pre className="orchid-live-command-pre">
-            {displayOutput || (!isAvailable
-              ? isBackground
-                ? '(background command is no longer available)'
-                : '(command output is no longer available)'
-              : isRunning ? '(waiting for output...)' : '(no output)')}
-          </pre>
-          {!isRunning && exitCode !== null && (
-            <div className="orchid-live-command-exit">
-              Process exited with code {exitCode}
-            </div>
-          )}
-          {isBackground && (showInput || showStop || showRelease) && (
-            <div className="orchid-live-command-controls">
-              {showInput ? (
-                <form
-                  className="orchid-live-command-input-row"
-                  onSubmit={(event) => void handleSendInput(event)}
-                >
-                  <TextInput
-                    size="xs"
-                    className="orchid-live-command-input"
-                    value={inputValue}
-                    placeholder="Send a line of input"
-                    aria-label={`Send input to ${commandText || 'command'}`}
-                    aria-describedby={inputHint ? hintId : undefined}
-                    onChange={(event) => setInputValue(event.target.value)}
-                  />
-                  <Button type="submit" size="xs" variant="primary">
-                    Send
-                  </Button>
-                </form>
-              ) : (
-                <span className="flex-1" aria-hidden="true" />
-              )}
-              {showRelease && (
-                <Button size="xs" variant="ghost" onClick={() => void handleRelease()}>
-                  Release
-                </Button>
-              )}
-              {showStop && (
-                <Button size="xs" variant="error" onClick={() => void handleStop()}>
-                  Stop
-                </Button>
-              )}
-            </div>
-          )}
-          {inputHint && (
-            <div id={hintId} className="orchid-live-command-hint" role="status" aria-live="polite">{inputHint}</div>
-          )}
+          {bodyContent}
         </div>
       </CollapsibleRegion>
     </div>

--- a/electron/src/renderer/hooks/useChat.ts
+++ b/electron/src/renderer/hooks/useChat.ts
@@ -339,6 +339,17 @@ export function consumePendingCancel(state: CancelQueueState): boolean {
   return true;
 }
 
+/**
+ * Release the cancel mutex and drop any Esc staged while the last IPC was in
+ * flight. The subagent-cancel confirmation is the destructive terminal layer:
+ * it must always require one deliberate fresh keypress instead of draining a
+ * rapid double-Esc (issue #145).
+ */
+export function discardPendingCancel(state: CancelQueueState): void {
+  state.pending = false;
+  state.inFlight = false;
+}
+
 export function resetCancelQueue(state: CancelQueueState): void {
   state.inFlight = false;
   state.pending = false;
@@ -732,13 +743,15 @@ export function useChat(
     try {
       let runCancelPhase = true;
       while (runCancelPhase) {
+        let cancelStatus: string | undefined;
         try {
           const affinity = affinityRef.current.value;
           const sessionId = affinity.selectedSessionId ?? affinity.streamSessionId;
           const result = await window.orchid.chat.cancel(
             sessionId ? { sessionId } : undefined,
           );
-          const status = result && (result as { status: string }).status;
+          cancelStatus = result && (result as { status: string }).status;
+          const status = cancelStatus;
 
           // First Esc only shows confirmAgent hint
           if (status === 'confirming') {
@@ -783,7 +796,14 @@ export function useChat(
           // Ignore cancel errors — still release / drain the queue below.
         }
 
-        runCancelPhase = consumePendingCancel(cancelQueueRef.current);
+        if (cancelStatus === 'confirming_subagents') {
+          // Layer 3 is destructive: drop Esc presses staged during the last
+          // RTT so cancelling subagents needs a deliberate fresh keypress.
+          discardPendingCancel(cancelQueueRef.current);
+          runCancelPhase = false;
+        } else {
+          runCancelPhase = consumePendingCancel(cancelQueueRef.current);
+        }
       }
     } catch {
       // Unexpected throw outside the per-IPC try — never leave the mutex stuck.

--- a/electron/src/renderer/styles/components.css
+++ b/electron/src/renderer/styles/components.css
@@ -504,6 +504,12 @@
     @apply border-t border-base-300;
   }
 
+  /* Embedded live command inside a tool-result shell: no card chrome and no
+     top border — the shell's own border and disclosure own the framing. */
+  .orchid-live-command-embedded {
+    @apply my-1 overflow-hidden rounded-md;
+  }
+
   .orchid-live-command-pre {
     @apply m-0 overflow-x-auto whitespace-pre-wrap p-3 font-mono bg-base-300;
     font-size: 1rem;

--- a/electron/src/renderer/utils/tool-title.ts
+++ b/electron/src/renderer/utils/tool-title.ts
@@ -265,15 +265,15 @@ function commandTitle(
   description: string | null,
   command: string | null,
 ): ToolTitle {
+  // The title shows the description (or the command when no description
+  // exists); the full command stays available inside the expanded widget body
+  // instead of being appended to a running title (issue #160).
   const display = description || (command ? `$ ${command}` : null);
-  const commandDetail = command && description && description !== command ? `$ ${command}` : null;
 
   if (status === 'generating' || status === 'running') {
     const verb = status === 'generating' ? 'Preparing to run' : 'Running';
     if (!display) return compose(strong(`${verb} command`));
-    return commandDetail
-      ? compose(strong(`${verb} ${display}`), text(' · '), code(commandDetail))
-      : labeled(verb, display);
+    return labeled(verb, display);
   }
 
   if (status === 'failed') {

--- a/electron/tests/integration/tool-result-replay.test.ts
+++ b/electron/tests/integration/tool-result-replay.test.ts
@@ -163,15 +163,15 @@ describe('background command replay gating', () => {
       await Promise.resolve();
     });
 
-    expect(container.querySelector('.orchid-live-command')).toBeTruthy();
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeTruthy();
     expect(snapshot).toHaveBeenCalledTimes(1);
     expect(snapshot).toHaveBeenCalledWith(expect.objectContaining({
       commandId: 7,
       lastN: 50,
       sessionId: 'sess-replay',
     }));
-    // The exited snapshot freezes the widget and surfaces the exit code.
-    expect(container.querySelector('.orchid-live-command-title')?.textContent).toContain('exit 3');
+    // The exited snapshot freezes the embedded widget and surfaces the exit code.
+    expect(container.textContent).toContain('Process exited with code 3');
 
     // No further polling once the process reports terminal.
     await act(async () => {

--- a/electron/tests/unit/chat-cancel-gates.test.ts
+++ b/electron/tests/unit/chat-cancel-gates.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Esc interrupt gates (issue #145).
+ *
+ * Behavioral coverage for the cancel-serialization primitives and the global
+ * Escape ownership resolver: the subagent-cancel confirmation is the
+ * destructive terminal layer and must always require a deliberate fresh
+ * keypress, and Esc must reach chat cancellation while the session owns
+ * running subagents even without a live main-agent turn.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  beginCancelRequest,
+  consumePendingCancel,
+  discardPendingCancel,
+  resetCancelQueue,
+  type CancelQueueState,
+} from '../../src/renderer/hooks/useChat';
+import { resolveInputEscapeAction } from '../../src/renderer/components/InputArea';
+
+function freshQueue(): CancelQueueState {
+  return { inFlight: false, pending: false };
+}
+
+describe('cancel queue hardening', () => {
+  it('drains a staged Esc after a non-terminal cancel phase', () => {
+    const state = freshQueue();
+    expect(beginCancelRequest(state)).toBe('run');
+    // Esc pressed while the first IPC is in flight.
+    expect(beginCancelRequest(state)).toBe('queued');
+    // 'confirming' (layer 1) is not destructive: the staged Esc advances.
+    expect(consumePendingCancel(state)).toBe(true);
+    expect(state.inFlight).toBe(true);
+
+    // No further staged press: the mutex releases.
+    expect(consumePendingCancel(state)).toBe(false);
+    expect(state.inFlight).toBe(false);
+  });
+
+  it('discards staged Esc presses once the subagent-cancel phase is reached', () => {
+    const state = freshQueue();
+    beginCancelRequest(state);
+    beginCancelRequest(state); // staged during the layer-1 RTT
+
+    // 'confirming_subagents' is the destructive terminal layer: staged
+    // presses are dropped so layer 3 needs a fresh keypress.
+    discardPendingCancel(state);
+    expect(state).toEqual({ inFlight: false, pending: false });
+
+    // A deliberate new Esc starts a fresh cancel IPC.
+    expect(beginCancelRequest(state)).toBe('run');
+  });
+
+  it('resetCancelQueue releases everything', () => {
+    const state = freshQueue();
+    beginCancelRequest(state);
+    beginCancelRequest(state);
+    resetCancelQueue(state);
+    expect(state).toEqual({ inFlight: false, pending: false });
+  });
+});
+
+describe('resolveInputEscapeAction with running subagents', () => {
+  const base = {
+    hasActiveQuestion: false,
+    isSlashMode: false,
+    isViewActive: false,
+    settingsOpen: false,
+  };
+
+  it('allows Esc to cancel while subagents run without a live main turn', () => {
+    expect(resolveInputEscapeAction({
+      ...base,
+      canInterrupt: false,
+      hasRunningSubagents: true,
+    })).toBe('cancel-chat');
+  });
+
+  it('keeps the original gates when no subagents run', () => {
+    expect(resolveInputEscapeAction({
+      ...base,
+      canInterrupt: false,
+      hasRunningSubagents: false,
+    })).toBe('none');
+    expect(resolveInputEscapeAction({
+      ...base,
+      canInterrupt: true,
+      hasRunningSubagents: false,
+    })).toBe('cancel-chat');
+  });
+
+  it('still yields to questions, slash mode, inactive views, and settings', () => {
+    expect(resolveInputEscapeAction({
+      ...base,
+      hasActiveQuestion: true,
+      canInterrupt: false,
+      hasRunningSubagents: true,
+    })).toBe('cancel-question');
+    expect(resolveInputEscapeAction({
+      ...base,
+      isSlashMode: true,
+      canInterrupt: true,
+      hasRunningSubagents: true,
+    })).toBe('none');
+    expect(resolveInputEscapeAction({
+      ...base,
+      isViewActive: true,
+      canInterrupt: true,
+      hasRunningSubagents: true,
+    })).toBe('none');
+    expect(resolveInputEscapeAction({
+      ...base,
+      settingsOpen: true,
+      canInterrupt: true,
+      hasRunningSubagents: true,
+    })).toBe('none');
+  });
+});

--- a/electron/tests/unit/chat-ipc.test.ts
+++ b/electron/tests/unit/chat-ipc.test.ts
@@ -517,6 +517,7 @@ const mocks = vi.hoisted(() => {
   const backgroundStore = {
     entries: backgroundEntries,
     terminateSession: vi.fn(),
+    terminateScope: vi.fn(),
     snapshot: vi.fn((commandId: number, _lastN?: number) => {
       const entry = backgroundEntries.get(commandId);
       if (!entry) return undefined;
@@ -561,6 +562,7 @@ const mocks = vi.hoisted(() => {
     _reset: () => {
       backgroundEntries.clear();
       backgroundStore.terminateSession.mockClear();
+      backgroundStore.terminateScope.mockClear();
       backgroundStore.snapshot.mockClear();
       backgroundStore.snapshotVisible.mockClear();
       backgroundStore.snapshotForSession.mockClear();
@@ -605,6 +607,7 @@ const mocks = vi.hoisted(() => {
     subagentManager: {
       cancelRunning: vi.fn(() => []),
       discardSession: vi.fn(),
+      getStates: vi.fn((): Array<{ id: string; state: string }> => []),
     },
     publishSessionActivity: vi.fn(),
     completeSessionActivity: vi.fn(),
@@ -2377,6 +2380,122 @@ describe('chat IPC teardown and bgcmd bounds', () => {
       command: '',
       agentScopeId: 'subagent-xyz',
     });
+  });
+});
+
+describe('chat:cancel interrupt layers (issue #145)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.handlers.clear();
+    mocks.streamResponses.length = 0;
+    mocks.streamEventSequences.length = 0;
+    mocks.subagentManager.cancelRunning.mockClear();
+    mocks.subagentManager.getStates.mockClear();
+    mocks.subagentManager.getStates.mockReturnValue([]);
+    mocks.runtimeRegistry._reset();
+    mocks.electronWebContents.fromId.mockReset();
+    mocks.electronWebContents.fromId.mockReturnValue(null);
+    mocks.electronWebContents.getAllWebContents.mockReset();
+    mocks.electronWebContents.getAllWebContents.mockReturnValue([]);
+    mocks.sessionManager._reset();
+
+    chatIpc = await import('../../src/main/ipc/chat');
+    chatIpc.registerChatIPC();
+  });
+
+  afterEach(() => {
+    chatIpc.unregisterChatIPC();
+    mocks.handlers.clear();
+    mocks.streamResponses.length = 0;
+    mocks.streamEventSequences.length = 0;
+    mocks.sessionManager._reset();
+  });
+
+  it('second Esc terminates only main-scoped processes and leaves subagents running', async () => {
+    const sessionId = 'efefefef-efef-4efe-8efe-efefefefefef';
+    const selection = {
+      connectionId: '11111111-1111-4111-8111-111111111111',
+      modelId: 'vendor/path/model',
+    };
+    mocks.sessionManager._setActive({
+      ...makeSession(sessionId),
+      selection,
+      modelLabel: selection.modelId,
+    });
+    let releaseStream!: () => void;
+    const streamGate = new Promise<void>((resolve) => { releaseStream = resolve; });
+    mocks.streamChat.mockImplementationOnce(async function* () {
+      yield { type: 'content', text: 'subagents keep working' };
+      await streamGate;
+      yield { type: 'finish', finishReason: 'stop' };
+    });
+    const send = vi.fn();
+    const source = { id: 916, send };
+    mocks.sessionManager._setActiveForWindow('916', mocks.sessionManager.getActive()!);
+    mocks.electronWebContents.getAllWebContents.mockReturnValue([source]);
+    const chatSend = mocks.handlers.get(IPC_CHANNELS.CHAT_SEND)!;
+    const chatCancel = mocks.handlers.get(IPC_CHANNELS.CHAT_CANCEL)!;
+
+    await chatSend({ sender: source }, { message: 'Run the crew' });
+    await waitForChannelCount(send, IPC_CHANNELS.CHAT_CHUNK, 1);
+
+    expect(await chatCancel({ sender: source }, { sessionId })).toMatchObject({ status: 'confirming' });
+    expect(await chatCancel({ sender: source }, { sessionId })).toMatchObject({ status: 'confirming_subagents' });
+
+    expect(mocks.backgroundStore.terminateScope).toHaveBeenCalledWith(sessionId, 'main');
+    expect(mocks.backgroundStore.terminateSession).not.toHaveBeenCalled();
+    expect(mocks.subagentManager.cancelRunning).not.toHaveBeenCalled();
+
+    releaseStream();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
+  it('keeps the subagent-cancel layer reachable after the main turn is gone', async () => {
+    const sessionId = 'fdfdfdfd-fdfd-4fdf-8fdf-fdfdfdfdfdfd';
+    const selection = {
+      connectionId: '11111111-1111-4111-8111-111111111111',
+      modelId: 'vendor/path/model',
+    };
+    mocks.sessionManager._setActive({
+      ...makeSession(sessionId),
+      selection,
+      modelLabel: selection.modelId,
+    });
+    mocks.streamResponses.push('turn finished');
+    const send = vi.fn();
+    const source = { id: 917, send };
+    mocks.sessionManager._setActiveForWindow('917', mocks.sessionManager.getActive()!);
+    mocks.electronWebContents.getAllWebContents.mockReturnValue([source]);
+    const chatSend = mocks.handlers.get(IPC_CHANNELS.CHAT_SEND)!;
+    const chatCancel = mocks.handlers.get(IPC_CHANNELS.CHAT_CANCEL)!;
+
+    await chatSend({ sender: source }, { message: 'Delegate everything' });
+    await waitForChannelCount(send, IPC_CHANNELS.CHAT_DONE, 1);
+    // Let the finalize microtask dispose the ActiveAgent (post-interrupt-reset
+    // state: no live main turn, subagents still running).
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    mocks.subagentManager.getStates.mockReturnValue([
+      { id: 'subagent-1', state: 'running' },
+    ]);
+    mocks.subagentManager.cancelRunning.mockReturnValue(['subagent-1']);
+    expect(await chatCancel({ sender: source }, { sessionId })).toMatchObject({ status: 'confirming_subagents' });
+    expect(mocks.subagentManager.cancelRunning).not.toHaveBeenCalled();
+
+    expect(await chatCancel({ sender: source }, { sessionId })).toMatchObject({ status: 'cancelled' });
+    expect(mocks.subagentManager.cancelRunning).toHaveBeenCalledWith(sessionId);
+    expect(mocks.backgroundStore.terminateSession).toHaveBeenCalledWith(sessionId);
+    expect(mocks.completeSessionActivity).toHaveBeenCalled();
+  });
+
+  it('returns no_active_stream when no main turn and no running subagents exist', async () => {
+    const sessionId = 'd1d1d1d1-d1d1-4d1d-8d1d-d1d1d1d1d1d1';
+    mocks.sessionManager._setActive(makeSession(sessionId));
+    const chatCancel = mocks.handlers.get(IPC_CHANNELS.CHAT_CANCEL)!;
+
+    expect(await chatCancel({ sender: { id: 918, send: vi.fn() } }, { sessionId }))
+      .toMatchObject({ status: 'no_active_stream' });
+    expect(mocks.subagentManager.cancelRunning).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/tests/unit/chat-rendering-contract.test.ts
+++ b/electron/tests/unit/chat-rendering-contract.test.ts
@@ -455,9 +455,11 @@ describe('live command gating (process liveness)', () => {
     expandShell(container);
     await flush();
 
-    expect(container.querySelector('.orchid-live-command')).toBeTruthy();
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeTruthy();
     expect(container.querySelector('.orchid-tool-running-hint')).toBeNull();
-    expect(api.snapshot).toHaveBeenCalledWith({ commandId: 42, lastN: 50, sessionId: 'sess-1', includeTail: false });
+    // Embedded widgets mount only while the shell is expanded, so the tail is
+    // requested alongside the status poll.
+    expect(api.snapshot).toHaveBeenCalledWith({ commandId: 42, lastN: 50, sessionId: 'sess-1', includeTail: true });
   });
 
   it('renders a foreground live widget keyed by the tool call id while running', async () => {
@@ -477,9 +479,13 @@ describe('live command gating (process liveness)', () => {
     expandShell(container);
     await flush();
 
-    expect(container.querySelector('.orchid-live-command')).toBeTruthy();
+    // Embedded (issue #160): no second toggle header — the shell title carries
+    // the description and the widget renders its body only.
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeTruthy();
+    expect(container.querySelector('.orchid-live-command-title')).toBeNull();
+    expect(container.querySelector('.orchid-tool-block-title')?.textContent).toContain('wait for it');
+    expect(container.querySelector('.orchid-tool-block-title')?.textContent).not.toContain('sleep 30');
     expect(container.querySelector('.orchid-tool-running-hint')).toBeNull();
-    expect(container.querySelector('.orchid-live-command-title')?.textContent).toContain('wait for it');
     expect(api.snapshot).toHaveBeenCalledTimes(1);
     expect(api.snapshot).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'call-fg-1', lastN: 50, sessionId: 'sess-2' }));
   });
@@ -509,6 +515,7 @@ describe('live command gating (process liveness)', () => {
 
     expect(container.querySelector('[data-result-family="generic"]')).toBeTruthy();
     expect(container.querySelector('.orchid-live-command')).toBeNull();
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeNull();
     expect(api.snapshot).not.toHaveBeenCalled();
   });
 
@@ -530,9 +537,10 @@ describe('live command gating (process liveness)', () => {
 
     expect(container.querySelector('.orchid-tool-running-hint')?.textContent).toContain('Running');
     expect(container.querySelector('.orchid-live-command')).toBeNull();
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeNull();
   });
 
-  it('does not collapse the shell when toggling the live widget itself', async () => {
+  it('does not collapse the shell when clicking inside the embedded live widget', async () => {
     installBgCmd();
     const { container } = render(
       createElement(ToolCallBlock, { block: backgroundResultBlock('bg-stop-prop'), sessionId: 'sess-5' }),
@@ -543,12 +551,11 @@ describe('live command gating (process liveness)', () => {
     const shellTitle = container.querySelector('.orchid-tool-block-title') as HTMLElement;
     expect(shellTitle.getAttribute('aria-expanded')).toBe('true');
 
-    const widgetTitle = container.querySelector('.orchid-live-command-title') as HTMLElement;
-    fireEvent.click(widgetTitle);
+    const widgetBody = container.querySelector('.orchid-live-command-embedded') as HTMLElement;
+    fireEvent.click(widgetBody);
     await flush();
 
-    // The widget toggled its own disclosure open; the outer shell stayed open.
-    expect(widgetTitle.getAttribute('aria-expanded')).toBe('true');
+    // The click inside the widget never collapsed the outer shell.
     expect(
       container.querySelector('.orchid-tool-block-title')?.getAttribute('aria-expanded'),
     ).toBe('true');
@@ -573,7 +580,7 @@ describe('live command gating (process liveness)', () => {
     expandShell(container);
     await flush();
 
-    expect(container.querySelector('.orchid-live-command')).toBeTruthy();
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeTruthy();
     expect(container.querySelector('.orchid-tool-running-hint')).toBeNull();
     const callsAfterMount = api.snapshot.mock.calls.length;
     expect(callsAfterMount).toBeGreaterThanOrEqual(1);
@@ -606,7 +613,7 @@ describe('live command gating (process liveness)', () => {
     });
 
     // Live widget unmounted, canonical result rendered instead.
-    expect(container.querySelector('.orchid-live-command')).toBeNull();
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeNull();
     expect(container.querySelector('[data-result-family="generic"]')).toBeTruthy();
     // Generic canonical value is rendered as the tool stdout.
     expect(container.textContent).toContain('PASS 2/2 tests');

--- a/electron/tests/unit/subagent-transcript-session.test.tsx
+++ b/electron/tests/unit/subagent-transcript-session.test.tsx
@@ -137,7 +137,7 @@ describe('SubagentTranscript live-command session wiring', () => {
       await Promise.resolve();
     });
 
-    expect(container.querySelector('.orchid-live-command')).toBeTruthy();
+    expect(container.querySelector('.orchid-live-command-embedded')).toBeTruthy();
     expect(snapshot).toHaveBeenCalledWith(
       expect.objectContaining({ commandId: 42, sessionId: 'session-1' }),
     );

--- a/electron/tests/unit/tool-title.test.ts
+++ b/electron/tests/unit/tool-title.test.ts
@@ -22,7 +22,7 @@ describe('tool widget titles', () => {
     expect(toolTitleText(title)).toBe('Preparing to run $ npm test -- --run tests/integration/renderer-style-contract.test.ts');
   });
 
-  it('shows the description and full command while execute_command is running', () => {
+  it('shows only the description while execute_command is running (command lives in the widget body)', () => {
     const title = buildToolTitle({
       toolName: 'execute_command',
       status: 'running',
@@ -33,9 +33,7 @@ describe('tool widget titles', () => {
       partialArgs: '',
     });
 
-    expect(toolTitleText(title)).toBe(
-      'Running renderer tests · $ npm test -- --run tests/integration/renderer-style-contract.test.ts',
-    );
+    expect(toolTitleText(title)).toBe('Running renderer tests');
   });
 
   it('uses the assigned subagent names for wait_for_subagent', () => {


### PR DESCRIPTION
## Summary

Two bug fixes, one per issue.

### Esc no longer kills subagents and layer 3 stays reachable (Zeptiny/orchid#145)

**Before:** pressing Esc twice to stop the main agent also killed every running subagent — their background commands were terminated session-wide even though subagents themselves were only supposed to die on the third, deliberate Esc. Worse, if you hesitated more than 5s on the "Cancel subagents?" prompt, the interrupt state auto-reset and disposed the turn: Esc then did nothing, and the only way to stop still-running subagents was the unconditional Activity stop.

**Now:**
- The second Esc terminates only the main agent's own processes (`terminateScope`/`dropScope` with `main`), so subagent-owned commands keep running until the third Esc confirms subagent cancellation.
- A standalone subagent-only cancel flow keeps layer 3 alive indefinitely: when no main-agent turn exists but the session owns queued/running subagents, the first Esc stages the confirmation and the next cancels them and their processes. The stage expires after 5s (mirroring the interrupt machine) so a late Esc re-confirms instead of firing the destructive cancel; a new main turn clears it.
- Renderer hardening: Esc presses staged while a cancel IPC is in flight are discarded once the `confirming_subagents` phase is reached, so mashing Esc can no longer run all three layers in one burst — cancelling subagents always requires a deliberate fresh keypress.
- Esc now reaches chat cancellation while queued/running subagents exist even with no live main-agent turn (composer Escape gate learns about running subagents via the existing subagent stream state).

### Single dropdown on running commands; no command echoed in the title (Zeptiny/orchid#160)

**Before:** a running/replayed `execute_command` widget showed two stacked collapsible headers — the tool shell's disclosure and the embedded live-command card's own toggle — and the shell title read "Running renderer tests · $ npm test …".

**Now:** live command widgets render headerless (body only) inside tool-result shells, so the shell's chevron is the single expand/collapse control; the sidebar Commands section keeps its standalone collapsible card. Running/generating titles show just the description (the command remains the fallback when no description exists and stays visible inside the expanded body).

## Test plan

- `chat-ipc.test.ts`: second Esc asserts `terminateScope(sessionId, 'main')` and no `terminateSession`/`cancelRunning`; standalone flow asserts `confirming_subagents` → `cancelled` after the main turn is disposed, and `no_active_stream` when nothing runs.
- `chat-cancel-gates.test.ts` (new): cancel-queue drain/discard semantics and the Escape resolver's running-subagents gate (question/slash/settings precedence intact).
- Renderer contract tests updated for the embedded widget (no second toggle, tail requested while expanded, exit code surfaced in the body) and the trimmed running title.
- Full suite: 4598 tests passing; typecheck, lint, and runtime-cycle check clean.
