### PR TITLE
fix(accounting): extract generic usage-body cost for compatible providers

### DIFF
--- a/electron/src/main/providers/drivers/compatible.ts
+++ b/electron/src/main/providers/drivers/compatible.ts
@@ -133,6 +133,16 @@ function record(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+/** HTTP header names are case-insensitive; the middleware lowercases but the facet contract does not guarantee it. */
+function headerValue(headers: Readonly<Record<string, string>>, name: string): string | undefined {
+  const direct = headers[name];
+  if (direct !== undefined) return direct;
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === name) return value;
+  }
+  return undefined;
+}
+
 /**
  * Extract the de-facto usage-body cost convention shared by OpenAI-compatible
  * gateways (OpenRouter, Surplus Intelligence, Requesty, …): `usage.cost` (or
@@ -147,7 +157,7 @@ export function extractGenericUsageCostEvidence(
 ): GenericUsageCostEvidence {
   const usage = record(rawUsage);
   const bodyCost = decimalText(usage?.cost) ?? decimalText(usage?.cost_usd);
-  const headerCost = decimalText(headers['x-request-cost-usd']);
+  const headerCost = decimalText(headerValue(headers, 'x-request-cost-usd'));
   const costDetails = record(usage?.cost_details);
   return {
     reportedCostUsd: bodyCost ?? headerCost,

--- a/electron/src/main/providers/drivers/compatible.ts
+++ b/electron/src/main/providers/drivers/compatible.ts
@@ -12,7 +12,7 @@ import {
   OPENAI_RESPONSES_THINKING_POLICY,
 } from '../facets/thinking';
 import { fetchModelsEndpoint, modelsListEntries } from './models-endpoint';
-import type { DriverCredential, ProviderDriver, ReasoningProviderOptions } from './types';
+import type { DriverCostEvidence, DriverCredential, DriverPricingFacet, ProviderDriver, ReasoningProviderOptions } from './types';
 
 export interface GenericEndpoint {
   readonly endpoint: string;
@@ -111,6 +111,70 @@ function apiKeyForEmbedding(credential: DriverCredential): string | undefined {
   return undefined;
 }
 
+export interface GenericUsageCostEvidence {
+  /** Usage-body request charge in USD; U7 gives this precedence over formulae. */
+  readonly reportedCostUsd: string | undefined;
+  /** Informational per-field cost breakdown when the gateway provides one. */
+  readonly costDetails: Readonly<Record<string, unknown>> | undefined;
+}
+
+function decimalText(value: unknown): string | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value >= 0 ? String(value) : undefined;
+  }
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return /^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(trimmed) ? trimmed : undefined;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+/**
+ * Extract the de-facto usage-body cost convention shared by OpenAI-compatible
+ * gateways (OpenRouter, Surplus Intelligence, Requesty, …): `usage.cost` (or
+ * the `cost_usd` variant), denominated in USD. The `x-request-cost-usd`
+ * header remains the fallback so a facet extraction never clobbers
+ * header-derived evidence. Undocumented shapes stay undefined so accounting
+ * records unknown rather than a guess.
+ */
+export function extractGenericUsageCostEvidence(
+  headers: Readonly<Record<string, string>>,
+  rawUsage: unknown,
+): GenericUsageCostEvidence {
+  const usage = record(rawUsage);
+  const bodyCost = decimalText(usage?.cost) ?? decimalText(usage?.cost_usd);
+  const headerCost = decimalText(headers['x-request-cost-usd']);
+  const costDetails = record(usage?.cost_details);
+  return {
+    reportedCostUsd: bodyCost ?? headerCost,
+    // Clone so the ledger sanitizer never sees the same object twice (the raw
+    // usage graph is persisted separately as providerEvidence.rawUsage).
+    costDetails: costDetails ? { ...costDetails } : undefined,
+  };
+}
+
+function genericUsageCostPricingFacet(): DriverPricingFacet {
+  return {
+    costEvidence: ({ headers, rawUsage }): DriverCostEvidence => {
+      const generic = extractGenericUsageCostEvidence(headers, rawUsage);
+      return {
+        ...(generic.reportedCostUsd ? {
+          reportedCostAmount: generic.reportedCostUsd,
+          reportedCurrency: 'USD',
+        } : {}),
+        providerEvidence: {
+          ...(generic.reportedCostUsd ? { reportedUsageCostUsd: generic.reportedCostUsd } : {}),
+          ...(generic.costDetails ? { costDetails: generic.costDetails } : {}),
+        },
+      };
+    },
+  };
+}
+
 /**
  * A user-configured OpenAI-compatible endpoint is treated as ids-only:
  * nothing beyond the id is trusted from an unverified shape (R27).
@@ -179,6 +243,7 @@ export function createCompatibleProviderDrivers(options: {
       // default plain-text policy.
       thinkingPolicy: (model: EffectiveModel): ThinkingPolicy | undefined =>
         model.protocol === 'openai-responses' ? OPENAI_RESPONSES_THINKING_POLICY : undefined,
+      pricingFacet: genericUsageCostPricingFacet(),
       discoveryFacet: {
         fetchModels: async ({ connection, credential, endpoint }) => {
           if (!endpoint) throw new Error('Generic OpenAI-compatible connection requires an endpoint');
@@ -208,6 +273,7 @@ export function createCompatibleProviderDrivers(options: {
         });
       },
       thinkingPolicy: (): ThinkingPolicy => ANTHROPIC_THINKING_POLICY,
+      pricingFacet: genericUsageCostPricingFacet(),
     },
   ];
 }

--- a/electron/tests/integration/provider-attempt-accounting.test.ts
+++ b/electron/tests/integration/provider-attempt-accounting.test.ts
@@ -534,6 +534,61 @@ describe('provider attempt accounting middleware', () => {
     ledger.close();
   });
 
+  it('records the generic usage-body cost report through the compatible driver facet', async () => {
+    const ledger = store();
+    const { createCompatibleProviderDrivers } = await import('../../src/main/providers/drivers/compatible');
+    const facet = createCompatibleProviderDrivers()[0].pricingFacet;
+    const genericSnapshot = snapshot();
+    genericSnapshot.providerId = 'generic-openai-compatible';
+    genericSnapshot.protocol = 'openai-compatible';
+    const middleware = createAttemptAccountingMiddleware({
+      store: ledger, sessionId: 'session-1', chainId: 'chain-1', turnId: 'turn-1',
+      snapshot: genericSnapshot,
+      pricingFacet: facet,
+    });
+    const wrapStream = middleware.wrapStream! as unknown as (input: Record<string, unknown>) => Promise<{ stream: ReadableStream<unknown> }>;
+    const result = await wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'finish', finishReason: 'stop',
+              usage: {
+                inputTokens: { total: 15, noCache: 15, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: 16, text: 16, reasoning: undefined },
+                raw: {
+                  prompt_tokens: 15,
+                  completion_tokens: 16,
+                  cost: 0.0000914,
+                  cost_details: { upstream_inference_cost: 0.0000914 },
+                },
+              },
+            });
+            controller.close();
+          },
+        }),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params: {}, model: {},
+    });
+    await consume(result.stream);
+
+    expect(ledger.listAttempts('session-1')[0]).toMatchObject({
+      outcome: 'succeeded',
+      costState: 'reported',
+      costSource: 'provider-reported',
+      costAmount: '0.0000914',
+      providerEvidence: {
+        'generic-openai-compatible': {
+          reportedUsageCostUsd: '0.0000914',
+          costDetails: { upstream_inference_cost: 0.0000914 },
+        },
+      },
+    });
+    ledger.close();
+  });
+
   it('captures the provider-reported service tier for parameter mechanisms (R22)', async () => {
     const ledger = store();
     const tiered = snapshot();

--- a/electron/tests/unit/provider-generic-usage-cost.test.ts
+++ b/electron/tests/unit/provider-generic-usage-cost.test.ts
@@ -48,6 +48,14 @@ describe('generic usage-body cost evidence', () => {
     ).toBe('0.0000914');
   });
 
+  it('reads the cost header regardless of its casing', async () => {
+    const { extractGenericUsageCostEvidence } = await import('../../src/main/providers/drivers/compatible');
+
+    expect(
+      extractGenericUsageCostEvidence({ 'X-Request-Cost-USD': '0.0042' }, {}).reportedCostUsd,
+    ).toBe('0.0042');
+  });
+
   it('declares the facet on both generic compatible drivers', async () => {
     const { createCompatibleProviderDrivers } = await import('../../src/main/providers/drivers/compatible');
 

--- a/electron/tests/unit/provider-generic-usage-cost.test.ts
+++ b/electron/tests/unit/provider-generic-usage-cost.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+describe('generic usage-body cost evidence', () => {
+  it('extracts the OpenRouter-style usage cost as a USD provider report', async () => {
+    const { extractGenericUsageCostEvidence } = await import('../../src/main/providers/drivers/compatible');
+
+    const evidence = extractGenericUsageCostEvidence({}, {
+      prompt_tokens: 15,
+      completion_tokens: 16,
+      total_tokens: 31,
+      cost: 0.0000914,
+      cost_details: { upstream_inference_cost: 0.0000914 },
+    });
+
+    expect(evidence.reportedCostUsd).toBe('0.0000914');
+    expect(evidence.costDetails).toMatchObject({ upstream_inference_cost: 0.0000914 });
+  });
+
+  it('accepts string costs and the cost_usd variant', async () => {
+    const { extractGenericUsageCostEvidence } = await import('../../src/main/providers/drivers/compatible');
+
+    expect(extractGenericUsageCostEvidence({}, { cost: '0.0012' }).reportedCostUsd).toBe('0.0012');
+    expect(extractGenericUsageCostEvidence({}, { cost_usd: 2.5 }).reportedCostUsd).toBe('2.5');
+  });
+
+  it('keeps a zero charge as an authoritative report', async () => {
+    const { extractGenericUsageCostEvidence } = await import('../../src/main/providers/drivers/compatible');
+
+    expect(extractGenericUsageCostEvidence({}, { cost: 0 }).reportedCostUsd).toBe('0');
+  });
+
+  it('ignores undocumented shapes instead of guessing a cost', async () => {
+    const { extractGenericUsageCostEvidence } = await import('../../src/main/providers/drivers/compatible');
+
+    expect(extractGenericUsageCostEvidence({}, { cost: -1 }).reportedCostUsd).toBeUndefined();
+    expect(extractGenericUsageCostEvidence({}, { cost: 'free' }).reportedCostUsd).toBeUndefined();
+    expect(extractGenericUsageCostEvidence({}, { cost: { usd: 1 } }).reportedCostUsd).toBeUndefined();
+    expect(extractGenericUsageCostEvidence({}, 'usage-text').reportedCostUsd).toBeUndefined();
+    expect(extractGenericUsageCostEvidence({}, undefined).reportedCostUsd).toBeUndefined();
+  });
+
+  it('falls back to the allowlisted cost header and lets the usage body win', async () => {
+    const { extractGenericUsageCostEvidence } = await import('../../src/main/providers/drivers/compatible');
+
+    expect(extractGenericUsageCostEvidence({ 'x-request-cost-usd': '0.0042' }, {}).reportedCostUsd).toBe('0.0042');
+    expect(
+      extractGenericUsageCostEvidence({ 'x-request-cost-usd': '0.0042' }, { cost: 0.0000914 }).reportedCostUsd,
+    ).toBe('0.0000914');
+  });
+
+  it('declares the facet on both generic compatible drivers', async () => {
+    const { createCompatibleProviderDrivers } = await import('../../src/main/providers/drivers/compatible');
+
+    for (const driver of createCompatibleProviderDrivers()) {
+      const extracted = driver.pricingFacet?.costEvidence?.({
+        headers: {},
+        rawUsage: { cost: 0.0000914, cost_details: { upstream_inference_cost: 0.0000914 } },
+      });
+      expect(extracted).toMatchObject({
+        reportedCostAmount: '0.0000914',
+        reportedCurrency: 'USD',
+        providerEvidence: { reportedUsageCostUsd: '0.0000914' },
+      });
+    }
+  });
+
+  it('omits the report when neither body nor header carries a usable cost', async () => {
+    const { createCompatibleProviderDrivers } = await import('../../src/main/providers/drivers/compatible');
+    const facet = createCompatibleProviderDrivers()[0].pricingFacet;
+
+    const extracted = facet?.costEvidence?.({ headers: {}, rawUsage: { prompt_tokens: 15 } });
+    expect(extracted?.reportedCostAmount).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Generic OpenAI/Anthropic-compatible connections now extract the de-facto usage-body cost convention (`usage.cost` / `cost_usd`, OpenRouter-style) into a **provider-reported** cost, which always outranks formula pricing.
- Both generic drivers declare a `pricingFacet.costEvidence` facet: keeps `0` as an authoritative charge, rejects undocumented shapes (so accounting records `unknown` rather than guessing), falls back to the `x-request-cost-usd` header, and persists the `cost_details` breakdown into provider evidence.
- No middleware changes — flows through the existing driver → execution-context wiring (R4 path).

## Why
Previously only the Neuralwatt driver implemented cost-evidence extraction, and the universal path reads only one header. Gateways like OpenRouter, Requesty, and Surplus Intelligence report cost in the response body — that data flowed through the pipeline (`usage.raw`) but nothing read it for generic connections, so costs fell back to formula/`unknown`.

## Testing
- New `tests/unit/provider-generic-usage-cost.test.ts` (7 cases: number/string costs, `cost_usd` variant, zero charge, invalid shapes, header fallback/precedence, facet wiring on both drivers).
- New end-to-end integration case: driver facet + OpenRouter-style streamed `usage.raw` → ledger row `costState: 'reported'`, `costSource: 'provider-reported'`.
- Full provider suite (356 tests), typecheck, lint, runtime-cycle check all green.
- Verified live against `api.surplusintelligence.ai` — note: that gateway strips cost from **streamed** responses entirely (non-streaming bodies carry it), so its streaming attempts still fall back to formula/`unknown`; this fix fully covers gateways that do report cost on streams.

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage-cost reporting for compatible AI providers.
  * Supports provider-reported USD costs, including detailed inference cost information.
  * Recognizes costs from response data and supported cost headers.
  * Available for both OpenAI-compatible and Anthropic-compatible providers.

* **Bug Fixes**
  * Improved accuracy and consistency of provider pricing records, including zero-cost and missing-cost scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->