### PR TITLE
fix(providers): fetch models while adding a connection + model search (#138, #155)

### DIFF
--- a/electron/src/main/ipc/provider-models.ts
+++ b/electron/src/main/ipc/provider-models.ts
@@ -12,11 +12,20 @@ import { ipcMain } from 'electron';
 import { z } from 'zod';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
 import type {
+  ProviderDraftDiscoveryMessage,
+  ProviderDraftDiscoveryResult,
   ProviderDiscoverModelsResult,
   ProviderModelOption,
 } from '../../shared/types/ipc';
 import type { ProviderConnection, ProviderDefinition } from '../../shared/types/provider';
 import {
+  providerAuthMethodSchema,
+  providerEndpointSchema,
+  providerProtocolSchema,
+  environmentVariableSchema,
+} from '../../shared/types/provider';
+import {
+  discoverConnectionModels,
   listConnectionModelRows,
   type ConnectionDiscoveryOutcome,
 } from '../providers/facets/discovery';
@@ -31,6 +40,7 @@ import {
   pricingView,
   readApiKeyForTrustedStatus,
   requireConnection,
+  requireStaticConnectionSupport,
   runConnectionDiscovery,
   services,
   statusView,
@@ -41,6 +51,33 @@ import {
 const modelListSchema = connectionIdSchema.extend({
   includeDisabled: z.boolean().optional(),
 }).strict();
+
+const draftDiscoverySchema = z.object({
+  providerId: z.string().trim().min(1),
+  protocol: providerProtocolSchema,
+  authMethod: providerAuthMethodSchema,
+  endpoint: providerEndpointSchema.nullable().optional(),
+  allowInsecureHttp: z.boolean().optional(),
+  environmentVariable: environmentVariableSchema.optional(),
+  // The value exists only for this validated IPC request. Do not log this
+  // schema error or payload because it may include a usable credential.
+  apiKey: z.string().trim().min(1).max(32_768).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.authMethod === 'environment' && !value.environmentVariable) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['environmentVariable'],
+      message: 'Environment authentication requires an environment variable name',
+    });
+  }
+  if (value.authMethod !== 'environment' && value.environmentVariable !== undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['environmentVariable'],
+      message: 'An environment variable is valid only for environment authentication',
+    });
+  }
+});
 
 // ── Model options ───────────────────────────────────────────────────────────
 
@@ -231,6 +268,78 @@ async function credentialForQuota(
   return { kind: 'api-key', apiKey };
 }
 
+/** Non-persisted live discovery for a connection that does not exist yet (#138). */
+async function discoverDraftModels(
+  input: ProviderDraftDiscoveryMessage,
+  current = services(),
+): Promise<ProviderDraftDiscoveryResult> {
+  const empty: ProviderDraftDiscoveryResult = {
+    status: 'unsupported',
+    models: [],
+    discoveredAt: null,
+    message: null,
+  };
+  const draftConnection = {
+    id: '00000000-0000-4000-8000-000000000002',
+    providerId: input.providerId,
+    name: 'Draft discovery',
+    protocol: input.protocol,
+    authMethod: input.authMethod,
+    credential: input.authMethod === 'environment'
+      ? { kind: 'environment' as const, variable: input.environmentVariable! }
+      : { kind: 'none' as const },
+    modelIds: [],
+    health: 'draft' as const,
+    ...(input.endpoint ? { endpoint: input.endpoint } : {}),
+    ...(input.allowInsecureHttp !== undefined ? { allowInsecureHttp: input.allowInsecureHttp } : {}),
+  } satisfies ProviderConnection;
+  // Same trust boundary as creation: provider, protocol, auth, and endpoint are
+  // validated before any driver code runs. Nothing is persisted afterwards.
+  const check = requireStaticConnectionSupport(draftConnection, current);
+  const credential: DriverCredential | undefined =
+    input.authMethod === 'api-key'
+      ? input.apiKey ? { kind: 'api-key', apiKey: input.apiKey } : undefined
+      : input.authMethod === 'environment'
+        ? process.env[input.environmentVariable!]
+          ? { kind: 'api-key', apiKey: process.env[input.environmentVariable!]! }
+          : undefined
+        : { kind: 'none' };
+  const outcome = await discoverConnectionModels({
+    driver: current.registry.require(check.definition.id),
+    connection: draftConnection,
+    provider: check.definition,
+    credential,
+  });
+  if (outcome.status !== 'ok') {
+    return { ...empty, status: outcome.status, message: draftDiscoveryMessage(outcome) };
+  }
+  return {
+    status: 'ok',
+    models: outcome.discoveredModels.map((model) => modelView({
+      id: model.id,
+      displayName: model.displayName ?? model.id,
+      protocol: model.protocol ?? draftConnection.protocol,
+      ...(model.capabilities ? { capabilities: model.capabilities } : {}),
+      ...(model.limits ? { limits: model.limits } : {}),
+    }, 'provider')),
+    discoveredAt: outcome.discoveredModels[0]?.discoveredAt ?? null,
+    message: draftDiscoveryMessage(outcome),
+  };
+}
+
+function draftDiscoveryMessage(outcome: ConnectionDiscoveryOutcome): string {
+  switch (outcome.status) {
+    case 'ok':
+      return `Fetched ${outcome.discoveredModels.length} model${outcome.discoveredModels.length === 1 ? '' : 's'} from the live endpoint. Select the ones this connection should enable.`;
+    case 'failed':
+      return `Live model discovery failed (${outcome.message}).`;
+    case 'no-credential':
+      return 'Enter a working credential before fetching models.';
+    case 'unsupported':
+      return 'This provider does not publish a models endpoint Orchid can read.';
+  }
+}
+
 // ── Registration ────────────────────────────────────────────────────────────
 
 export function registerProviderModelsIPC(): void {
@@ -269,6 +378,12 @@ export function registerProviderModelsIPC(): void {
     });
   });
 
+  ipcMain.handle(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS, async (_event, payload: unknown) => {
+    const parsed = draftDiscoverySchema.safeParse(payload);
+    if (!parsed.success) throw new Error('Invalid providers:discover_draft_models payload');
+    return discoverDraftModels(parsed.data);
+  });
+
   ipcMain.handle(IPC_CHANNELS.PROVIDERS_QUOTA_REFRESH, async (_event, payload: unknown) => {
     const parsed = connectionIdSchema.safeParse(payload);
     if (!parsed.success) throw new Error('Invalid providers:quota_refresh payload');
@@ -280,5 +395,6 @@ export function registerProviderModelsIPC(): void {
 export function unregisterProviderModelsIPC(): void {
   ipcMain.removeHandler(IPC_CHANNELS.PROVIDERS_MODEL_LIST);
   ipcMain.removeHandler(IPC_CHANNELS.PROVIDERS_DISCOVER_MODELS);
+  ipcMain.removeHandler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS);
   ipcMain.removeHandler(IPC_CHANNELS.PROVIDERS_QUOTA_REFRESH);
 }

--- a/electron/src/main/ipc/providers.ts
+++ b/electron/src/main/ipc/providers.ts
@@ -492,7 +492,8 @@ interface StaticConnectionCheck {
   readonly orphanedModelIds: readonly string[];
 }
 
-function requireStaticConnectionSupport(
+/** Shared static gate for persisted and draft connections alike. */
+export function requireStaticConnectionSupport(
   connection: ProviderConnection,
   current = services(),
 ): StaticConnectionCheck {
@@ -708,12 +709,16 @@ async function stopProviderConnectionTurns(
 
 // ── Live model discovery ────────────────────────────────────────────────────
 
-/** Resolve the request credential for one discovery fetch; undefined when unusable. */
+/**
+ * Resolve the request credential for one discovery fetch. `none`-auth
+ * connections fetch unauthenticated (local compatible endpoints commonly serve
+ * /models without auth); undefined means no usable credential right now.
+ */
 export async function discoveryCredential(
   connection: ProviderConnection,
   current: ProviderIPCServices,
 ): Promise<DriverCredential | undefined> {
-  if (connection.authMethod === 'none') return undefined;
+  if (connection.authMethod === 'none') return { kind: 'none' };
   if (connection.credential.kind === 'environment') {
     const apiKey = process.env[connection.credential.variable];
     return apiKey ? { kind: 'api-key', apiKey } : undefined;

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -44,6 +44,7 @@ import type {
   ProviderConnectionIdMessage,
   ProviderDisconnectMessage,
   ProviderDeleteConnectionMessage,
+  ProviderDraftDiscoveryMessage,
   ProviderModelListMessage,
   ProviderStatusRefreshMessage,
   SessionLoadMessage,
@@ -445,6 +446,9 @@ const orchidAPI: OrchidAPI = {
 
     discoverModels: (message: ProviderConnectionIdMessage) =>
       invoke(IPC_CHANNELS.PROVIDERS_DISCOVER_MODELS, message),
+
+    discoverDraftModels: (message: ProviderDraftDiscoveryMessage) =>
+      invoke(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS, message),
 
     refreshStatus: (message: ProviderStatusRefreshMessage) =>
       invoke(IPC_CHANNELS.PROVIDERS_STATUS_REFRESH, message),

--- a/electron/src/renderer/components/Onboarding/OnboardingScreen.tsx
+++ b/electron/src/renderer/components/Onboarding/OnboardingScreen.tsx
@@ -796,6 +796,7 @@ export function OnboardingScreen({ isOpen, onComplete, onSkip }: OnboardingScree
           onCreate={providers.createConnection}
           onSubmitApiKey={providers.submitApiKey}
           onValidate={providers.validateConnection}
+          onDiscoverDraftModels={providers.discoverDraftModels}
           onComplete={handleProviderComplete}
         />
       )}

--- a/electron/src/renderer/components/Preferences/ProvidersTab.tsx
+++ b/electron/src/renderer/components/Preferences/ProvidersTab.tsx
@@ -100,6 +100,7 @@ export function ProvidersTab({ onNotify }: { readonly onNotify: Notify }) {
         onSubmitApiKey={providers.submitApiKey}
         onValidate={providers.validateConnection}
         onDiscoverModels={providers.discoverModels}
+        onDiscoverDraftModels={providers.discoverDraftModels}
         onListModels={providers.modelList}
         onComplete={completeConnection}
       />

--- a/electron/src/renderer/components/Providers/ConnectionModelsDialog.tsx
+++ b/electron/src/renderer/components/Providers/ConnectionModelsDialog.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from 'react';
 import type {
   ProviderConnectionView,
   ProviderDefinitionView,
-  ProviderDiscoverModelsResult,
   ProviderModelOption,
   ProviderModelView,
 } from '../../../shared/types/ipc';
@@ -13,6 +12,7 @@ import type {
   ReasoningModelConfig,
 } from '../../../shared/types/provider';
 import type { PricingRateFields } from '../../../shared/types/provider-facets';
+import { fuzzyMatch } from '../../../shared/commands';
 import {
   CONNECTION_MODEL_MODALITIES,
   connectionModelCapabilities,
@@ -97,9 +97,17 @@ export interface ConnectionModelsEditorProps {
   readonly disabled?: boolean;
   /** Unified listing rows from the main process (edit mode); locally composed when absent. */
   readonly unifiedModels?: readonly ProviderModelOption[] | null;
+  /**
+   * Live rows fetched while the connection does not exist yet (#138); merged as
+   * provider rows below catalog and custom models.
+   */
+  readonly previewModels?: readonly ProviderModelView[] | null;
+  /** When the live endpoint published `previewModels`; drives the discovered badge. */
+  readonly previewDiscoveredAt?: string | null;
   readonly discoveryAvailable?: boolean;
   readonly discovering?: boolean;
-  readonly onDiscoverModels?: () => Promise<ProviderDiscoverModelsResult>;
+  /** Runs one live fetch; only the surfaced message is consumed here. */
+  readonly onDiscoverModels?: () => Promise<{ readonly message: string | null }>;
   readonly onSelectedModelIdsChange: (modelIds: readonly string[]) => void;
   readonly onCustomModelsChange: (models: readonly CustomConnectionModel[]) => void;
   readonly onReasoningConfigChange: (config: Record<string, ReasoningModelConfig>) => void;
@@ -275,6 +283,8 @@ export function ConnectionModelsEditor({
   tierSelections = {},
   disabled = false,
   unifiedModels = null,
+  previewModels = null,
+  previewDiscoveredAt = null,
   discoveryAvailable = false,
   discovering = false,
   onDiscoverModels,
@@ -291,6 +301,7 @@ export function ConnectionModelsEditor({
   const [pricingDraft, setPricingDraft] = useState(EMPTY_PRICING_DRAFT);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [modelQuery, setModelQuery] = useState('');
 
   const catalogModels = useMemo(
     () => definition.models.filter(
@@ -303,7 +314,7 @@ export function ConnectionModelsEditor({
     [catalogModels],
   );
 
-  const rows = useMemo<readonly EditorModelRow[]>(() => {
+  const baseRows = useMemo<readonly EditorModelRow[]>(() => {
     const overrideView = (
       view: ProviderModelView,
       override: CustomConnectionModel | undefined,
@@ -383,16 +394,45 @@ export function ConnectionModelsEditor({
     return local;
   }, [unifiedModels, catalogModels, catalogModelIds, customModels]);
 
+  // Preview rows fetched before the connection exists (#138) layer under catalog
+  // and custom models; ids already listed keep their existing metadata.
+  const rows = useMemo<readonly EditorModelRow[]>(() => {
+    if (!previewModels || previewModels.length === 0) return baseRows;
+    const present = new Set(baseRows.map((row) => row.view.id));
+    const appended = previewModels
+      .filter((model) => !present.has(model.id) && modelAvailable(model))
+      .map((model) => ({
+        view: model,
+        source: 'provider' as const,
+        customized: false,
+        discoveredAt: previewDiscoveredAt,
+        removable: false,
+      }));
+    return appended.length > 0 ? [...baseRows, ...appended] : baseRows;
+  }, [baseRows, previewModels, previewDiscoveredAt]);
+
+  const normalizedQuery = modelQuery.trim().toLowerCase();
+  const filteredRows = useMemo(() => {
+    if (!normalizedQuery) return rows;
+    return rows.filter((row) =>
+      fuzzyMatch(normalizedQuery, row.view.displayName) >= 0
+      || fuzzyMatch(normalizedQuery, row.view.id) >= 0);
+  }, [rows, normalizedQuery]);
+
   const selectableModelIds = useMemo(
     () => rows.map((row) => row.view.id),
     [rows],
+  );
+  const visibleModelIds = useMemo(
+    () => filteredRows.map((row) => row.view.id),
+    [filteredRows],
   );
   const discoveredRowIds = useMemo(
     () => new Set(rows.filter((row) => row.discoveredAt !== null).map((row) => row.view.id)),
     [rows],
   );
-  const allModelsSelected = selectableModelIds.length > 0
-    && selectableModelIds.every((modelId) => selectedModelIds.includes(modelId));
+  const allModelsSelected = visibleModelIds.length > 0
+    && visibleModelIds.every((modelId) => selectedModelIds.includes(modelId));
   const orphanModelIds = selectedModelIds.filter(
     (modelId) => !selectableModelIds.includes(modelId),
   );
@@ -416,7 +456,16 @@ export function ConnectionModelsEditor({
   };
 
   const toggleAllModels = () => {
-    onSelectedModelIdsChange(allModelsSelected ? [] : selectableModelIds);
+    // With an active search, select-all touches only the visible rows so a
+    // filtered view never silently changes hidden selections (#155).
+    if (allModelsSelected) {
+      const visible = new Set(visibleModelIds);
+      onSelectedModelIdsChange(
+        selectedModelIds.filter((modelId) => !visible.has(modelId)),
+      );
+      return;
+    }
+    onSelectedModelIdsChange([...new Set([...selectedModelIds, ...visibleModelIds])]);
   };
 
   const startAddingCustomModel = () => {
@@ -647,7 +696,7 @@ export function ConnectionModelsEditor({
                       variant="ghost"
                       size="sm"
                       onClick={toggleAllModels}
-                      disabled={disabled || editingCustomModelId !== null || selectableModelIds.length === 0}
+                      disabled={disabled || editingCustomModelId !== null || visibleModelIds.length === 0}
                       aria-pressed={allModelsSelected}
                     >
                       {allModelsSelected ? 'Deselect all models' : 'Select all models'}
@@ -673,13 +722,30 @@ export function ConnectionModelsEditor({
               {notice && (
                 <Alert tone="info" role="status" icon="alertCircle" aria-live="polite">{notice}</Alert>
               )}
+              {(rows.length > 8 || modelQuery !== '') && (
+                <TextInput
+                  id="connection-models-search"
+                  aria-label="Search models"
+                  bordered={false}
+                  className="w-full"
+                  type="search"
+                  value={modelQuery}
+                  onChange={(event) => setModelQuery(event.target.value)}
+                  placeholder={`Search ${rows.length} models by name or id…`}
+                  disabled={disabled || editingCustomModelId !== null}
+                />
+              )}
               {rows.length === 0 ? (
                 <Alert tone="info" role="status" icon="cpu">
                   No models are available for this connection protocol.
                 </Alert>
+              ) : filteredRows.length === 0 ? (
+                <Alert tone="info" role="status" icon="search">
+                  No models match “{modelQuery.trim()}”. Clear the search to see all {rows.length}.
+                </Alert>
               ) : (
                 <ul className="list max-h-96 overflow-y-auto rounded-box border border-base-300 bg-base-100">
-                  {rows.map((row) => {
+                  {filteredRows.map((row) => {
                     const selected = selectedModelIds.includes(row.view.id);
                     return (
                       <li

--- a/electron/src/renderer/components/Providers/ConnectionWizard.tsx
+++ b/electron/src/renderer/components/Providers/ConnectionWizard.tsx
@@ -12,6 +12,8 @@ import type {
   ProviderConnectionUpdateMessage,
   ProviderConnectionView,
   ProviderDefinitionView,
+  ProviderDraftDiscoveryMessage,
+  ProviderDraftDiscoveryResult,
   ProviderDiscoverModelsResult,
   ProviderModelListMessage,
   ProviderModelOption,
@@ -69,6 +71,10 @@ export interface ConnectionWizardProps {
   readonly onDiscoverModels?: (
     message: ProviderConnectionIdMessage,
   ) => Promise<ProviderDiscoverModelsResult>;
+  /** Draft live discovery while the connection does not exist yet (#138). */
+  readonly onDiscoverDraftModels?: (
+    message: ProviderDraftDiscoveryMessage,
+  ) => Promise<ProviderDraftDiscoveryResult>;
   /** Unified per-connection listing used by the models editor in edit mode. */
   readonly onListModels?: (
     message: ProviderModelListMessage,
@@ -105,6 +111,26 @@ function describeError(error: unknown): string {
 }
 
 /**
+ * Identifies the draft inputs a preview was fetched against; a preview whose
+ * key no longer matches the form is inert (#138).
+ */
+function draftFetchKey(input: {
+  readonly providerId: string | undefined;
+  readonly protocol: ProviderProtocol;
+  readonly authMethod: ProviderAuthMethod;
+  readonly endpoint: string;
+  readonly allowInsecureHttp: boolean;
+}): string {
+  return [
+    input.providerId ?? '',
+    input.protocol,
+    input.authMethod,
+    input.endpoint,
+    input.allowInsecureHttp ? '1' : '0',
+  ].join('|');
+}
+
+/**
  * A keyboard-first modal that creates or edits one complete connection.
  * It intentionally does not offer credential-handle editing.
  */
@@ -119,6 +145,7 @@ export function ConnectionWizard({
   onSubmitApiKey,
   onValidate,
   onDiscoverModels,
+  onDiscoverDraftModels,
   onListModels,
   onComplete,
 }: ConnectionWizardProps) {
@@ -145,6 +172,11 @@ export function ConnectionWizard({
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [unifiedModels, setUnifiedModels] = useState<readonly ProviderModelOption[] | null>(null);
+  const [preview, setPreview] = useState<{
+    readonly key: string;
+    readonly models: readonly ProviderModelView[];
+    readonly discoveredAt: string | null;
+  } | null>(null);
   const [discovering, setDiscovering] = useState(false);
 
   const availableDefinitions = useMemo(
@@ -179,6 +211,15 @@ export function ConnectionWizard({
       || endpointChanged
   );
   const metadataLocked = submitting || (pendingConnection !== null && !existingConnection);
+  const activeDraftKey = draftFetchKey({
+    providerId: selectedDefinition?.id,
+    protocol,
+    authMethod,
+    endpoint: supportsCustomEndpoint ? endpoint.trim() : '',
+    allowInsecureHttp: supportsCustomEndpoint && allowInsecureHttp,
+  });
+  /** Live preview rows for exactly the current draft inputs, else null (#138). */
+  const activePreview = !existingConnection && preview?.key === activeDraftKey ? preview : null;
 
   const resetForDefinition = useCallback((definition: ProviderDefinitionView | undefined) => {
     const nextProtocol = defaultProtocol(definition);
@@ -197,6 +238,7 @@ export function ConnectionWizard({
     setEnvironmentVariable('');
     setApiKey('');
     setPendingConnection(null);
+    setPreview(null);
     setFeedback(null);
     setError(null);
   }, []);
@@ -251,19 +293,67 @@ export function ConnectionWizard({
     };
   }, [isOpen, existingConnection, onListModels]);
 
-  const discoverModels = useCallback(async (): Promise<ProviderDiscoverModelsResult> => {
-    if (!existingConnection || !onDiscoverModels) {
-      throw new Error('Live model discovery is unavailable for this connection.');
+  const discoverModels = useCallback(async (): Promise<{ message: string | null }> => {
+    if (existingConnection && onDiscoverModels) {
+      setDiscovering(true);
+      try {
+        const result = await onDiscoverModels({ connectionId: existingConnection.id });
+        if (result.status === 'ok') await refreshUnifiedModels(existingConnection.id);
+        return result;
+      } finally {
+        setDiscovering(false);
+      }
     }
-    setDiscovering(true);
-    try {
-      const result = await onDiscoverModels({ connectionId: existingConnection.id });
-      if (result.status === 'ok') await refreshUnifiedModels(existingConnection.id);
-      return result;
-    } finally {
-      setDiscovering(false);
+    if (!existingConnection && onDiscoverDraftModels && selectedDefinition) {
+      if (authMethod === 'environment' && !environmentVariable.trim()) {
+        throw new Error('Enter the environment variable that holds the provider credential before fetching models.');
+      }
+      const fetchKey = draftFetchKey({
+        providerId: selectedDefinition.id,
+        protocol,
+        authMethod,
+        endpoint: supportsCustomEndpoint ? endpoint.trim() : '',
+        allowInsecureHttp: supportsCustomEndpoint && allowInsecureHttp,
+      });
+      setDiscovering(true);
+      try {
+        const result: ProviderDraftDiscoveryResult = await onDiscoverDraftModels({
+          providerId: selectedDefinition.id,
+          protocol,
+          authMethod,
+          ...(supportsCustomEndpoint && endpoint.trim()
+            ? { endpoint: endpoint.trim(), allowInsecureHttp }
+            : {}),
+          ...(authMethod === 'environment' && environmentVariable.trim()
+            ? { environmentVariable: environmentVariable.trim() }
+            : {}),
+          ...(authMethod === 'api-key' && apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+        });
+        // A fetch that outlives its inputs (provider/protocol/auth/endpoint
+        // changed mid-flight) is stored but stays inert via the key gate.
+        if (result.status === 'ok') {
+          setPreview({ key: fetchKey, models: result.models, discoveredAt: result.discoveredAt });
+        }
+        return result;
+      } finally {
+        setDiscovering(false);
+      }
     }
-  }, [existingConnection, onDiscoverModels, refreshUnifiedModels]);
+    throw new Error('Live model discovery is unavailable for this connection.');
+  }, [
+    allowInsecureHttp,
+    apiKey,
+    authMethod,
+    endpoint,
+    environmentVariable,
+    existingConnection,
+    onDiscoverDraftModels,
+    onDiscoverModels,
+    protocol,
+    refreshUnifiedModels,
+    selectedDefinition,
+    supportsCustomEndpoint,
+  ]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -324,6 +414,7 @@ export function ConnectionWizard({
     setProtocol(nextProtocol);
     setConnectionModelIds(defaultModelIds(selectedDefinition ?? undefined, nextProtocol));
     setConnectionCustomModels([]);
+    setPreview(null);
     setModelsEditing(false);
     setError(null);
   };
@@ -749,11 +840,18 @@ export function ConnectionWizard({
                   reasoningConfig={reasoningConfig}
                   disabled={metadataLocked}
                   unifiedModels={existingConnection ? unifiedModels : null}
+                  previewModels={activePreview?.models ?? null}
+                  previewDiscoveredAt={activePreview?.discoveredAt ?? null}
                   discoveryAvailable={Boolean(
-                    existingConnection && selectedDefinition.supportsDiscovery && onDiscoverModels,
+                    selectedDefinition.supportsDiscovery
+                      && (existingConnection ? onDiscoverModels : onDiscoverDraftModels),
                   )}
                   discovering={discovering}
-                  onDiscoverModels={existingConnection && onDiscoverModels ? discoverModels : undefined}
+                  onDiscoverModels={
+                    (existingConnection && onDiscoverModels) || (!existingConnection && onDiscoverDraftModels)
+                      ? discoverModels
+                      : undefined
+                  }
                   onSelectedModelIdsChange={setConnectionModelIds}
                   onCustomModelsChange={setConnectionCustomModels}
                   onReasoningConfigChange={setReasoningConfig}

--- a/electron/src/renderer/hooks/useProviders.ts
+++ b/electron/src/renderer/hooks/useProviders.ts
@@ -13,6 +13,8 @@ import type {
   ProviderConnectionIdMessage,
   ProviderConnectionUpdateMessage,
   ProviderConnectionView,
+  ProviderDraftDiscoveryMessage,
+  ProviderDraftDiscoveryResult,
   ProviderDiscoverModelsResult,
   ProviderDisconnectMessage,
   ProviderModelListMessage,
@@ -81,6 +83,10 @@ export interface UseProvidersReturn {
   readonly discoverModels: (
     message: ProviderConnectionIdMessage,
   ) => Promise<ProviderDiscoverModelsResult>;
+  /** Draft live-discovery for a connection that does not exist yet (#138). */
+  readonly discoverDraftModels: (
+    message: ProviderDraftDiscoveryMessage,
+  ) => Promise<ProviderDraftDiscoveryResult>;
   readonly refreshStatus: (
     message: ProviderStatusRefreshMessage,
   ) => Promise<ProviderStatusView | null>;
@@ -492,6 +498,12 @@ export function useProviders(): UseProvidersReturn {
     [runMutation],
   );
 
+  const discoverDraftModels = useCallback(
+    (message: ProviderDraftDiscoveryMessage) =>
+      runMutation((providers) => providers.discoverDraftModels(message)),
+    [runMutation],
+  );
+
   const refreshStatus = useCallback(
     (message: ProviderStatusRefreshMessage) =>
       runMutation(
@@ -544,6 +556,7 @@ export function useProviders(): UseProvidersReturn {
     deleteConnection,
     modelList,
     discoverModels,
+    discoverDraftModels,
     refreshStatus,
     refreshQuota,
   };

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -787,6 +787,32 @@ export interface ProviderDiscoverModelsResult {
   message: string | null;
 }
 
+/**
+ * Draft live-discovery request for a connection that does not exist yet (#138).
+ * The one-shot `apiKey` is used only for this fetch and is never persisted or
+ * echoed back.
+ */
+export interface ProviderDraftDiscoveryMessage {
+  readonly providerId: string;
+  readonly protocol: ProviderProtocol;
+  readonly authMethod: ProviderAuthMethod;
+  readonly endpoint?: string | null;
+  readonly allowInsecureHttp?: boolean;
+  readonly environmentVariable?: string;
+  readonly apiKey?: string;
+}
+
+/** Result of one draft live-discovery fetch; nothing is persisted (#138). */
+export interface ProviderDraftDiscoveryResult {
+  readonly status: 'ok' | 'unsupported' | 'no-credential' | 'failed';
+  /** Renderer-ready provider rows for the wizard models editor. */
+  readonly models: readonly ProviderModelView[];
+  /** When the live endpoint published this snapshot; null unless status is ok. */
+  readonly discoveredAt: string | null;
+  /** Redacted, user-presentable detail; null when nothing needs surfacing. */
+  readonly message: string | null;
+}
+
 export interface ProviderMutationResult {
   connection: ProviderConnectionView;
   message: string | null;
@@ -1368,6 +1394,10 @@ export interface OrchidAPI {
     modelList: (message?: ProviderModelListMessage) => Promise<readonly ProviderModelOption[]>;
     /** One explicit live model discovery fetch for a connection; never polled (R26). */
     discoverModels: (message: ProviderConnectionIdMessage) => Promise<ProviderDiscoverModelsResult>;
+    /** Draft live-discovery fetch for a connection that does not exist yet (#138). */
+    discoverDraftModels: (
+      message: ProviderDraftDiscoveryMessage,
+    ) => Promise<ProviderDraftDiscoveryResult>;
     /** Refresh informational status only; it never changes connection health. */
     refreshStatus: (message: ProviderStatusRefreshMessage) => Promise<ProviderStatusView | null>;
     /**
@@ -1620,6 +1650,7 @@ export const IPC_CHANNELS = {
   PROVIDERS_DELETE: 'providers:delete',
   PROVIDERS_MODEL_LIST: 'providers:model_list',
   PROVIDERS_DISCOVER_MODELS: 'providers:discover_models',
+  PROVIDERS_DISCOVER_DRAFT_MODELS: 'providers:discover_draft_models',
   PROVIDERS_STATUS_REFRESH: 'providers:status_refresh',
   PROVIDERS_QUOTA_REFRESH: 'providers:quota_refresh',
 
@@ -1792,6 +1823,7 @@ export const ALLOWED_INVOKE_CHANNELS = [
   IPC_CHANNELS.PROVIDERS_DELETE,
   IPC_CHANNELS.PROVIDERS_MODEL_LIST,
   IPC_CHANNELS.PROVIDERS_DISCOVER_MODELS,
+  IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS,
   IPC_CHANNELS.PROVIDERS_STATUS_REFRESH,
   IPC_CHANNELS.PROVIDERS_QUOTA_REFRESH,
   IPC_CHANNELS.SESSION_LIST,

--- a/electron/tests/unit/connection-wizard.test.tsx
+++ b/electron/tests/unit/connection-wizard.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-/** Connection wizard protocol gating: a picker exists only when a provider offers a choice. */
+/** Connection wizard: protocol gating, draft model discovery, and model search. */
 import type { ComponentProps } from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -7,7 +7,20 @@ import { ConnectionWizard } from '../../src/renderer/components/Providers/Connec
 import type {
   ProviderConnectionView,
   ProviderDefinitionView,
+  ProviderModelView,
 } from '../../src/shared/types/ipc';
+
+function model(id: string, displayName: string): ProviderModelView {
+  return {
+    id,
+    displayName,
+    protocol: 'openai-compatible',
+    lifecycle: 'active',
+    source: 'catalog',
+    capabilities: { inputModalities: ['text'], outputModalities: ['text'], tools: true, reasoning: false },
+    limits: null,
+  };
+}
 
 function definition(overrides: Partial<ProviderDefinitionView> = {}): ProviderDefinitionView {
   return {
@@ -127,5 +140,168 @@ describe('connection wizard protocol picker', () => {
     expect(screen.queryByLabelText('Connection protocol')).toBeNull();
     expect(screen.queryByText('Protocol')).toBeNull();
     expect(screen.queryByText(/Protocol is fixed after creation/)).toBeNull();
+  });
+});
+
+describe('connection wizard draft model discovery (#138)', () => {
+  it('fetches live models while creating and flows selections into the create payload', async () => {
+    const onDiscoverDraftModels = vi.fn(async () => ({
+      status: 'ok' as const,
+      models: [{ ...model('live-model', 'Live Model'), source: 'provider' as const }],
+      discoveredAt: '2026-08-21T00:00:00.000Z',
+      message: 'Fetched 1 model from the live endpoint. Select the ones this connection should enable.',
+    }));
+    const { props } = renderWizard({
+      definitions: [definition({ supportsDiscovery: true })],
+      onDiscoverDraftModels,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /fetch models/i }));
+
+    await waitFor(() => expect(onDiscoverDraftModels).toHaveBeenCalledTimes(1));
+    expect(onDiscoverDraftModels).toHaveBeenCalledWith({
+      providerId: 'orchid-multi',
+      protocol: 'openai-compatible',
+      authMethod: 'api-key',
+    });
+    expect(await screen.findByText('Live Model')).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText('Use Live Model'));
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create connection' }));
+
+    await waitFor(() => expect(props.onCreate).toHaveBeenCalledTimes(1));
+    expect(props.onCreate).toHaveBeenCalledWith(expect.objectContaining({
+      modelIds: ['orchid-text', 'live-model'],
+    }));
+  });
+
+  it('surfaces the draft message without adding rows on failure', async () => {
+    const onDiscoverDraftModels = vi.fn(async () => ({
+      status: 'failed' as const,
+      models: [],
+      discoveredAt: null,
+      message: 'Live model discovery failed (endpoint unreachable).',
+    }));
+    renderWizard({
+      definitions: [definition({ supportsDiscovery: true })],
+      onDiscoverDraftModels,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /fetch models/i }));
+
+    expect(await screen.findByText(/Live model discovery failed/)).toBeDefined();
+    expect(screen.queryByText('Live Model')).toBeNull();
+  });
+
+  it('omits the fetch affordance when the provider publishes no models endpoint', () => {
+    renderWizard({
+      definitions: [definition({ supportsDiscovery: false })],
+      onDiscoverDraftModels: vi.fn(),
+    });
+
+    expect(screen.queryByRole('button', { name: /fetch models/i })).toBeNull();
+  });
+
+  it('omits the fetch affordance when draft discovery is unavailable', () => {
+    renderWizard({ definitions: [definition({ supportsDiscovery: true })] });
+
+    expect(screen.queryByRole('button', { name: /fetch models/i })).toBeNull();
+  });
+
+  it('drops preview rows once the draft inputs they were fetched against change', async () => {
+    const onDiscoverDraftModels = vi.fn(async () => ({
+      status: 'ok' as const,
+      models: [{ ...model('live-model', 'Live Model'), source: 'provider' as const }],
+      discoveredAt: '2026-08-21T00:00:00.000Z',
+      message: 'Fetched 1 model from the live endpoint. Select the ones this connection should enable.',
+    }));
+    renderWizard({
+      definitions: [definition({
+        id: 'generic-openai-compatible',
+        displayName: 'Generic OpenAI-compatible',
+        supportedAuthMethods: ['none'],
+        allowsCustomModels: true,
+        supportsDiscovery: true,
+        models: [],
+      })],
+      onDiscoverDraftModels,
+    });
+
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://a.example.com/v1' } });
+    fireEvent.click(screen.getByRole('button', { name: /fetch models/i }));
+    expect(await screen.findByText('Live Model')).toBeDefined();
+    expect(onDiscoverDraftModels).toHaveBeenCalledWith(expect.objectContaining({
+      endpoint: 'https://a.example.com/v1',
+    }));
+
+    // Retyping the endpoint invalidates rows fetched against the old one.
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://b.example.com/v1' } });
+    expect(screen.queryByText('Live Model')).toBeNull();
+  });
+});
+
+describe('connection wizard model search (#155)', () => {
+  it('filters rows by fuzzy query and scopes select-all to visible rows', async () => {
+    const models = Array.from({ length: 10 }, (_, index) => model(`orchid-${index}`, `Orchid ${index}`));
+    const { props } = renderWizard({
+      definitions: [definition({ models })],
+    });
+
+    fireEvent.change(screen.getByLabelText('Search models'), { target: { value: 'orchid-3' } });
+    expect(screen.getByText('Orchid 3')).toBeDefined();
+    expect(screen.queryByText('Orchid 1')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /select all models/i }));
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create connection' }));
+
+    await waitFor(() => expect(props.onCreate).toHaveBeenCalledTimes(1));
+    // Only the default selection plus the single visible row are enabled; the
+    // nine hidden models are untouched by a filtered select-all.
+    expect(props.onCreate).toHaveBeenCalledWith(expect.objectContaining({
+      modelIds: ['orchid-0', 'orchid-3'],
+    }));
+  });
+
+  it('shows an empty state when nothing matches the query', () => {
+    renderWizard({
+      definitions: [definition({
+        models: Array.from({ length: 9 }, (_, index) => model(`orchid-${index}`, `Orchid ${index}`)),
+      })],
+    });
+
+    fireEvent.change(screen.getByLabelText('Search models'), { target: { value: 'zzz-nothing' } });
+
+    expect(screen.getByText(/no models match/i)).toBeDefined();
+    expect(screen.queryByText('Orchid 1')).toBeNull();
+  });
+
+  it('omits the search input for short model lists', () => {
+    renderWizard();
+
+    expect(screen.queryByLabelText('Search models')).toBeNull();
+  });
+
+  it('deselects only visible rows when a filter is active', async () => {
+    const models = Array.from({ length: 10 }, (_, index) => model(`orchid-${index}`, `Orchid ${index}`));
+    const { props } = renderWizard({
+      definitions: [definition({ models })],
+    });
+
+    // Select everything unfiltered, then narrow to one row and deselect it:
+    // the nine hidden selections must survive.
+    fireEvent.click(screen.getByRole('button', { name: /select all models/i }));
+    fireEvent.change(screen.getByLabelText('Search models'), { target: { value: 'orchid-3' } });
+    fireEvent.click(screen.getByRole('button', { name: /deselect all models/i }));
+    fireEvent.change(screen.getByLabelText('Search models'), { target: { value: '' } });
+
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create connection' }));
+
+    await waitFor(() => expect(props.onCreate).toHaveBeenCalledTimes(1));
+    expect(props.onCreate).toHaveBeenCalledWith(expect.objectContaining({
+      modelIds: ['orchid-0', 'orchid-1', 'orchid-2', 'orchid-4', 'orchid-5', 'orchid-6', 'orchid-7', 'orchid-8', 'orchid-9'],
+    }));
   });
 });

--- a/electron/tests/unit/provider-ipc.test.ts
+++ b/electron/tests/unit/provider-ipc.test.ts
@@ -1512,6 +1512,218 @@ describe('provider live model discovery IPC', () => {
     expect(memory.status.invalidate).toHaveBeenCalledWith('openai', id);
     expect(memory.pricing.invalidate).toHaveBeenCalledWith('openai', id);
   });
+
+  describe('draft discovery before the connection exists (#138)', () => {
+    function genericDraftServices(fetchModels: unknown) {
+      const memory = memoryServices([GENERIC]);
+      const registryWithGenericDiscovery = new ProviderDriverRegistry([{
+        id: 'generic-openai-compatible',
+        supportedAuthMethods: ['api-key', 'environment', 'none'],
+        supportedProtocols: ['openai-compatible'],
+        allowsCustomEndpoint: true,
+        origin: null,
+        createLanguageModel: vi.fn(),
+        discoveryFacet: { fetchModels: fetchModels as never },
+      }]);
+      return { ...memory, services: { ...memory.services, registry: registryWithGenericDiscovery } };
+    }
+
+    it('fetches provider rows for a draft connection without persisting anything', async () => {
+      const fetchModels = vi.fn(async () => [
+        { id: 'nw-base', displayName: 'NW Base Live' },
+        { id: 'nw-draft-new', displayName: 'NW Draft New' },
+      ]);
+      const memory = discoveryServices(fetchModels);
+      process.env.ORCHID_TEST_NEURALWATT_KEY = 'nw-env-key';
+      try {
+        providersIpc._setProviderIPCServicesForTests(memory.services);
+        registerProviderIpc();
+
+        const result = await handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+          providerId: 'neuralwatt',
+          protocol: 'openai-compatible',
+          authMethod: 'environment',
+          environmentVariable: 'ORCHID_TEST_NEURALWATT_KEY',
+        });
+
+        expect(result.status).toBe('ok');
+        expect(result.models).toEqual([
+          expect.objectContaining({
+            id: 'nw-base',
+            displayName: 'NW Base Live',
+            protocol: 'openai-compatible',
+            source: 'provider',
+          }),
+          expect.objectContaining({ id: 'nw-draft-new', source: 'provider' }),
+        ]);
+        expect(typeof result.discoveredAt).toBe('string');
+        expect(result.message).toMatch(/fetched 2 models/i);
+        expect(fetchModels).toHaveBeenCalledWith(expect.objectContaining({
+          credential: { kind: 'api-key', apiKey: 'nw-env-key' },
+        }));
+        // A draft fetch never creates or mutates stored connections.
+        expect(memory.records.size).toBe(0);
+        expect(memory.connections.create).not.toHaveBeenCalled();
+        expect(memory.connections.update).not.toHaveBeenCalled();
+      } finally {
+        delete process.env.ORCHID_TEST_NEURALWATT_KEY;
+      }
+    });
+
+    it('uses the one-shot payload api key for the fetch only', async () => {
+      const fetchModels = vi.fn(async () => [{ id: 'nw-draft' }]);
+      const memory = discoveryServices(fetchModels);
+      providersIpc._setProviderIPCServicesForTests(memory.services);
+      registerProviderIpc();
+
+      const result = await handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'neuralwatt',
+        protocol: 'openai-compatible',
+        authMethod: 'api-key',
+        apiKey: 'nw-draft-key',
+      });
+
+      expect(result.status).toBe('ok');
+      expect(fetchModels).toHaveBeenCalledWith(expect.objectContaining({
+        credential: { kind: 'api-key', apiKey: 'nw-draft-key' },
+      }));
+      expect(JSON.stringify(result)).not.toContain('nw-draft-key');
+    });
+
+    it('reports no-credential drafts without calling the driver', async () => {
+      const fetchModels = vi.fn();
+      const memory = discoveryServices(fetchModels);
+      providersIpc._setProviderIPCServicesForTests(memory.services);
+      registerProviderIpc();
+
+      const result = await handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'neuralwatt',
+        protocol: 'openai-compatible',
+        authMethod: 'api-key',
+      });
+
+      expect(result).toMatchObject({ status: 'no-credential', models: [] });
+      expect(result.message).toMatch(/working credential/i);
+      expect(fetchModels).not.toHaveBeenCalled();
+    });
+
+    it('keeps the failure redacted and non-blocking when the endpoint fails', async () => {
+      const fetchModels = vi.fn(async () => {
+        throw new Error('boom with key sk-nw-secret');
+      });
+      const memory = discoveryServices(fetchModels);
+      providersIpc._setProviderIPCServicesForTests(memory.services);
+      registerProviderIpc();
+
+      const result = await handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'neuralwatt',
+        protocol: 'openai-compatible',
+        authMethod: 'api-key',
+        apiKey: 'nw-draft-key',
+      });
+
+      expect(result.status).toBe('failed');
+      expect(result.message).toMatch(/discovery failed/i);
+      expect(JSON.stringify(result)).not.toContain('sk-nw-secret');
+    });
+
+    it('applies the create-time static gate to drafts', async () => {
+      const fetchModels = vi.fn();
+      const memory = discoveryServices(fetchModels);
+      providersIpc._setProviderIPCServicesForTests(memory.services);
+      registerProviderIpc();
+
+      await expect(handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'neuralwatt',
+        protocol: 'anthropic-messages',
+        authMethod: 'api-key',
+        apiKey: 'nw-draft-key',
+      })).rejects.toThrow(/not supported/i);
+
+      await expect(handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'unknown-provider',
+        protocol: 'openai-compatible',
+        authMethod: 'api-key',
+      })).rejects.toThrow(/unknown provider/i);
+
+      expect(fetchModels).not.toHaveBeenCalled();
+    });
+
+    it('validates generic endpoints and passes them to the driver fetch', async () => {
+      const fetchModels = vi.fn(async () => [{ id: 'generic-live' }]);
+      const memory = genericDraftServices(fetchModels);
+      providersIpc._setProviderIPCServicesForTests(memory.services);
+      registerProviderIpc();
+
+      await expect(handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'generic-openai-compatible',
+        protocol: 'openai-compatible',
+        authMethod: 'none',
+      })).rejects.toThrow(/requires a custom endpoint/i);
+      expect(fetchModels).not.toHaveBeenCalled();
+
+      const result = await handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'generic-openai-compatible',
+        protocol: 'openai-compatible',
+        authMethod: 'none',
+        endpoint: 'https://api.example.com/v1',
+      });
+
+      expect(result.status).toBe('ok');
+      expect(fetchModels).toHaveBeenCalledWith(expect.objectContaining({
+        endpoint: 'https://api.example.com/v1',
+      }));
+    });
+
+    it('persists discovery for none-auth connections so draft previews converge after create', async () => {
+      const fetchModels = vi.fn(async () => [{ id: 'generic-live' }]);
+      const memory = genericDraftServices(fetchModels);
+      providersIpc._setProviderIPCServicesForTests(memory.services);
+      registerProviderIpc();
+
+      const draft = await handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'generic-openai-compatible',
+        protocol: 'openai-compatible',
+        authMethod: 'none',
+        endpoint: 'https://api.example.com/v1',
+      });
+      expect(draft.status).toBe('ok');
+
+      const created = await handler(IPC_CHANNELS.PROVIDERS_CREATE)(null, {
+        providerId: 'generic-openai-compatible',
+        name: 'Local endpoint',
+        protocol: 'openai-compatible',
+        authMethod: 'none',
+        endpoint: 'https://api.example.com/v1',
+        modelIds: ['generic-live'],
+      });
+
+      // The persisted path fetches for none-auth too, so the id selected from
+      // the draft preview is backed instead of orphaned after creation.
+      expect(fetchModels).toHaveBeenCalledTimes(2);
+      const record = memory.records.get(created.connection.id);
+      expect(record?.discoveredModels).toEqual([
+        expect.objectContaining({ id: 'generic-live', provenance: 'provider' }),
+      ]);
+    });
+
+    it('reports no-credential when an environment variable is declared but unset', async () => {
+      const fetchModels = vi.fn();
+      const memory = discoveryServices(fetchModels);
+      providersIpc._setProviderIPCServicesForTests(memory.services);
+      registerProviderIpc();
+
+      const result = await handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+        providerId: 'neuralwatt',
+        protocol: 'openai-compatible',
+        authMethod: 'environment',
+        environmentVariable: 'ORCHID_TEST_NEURALWATT_UNSET',
+      });
+
+      expect(result).toMatchObject({ status: 'no-credential', models: [] });
+      expect(fetchModels).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('provider per-model pricing override IPC', () => {
@@ -1649,5 +1861,20 @@ describe('provider channel zod rejection', () => {
       .rejects.toThrow('Invalid providers:quota_refresh payload');
     await expect(handler(IPC_CHANNELS.PROVIDERS_QUOTA_REFRESH)(null, {}))
       .rejects.toThrow('Invalid providers:quota_refresh payload');
+  });
+
+  it('rejects providers:discover_draft_models with an invalid payload', async () => {
+    registerProviderIpc();
+
+    await expect(handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, undefined))
+      .rejects.toThrow('Invalid providers:discover_draft_models payload');
+    await expect(handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {}))
+      .rejects.toThrow('Invalid providers:discover_draft_models payload');
+    // Environment auth without a variable never reaches driver code.
+    await expect(handler(IPC_CHANNELS.PROVIDERS_DISCOVER_DRAFT_MODELS)(null, {
+      providerId: 'openai',
+      protocol: 'openai-compatible',
+      authMethod: 'environment',
+    })).rejects.toThrow('Invalid providers:discover_draft_models payload');
   });
 });


### PR DESCRIPTION
## Summary

Fixes two open provider-setup issues on top of `fix/issue-166-generic-usage-cost` (the branch this was cut from):

### #138 — Cannot fetch models while adding new connection
Live model discovery only worked for already-saved connections because the `providers:discover_models` channel is keyed by `connectionId` and reads the persisted vault credential. This adds a **draft discovery** path so the wizard can fetch live models *before* the connection exists:

- **New IPC channel `providers:discover_draft_models`** (`main/ipc/provider-models.ts`): builds a transient draft connection and validates it through the exact create-time gate (`requireStaticConnectionSupport`, now shared/exported) — provider must resolve to a catalog definition, protocol/auth must match driver + definition, and custom endpoints are re-validated. Runs the existing pure `discoverConnectionModels` (failures redacted via `redactStatusDiagnostic`) and returns `ProviderModelView` rows. **Nothing is persisted**; the one-shot `apiKey` from the payload is used only for the fetch and never echoed or logged.
- **Wizard** (`ConnectionWizard.tsx`): the "Fetch models" button now appears in create mode whenever the provider supports discovery. Results merge into the models editor as provider-sourced rows (with discovered badges), keyed to the draft inputs (`provider|protocol|auth|endpoint|insecure`) they were fetched against — a preview becomes inert the moment any of those inputs change, so a slow fetch can never land rows from the old provider/endpoint, and retyping the endpoint drops stale rows.
- **Convergence**: selected preview ids flow into the create payload; the existing post-create discovery persists the real snapshot, so previews and persisted state agree.
- **Behavior alignment**: `discoveryCredential` now resolves `none`-auth connections to an unauthenticated fetch (matching the draft path). Previously a `none`-auth saved connection could never rediscover — draft previews would have been orphaned after create. Local OpenAI-compatible endpoints (ollama/vLLM-style) commonly serve `/models` without auth.

### #155 — Add search for models on connection modal
- The models editor gains a fuzzy search input (shown past 8 rows, or while a query is active) matching display names and ids via the shared `fuzzyMatch` helper.
- **Select/Deselect all is scoped to visible rows only** — a filtered view never silently changes hidden selections.
- Filtered empty state tells the user how to clear the search.

## Security notes
- Draft payload is `.strict()` Zod-validated with the same env-var cross-field rules as create; the api-key field carries the same "never log payload" caveat as `submitApiKeySchema`.
- The renderer cannot select drivers or origins: `providerId` resolves only through the trusted catalog, endpoints only apply to `allowsCustomEndpoint` drivers and pass `validateGenericEndpoint` (loopback/HTTPS rules).
- No new SSRF surface — the fetch capability equals what create + manual discovery already permitted.

## Testing
- `provider-ipc.test.ts`: +8 tests — draft fetch returns provider rows with nothing persisted; one-shot key transit (asserted absent from serialized result); no-credential (missing key / unset env var) without calling the driver; redacted failure; static-gate rejection (unsupported protocol, unknown provider, missing endpoint); endpoint passthrough; **none-auth create→persist convergence**.
- `connection-wizard.test.tsx`: +7 tests — fetch visible in create mode with correct draft payload, selections flow into create `modelIds`; failure surfaces a notice without rows; affordance gating; preview invalidated on endpoint change; fuzzy filtering; select-all/deselect-all scoped to visible rows; empty state.
- Full suite: 299 files / 4625 tests green; `typecheck` + `lint` clean.

Closes #138
Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discover available models while setting up a new provider connection, before saving it.
  * Preview discovered models in the connection wizard and manage them alongside configured models.
  * Search models by name or ID, with filtered select-all and deselect-all controls.
  * Added clearer handling for authentication, environment variables, endpoints, and discovery errors.

* **Bug Fixes**
  * Prevented outdated model previews from appearing after connection details change.
  * Improved discovery support for unauthenticated connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->