### PR TITLE
fix(config): align per-project configuration with runtime capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ electron/
 │   │   │   ├── ToolResults/     # Tool result widgets by family (+ registry)
 │   │   │   ├── ToolWidgets/     # Tool call activity widgets (live command output)
 │   │   │   ├── ui/              # Typed primitives (Button, TextInput, Select, Tabs, …)
-│   │   │   ├── Preferences/     # Settings tab panels (used by ConfigView)
+│   │   │   ├── Preferences/     # Settings tab panels (shared by ConfigView and ProjectConfigView)
 │   │   │   ├── Providers/       # Connection list/wizard/models/status
 │   │   │   └── Onboarding/      # First-run setup wizard
 │   │   ├── hooks/

--- a/docs/solutions/logic-errors/trusted-projects-fail-closed-gating.md
+++ b/docs/solutions/logic-errors/trusted-projects-fail-closed-gating.md
@@ -43,7 +43,7 @@ Key files: `electron/src/main/project/trust.ts` (store/fingerprint/report), gate
 ## Gotchas discovered in review
 
 - Report building happens for *untrusted* content — cap raw config size, definition counts, and serialized value lengths, or a crafted repo DoSes the main process pre-trust.
-- Orchid's own writes (agent edits of root AGENTS.md, definition saves) flip trusted → changed by design; the next send re-prompts. Product-accepted residual.
+- Orchid's own writes (agent edits of root AGENTS.md, definition saves, `config:save_project` from ProjectConfigView) flip trusted → changed by design; the next send re-prompts. Product-accepted residual — note that every ProjectConfigView save (per-project MCP servers, tier models, AGENTS.md overrides, …) rewrites `.orchid.json` and therefore trips this, so the re-prompt frequency scales with project-config editing.
 - Grant records the fingerprint at click time, not review time (TOCTOU while the dialog is open) — accepted residual; a hardened version carries the reviewed fingerprint into `trust_set`.
 
 ## Verification

--- a/electron/src/main/ast/indexer.ts
+++ b/electron/src/main/ast/indexer.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import { Worker } from 'node:worker_threads';
 import { langForExtension, loadQueryFile, parseFile, runQuery } from './parser';
 import { ASTStore, type Symbol } from './store';
-import { getConfig } from '../config';
+import { getConfig, type Config } from '../config';
 import { withDisposableAsync } from '../utils/with-disposable';
 import type { ASTIndexResult, ASTIndexProgress } from '../../shared/types/ipc-boundary';
 
@@ -133,6 +133,11 @@ export interface IndexProjectOptions {
   force?: boolean;
   progressCallback?: ASTIndexProgressCallback;
   /**
+    * Frozen per-project config (ignored_dirs, ast_max_file_size) captured by
+    * the caller. Falls back to the process-wide config when omitted.
+    */
+  config?: Config;
+  /**
    * Force the index to run on the current thread (used by the worker itself
    * and tests that need a synchronous-style progress callback).
    */
@@ -190,6 +195,7 @@ export async function indexProject(
         opts.projectPath!,
         opts.force === true,
         trackProgress,
+        opts.config,
       );
       // Worker set its own session flag; mark main-process session as ready too
       // so ensureIndexed() short-circuits after a successful run.
@@ -215,11 +221,12 @@ export async function runIndexProjectImpl(opts: {
   projectPath?: string;
   force?: boolean;
   progressCallback?: ASTIndexProgressCallback;
+  config?: Config;
 }): Promise<ASTIndexResult> {
   const { force = false, progressCallback } = opts;
   const { projectPath } = opts;
 
-  const cfg = getConfig();
+  const cfg = opts.config ?? getConfig();
   if (!projectPath) {
     throw new Error('projectPath is required; pass the active workspace cwd');
   }
@@ -292,7 +299,7 @@ export async function runIndexProjectImpl(opts: {
     });
 
     try {
-      const readResult = await readAndHash(filepath);
+      const readResult = await readAndHash(filepath, cfg.ast_max_file_size);
 
       if (!readResult) {
         if (existingHashes[rel]) {
@@ -383,13 +390,14 @@ async function runIndexInWorker(
   projectPath: string,
   force: boolean,
   progressCallback?: ASTIndexProgressCallback,
+  config?: Config,
 ): Promise<ASTIndexResult> {
   const workerPath = path.join(__dirname, 'index-worker.js');
   if (!fs.existsSync(workerPath)) {
     console.warn(
       `AST worker not found at ${workerPath}; running index inline on the main thread`,
     );
-    return runIndexProjectImpl({ projectPath, force, progressCallback });
+    return runIndexProjectImpl({ projectPath, force, progressCallback, config });
   }
 
   const startData: AstWorkerStartData = {
@@ -407,7 +415,7 @@ async function runIndexInWorker(
     console.warn(
       `AST worker failed to start (${err instanceof Error ? err.message : String(err)}); running index inline on the main thread`,
     );
-    return runIndexProjectImpl({ projectPath, force, progressCallback });
+    return runIndexProjectImpl({ projectPath, force, progressCallback, config });
   }
 
   return new Promise<ASTIndexResult>((resolve, reject) => {
@@ -506,11 +514,13 @@ function shouldInclude(filepath: string): boolean {
  * Read file content and compute MD5 hash.
  * Returns null for files that should be skipped (too large, empty, binary).
  */
-async function readAndHash(filepath: string): Promise<{ content: string; hash: string } | null> {
-  const cfg = getConfig();
+async function readAndHash(
+  filepath: string,
+  maxFileSize: number,
+): Promise<{ content: string; hash: string } | null> {
   try {
     const stat = await fs.promises.stat(filepath);
-    if (stat.size > cfg.ast_max_file_size) return null;
+    if (stat.size > maxFileSize) return null;
     if (stat.size === 0) return null;
 
     const content = await fs.promises.readFile(filepath, 'utf-8');

--- a/electron/src/main/config/schema.ts
+++ b/electron/src/main/config/schema.ts
@@ -85,6 +85,13 @@ export const agentsMdConfigSchema = z.object({
  * overrides deep-merge cleanly. All knobs for the live/durable separation
  * (batcher, persistence wave, admission, eviction, prompt bounding) are
  * collected here in one unit to avoid repeated schema churn.
+ *
+ * NOTE: these knobs are process-global by implementation — admission queues
+ * and event batchers are shared main-process resources read from the live
+ * config at emission time (`agents/manager.ts`, `agents/subagent-events.ts`),
+ * so a project-layer override in `.orchid.json` is NOT honored and the key is
+ * intentionally excluded from the project-config allow-list. Compaction
+ * behavior for subagents is per-project instead (`compaction.subagents`).
  */
 export const subagentsConfigSchema = z.object({
   event_max_per_flush: z.number().int().min(1).max(100_000).default(200),

--- a/electron/src/main/config/schema.ts
+++ b/electron/src/main/config/schema.ts
@@ -258,7 +258,7 @@ export const configSchema = z
      * conversation history. 0 disables the deadline entirely; naming then
      * only happens when a turn completes or is interrupted.
      */
-    session_title_max_wait_seconds: z.number().min(0).default(15),
+    session_title_max_wait_seconds: z.number().min(0).max(3600).default(15),
     /**
      * Max multi-step tool-loop iterations per stream (AI SDK stopWhen).
      */

--- a/electron/src/main/ipc/ast.ts
+++ b/electron/src/main/ipc/ast.ts
@@ -16,6 +16,8 @@ import { ASTStore } from '../ast/store';
 import { withDisposable } from '../utils/with-disposable';
 import { resolveBoundProjectPath } from './session';
 import { getProjectTrustState } from '../project/trust';
+import { getProjectRuntimeRegistry } from '../project/runtime';
+import type { Config } from '../config';
 import { astIndexSchema } from './payload-schemas';
 
 function broadcastProgress(projectPath: string, progress: ASTIndexProgress): void {
@@ -98,9 +100,20 @@ export function registerASTIPC(): void {
       };
     }
 
+    // Inline fallback consistency: the worker self-loads project config, but a
+    // missing worker bundle falls back to this main-thread snapshot. If the
+    // runtime cannot be resolved (e.g. the directory vanished), index without
+    // an explicit config and let the process-wide config apply.
+    let runtimeConfig: Config | undefined;
+    try {
+      runtimeConfig = getProjectRuntimeRegistry().get(projectPath).config;
+    } catch {
+      runtimeConfig = undefined;
+    }
     return indexProject({
       force,
       projectPath,
+      config: runtimeConfig,
       progressCallback: (progress) => broadcastProgress(projectPath, progress),
     });
   });

--- a/electron/src/main/ipc/config.ts
+++ b/electron/src/main/ipc/config.ts
@@ -16,7 +16,7 @@ import {
   HOME_CONFIG_PATH,
   PROJECT_CONFIG_NAME,
 } from '../config/loader';
-import { isPlainObject, mergeConfigUpdates } from '../config/merge';
+import { isPlainObject, isUnsafeKey, mergeConfigUpdates } from '../config/merge';
 import { configSchema } from '../config/schema';
 import { withConfigSaveLock } from '../config/write-lock';
 import {
@@ -32,6 +32,13 @@ import {
 } from './payload-schemas';
 import { resolveAuthorizedProjectDir } from './project-target';
 
+/**
+ * Config keys a project `.orchid.json` may override. Kept aligned with what
+ * the project runtime actually consumes from `ProjectRuntime.config` — keys
+ * that are process-global by implementation (`subagents`, worker pool sizing,
+ * onboarding state, …) stay out. `theme` is renderer-global and has no
+ * per-project consumer, so it is not overridable either.
+ */
 const PROJECT_CONFIG_ALLOWED_KEYS = new Set([
   'command_timeout',
   'command_max_output_bytes',
@@ -64,15 +71,29 @@ const PROJECT_CONFIG_ALLOWED_KEYS = new Set([
   'mcp_startup_timeout',
   'mcp_per_server_timeout',
   'mcp_result_max_bytes',
+  'mcp_servers',
+  'agents_md',
+  'default_model',
+  'tier_models',
+  'tier_reasoning_effort',
   'rag',
   'compaction',
   'ignored_dirs',
   'always_expand_tool_groups',
-  'theme',
   'personality',
 ]);
 
 // ── IPC registration ─────────────────────────────────────────────────────────
+
+/** Copy a plain record map, dropping prototype-pollution aliases. */
+function copyMapValues<T>(map: Record<string, T>): Record<string, T> {
+  const out: Record<string, T> = {};
+  for (const [key, value] of Object.entries(map)) {
+    if (isUnsafeKey(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}
 
 function loadJsonSafe(filePath: string): unknown {
   try {
@@ -163,12 +184,44 @@ export function registerConfigIPC(): void {
 
     const verifiedProjectDir = resolveAuthorizedProjectDir(event.sender.id, projectDir);
 
-    const filteredUpdates: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(updates)) {
-      if (PROJECT_CONFIG_ALLOWED_KEYS.has(key)) {
-        filteredUpdates[key] = value;
+    // Fail loudly instead of silently dropping keys: a caller must learn that
+    // a key cannot be configured per project, not believe it was saved.
+    const rejectedKeys = Object.keys(updates).filter((key) => !PROJECT_CONFIG_ALLOWED_KEYS.has(key));
+    if (rejectedKeys.length > 0) {
+      throw new Error(
+        `Not configurable per project: ${[...rejectedKeys].sort().join(', ')}. ` +
+          'Use the global configuration for these settings.',
+      );
+    }
+
+    const filteredUpdates: Record<string, unknown> = { ...updates };
+
+    // Project-scope override semantics that differ from the global merge:
+    // - `default_model: null` clears the override (inherit home) instead of
+    //   masking the home selection with an explicit null.
+    // - `tier_models` / `tier_reasoning_effort` are exact-map replacements so
+    //   removing one tier's override deletes its key (per-tier merge cannot
+    //   express deletion because null is a meaningful "use default" value).
+    // A null/non-object tier map would fall back to whole-key merge semantics
+    // that are silent no-ops here, so it is rejected with the same fail-loud
+    // contract as the allow-list above.
+    for (const mapKey of ['tier_models', 'tier_reasoning_effort'] as const) {
+      if (mapKey in filteredUpdates && !isPlainObject(filteredUpdates[mapKey])) {
+        throw new Error(
+          `Not configurable per project: ${mapKey} must be an object map of tier assignments.`,
+        );
       }
     }
+    const clearDefaultModel = filteredUpdates['default_model'] === null;
+    if (clearDefaultModel) delete filteredUpdates['default_model'];
+    const tierModelsUpdate = isPlainObject(filteredUpdates['tier_models'])
+      ? copyMapValues(filteredUpdates['tier_models'] as Record<string, unknown>)
+      : undefined;
+    if (tierModelsUpdate) delete filteredUpdates['tier_models'];
+    const tierReasoningUpdate = isPlainObject(filteredUpdates['tier_reasoning_effort'])
+      ? copyMapValues(filteredUpdates['tier_reasoning_effort'] as Record<string, unknown>)
+      : undefined;
+    if (tierReasoningUpdate) delete filteredUpdates['tier_reasoning_effort'];
 
     return withConfigSaveLock(async () => {
       const configPath = path.join(verifiedProjectDir, PROJECT_CONFIG_NAME);
@@ -177,14 +230,34 @@ export function registerConfigIPC(): void {
         isPlainObject(current) ? current : {},
         filteredUpdates,
       );
-      const filtered = Object.fromEntries(
-        Object.entries(merged).filter(([k]) => PROJECT_CONFIG_ALLOWED_KEYS.has(k)),
-      );
-      const validated = configSchema.safeParse(filtered);
-      if (!validated.success) {
-        throw new Error(`Invalid project config: ${validated.error.message}`);
+      if (clearDefaultModel) delete merged['default_model'];
+      if (tierModelsUpdate !== undefined) merged['tier_models'] = tierModelsUpdate;
+      if (tierReasoningUpdate !== undefined) {
+        merged['tier_reasoning_effort'] = tierReasoningUpdate;
       }
-      atomicWriteJson(configPath, filtered, { hardenDirectory: false });
+      // Write `merged` as-is: every updated key passed the allow-list above,
+      // and pre-existing file keys that are managed through other channels
+      // (notably project `permissions` via config:savePermissionScope) must
+      // survive a project-config save instead of being stripped.
+      const validated = configSchema.safeParse(merged);
+      if (!validated.success) {
+        // A hand-edited project file can already violate the schema under a
+        // key that is now allow-listed. Rejecting would block every unrelated
+        // save behind that pre-existing damage, so when the file was already
+        // invalid before this update, warn and write anyway (the invalid
+        // value is preserved as-is either way).
+        const prior = configSchema.safeParse(
+          isPlainObject(current) ? current : {},
+        );
+        if (prior.success) {
+          throw new Error(`Invalid project config: ${validated.error.message}`);
+        }
+        console.warn(
+          `[config] project config of '${verifiedProjectDir}' was already invalid ` +
+            `before this save; writing anyway: ${validated.error.message}`,
+        );
+      }
+      atomicWriteJson(configPath, merged, { hardenDirectory: false });
       ConfigManager.reset();
       clearProjectRuntimeRegistry();
       invalidateAllProjectMCPManagers();

--- a/electron/src/main/ipc/config.ts
+++ b/electron/src/main/ipc/config.ts
@@ -6,6 +6,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ipcMain } from 'electron';
+import type { ZodError, ZodIssue } from 'zod';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
 import {
   getConfig,
@@ -101,6 +102,43 @@ function loadJsonSafe(filePath: string): unknown {
   } catch {
     return null;
   }
+}
+
+function issuePathKey(path: readonly PropertyKey[]): string {
+  return path.map(String).join('.');
+}
+
+function valueAtPath(source: unknown, path: readonly PropertyKey[]): unknown {
+  let current: unknown = source;
+  for (const key of path) {
+    if (current === null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key as string];
+  }
+  return current;
+}
+
+function unchangedValue(before: unknown, after: unknown): boolean {
+  return before === after || JSON.stringify(before) === JSON.stringify(after);
+}
+
+/**
+ * Validation issues this update introduced: errors at paths the prior file did
+ * not already fail, or a changed value at a previously-invalid path.
+ */
+function introducedIssues(
+  mergedError: ZodError,
+  priorError: ZodError,
+  priorRaw: Record<string, unknown>,
+  mergedRaw: Record<string, unknown>,
+): ZodIssue[] {
+  const priorPaths = new Set(priorError.issues.map((issue) => issuePathKey(issue.path)));
+  return mergedError.issues.filter((issue) => {
+    if (!priorPaths.has(issuePathKey(issue.path))) return true;
+    return !unchangedValue(
+      valueAtPath(priorRaw, issue.path),
+      valueAtPath(mergedRaw, issue.path),
+    );
+  });
 }
 
 export function registerConfigIPC(): void {
@@ -243,14 +281,29 @@ export function registerConfigIPC(): void {
       if (!validated.success) {
         // A hand-edited project file can already violate the schema under a
         // key that is now allow-listed. Rejecting would block every unrelated
-        // save behind that pre-existing damage, so when the file was already
-        // invalid before this update, warn and write anyway (the invalid
-        // value is preserved as-is either way).
+        // save behind that pre-existing damage, so only invalid values this
+        // update leaves untouched are preserved with a warning (they are kept
+        // as-is either way); violations this save introduces still reject.
         const prior = configSchema.safeParse(
           isPlainObject(current) ? current : {},
         );
         if (prior.success) {
           throw new Error(`Invalid project config: ${validated.error.message}`);
+        }
+        const introduced = introducedIssues(
+          validated.error,
+          prior.error,
+          isPlainObject(current) ? current : {},
+          merged,
+        );
+        if (introduced.length > 0) {
+          const paths = introduced
+            .map((issue) => issuePathKey(issue.path) || '<root>')
+            .join(', ');
+          throw new Error(
+            `Invalid project config: this save introduces new violations ` +
+              `(${paths}): ${validated.error.message}`,
+          );
         }
         console.warn(
           `[config] project config of '${verifiedProjectDir}' was already invalid ` +

--- a/electron/src/main/ipc/payload-schemas.ts
+++ b/electron/src/main/ipc/payload-schemas.ts
@@ -112,8 +112,9 @@ export const configSaveSchema = z.object({
 
 /**
  * Project-scoped config:save payload — a verified `projectDir` plus a
- * free-form updates map. Allowed-key filtering and merged-structure
- * validation happen in the handler after the workspace is verified.
+ * free-form updates map. Allow-list rejection (fail-loud, no filtering) and
+ * merged-structure validation happen in the handler after the workspace is
+ * verified.
  */
 export const configSaveProjectSchema = z.object({
   projectDir: z.string().min(1),

--- a/electron/src/main/rag/embedder.ts
+++ b/electron/src/main/rag/embedder.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ModelSelection } from '../../shared/types/provider';
+import type { RAGConfig } from '../../shared/types/ipc-boundary';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -312,7 +313,7 @@ export class ApiEmbedder implements IEmbedder {
  * credential, and code-owned endpoint resolution; legacy alias strings never
  * reach this function as executable providers.
  */
-export async function createEmbedderFromConfig(): Promise<IEmbedder> {
+export async function createEmbedderFromConfig(rag?: RAGConfig): Promise<IEmbedder> {
   let cfgThreads = DEFAULT_THREADS;
   let cfgBatch = DEFAULT_BATCH_SIZE;
   let cfgModel: string | undefined;
@@ -320,22 +321,24 @@ export async function createEmbedderFromConfig(): Promise<IEmbedder> {
   let cfgApiTimeout: number | undefined;
   let cfgApiRetries: number | undefined;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { getConfig } = require('../config/loader') as typeof import('../config/loader');
-    const rag = getConfig().rag;
-    cfgModel = rag.embedding_model;
-    cfgApiSelection = rag.embedding_api_model;
-    if (typeof rag.embedding_threads === 'number' && rag.embedding_threads > 0) {
-      cfgThreads = rag.embedding_threads;
+    const conf = rag ?? (() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getConfig } = require('../config/loader') as typeof import('../config/loader');
+      return getConfig().rag;
+    })();
+    cfgModel = conf.embedding_model;
+    cfgApiSelection = conf.embedding_api_model;
+    if (typeof conf.embedding_threads === 'number' && conf.embedding_threads > 0) {
+      cfgThreads = conf.embedding_threads;
     }
-    if (typeof rag.embedding_batch_size === 'number' && rag.embedding_batch_size > 0) {
-      cfgBatch = rag.embedding_batch_size;
+    if (typeof conf.embedding_batch_size === 'number' && conf.embedding_batch_size > 0) {
+      cfgBatch = conf.embedding_batch_size;
     }
-    if (typeof rag.embedding_api_timeout === 'number' && rag.embedding_api_timeout > 0) {
-      cfgApiTimeout = rag.embedding_api_timeout * 1000;
+    if (typeof conf.embedding_api_timeout === 'number' && conf.embedding_api_timeout > 0) {
+      cfgApiTimeout = conf.embedding_api_timeout * 1000;
     }
-    if (typeof rag.embedding_api_retries === 'number' && rag.embedding_api_retries >= 0) {
-      cfgApiRetries = rag.embedding_api_retries;
+    if (typeof conf.embedding_api_retries === 'number' && conf.embedding_api_retries >= 0) {
+      cfgApiRetries = conf.embedding_api_retries;
     }
   } catch {
     // config unavailable — use hard defaults

--- a/electron/src/main/rag/embedder.ts
+++ b/electron/src/main/rag/embedder.ts
@@ -320,6 +320,7 @@ export async function createEmbedderFromConfig(rag?: RAGConfig): Promise<IEmbedd
   let cfgApiSelection: ModelSelection | null = null;
   let cfgApiTimeout: number | undefined;
   let cfgApiRetries: number | undefined;
+  let cfgDownloadTimeouts: ModelDownloadOptions | undefined;
   try {
     const conf = rag ?? (() => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -340,6 +341,7 @@ export async function createEmbedderFromConfig(rag?: RAGConfig): Promise<IEmbedd
     if (typeof conf.embedding_api_retries === 'number' && conf.embedding_api_retries >= 0) {
       cfgApiRetries = conf.embedding_api_retries;
     }
+    cfgDownloadTimeouts = modelDownloadOptionsFromConfig(conf);
   } catch {
     // config unavailable — use hard defaults
   }
@@ -364,6 +366,7 @@ export async function createEmbedderFromConfig(rag?: RAGConfig): Promise<IEmbedd
     model: cfgModel ?? DEFAULT_ONNX_MODEL,
     threads: cfgThreads,
     batchSize: cfgBatch,
+    modelDownloadTimeouts: cfgDownloadTimeouts,
   });
 }
 
@@ -384,6 +387,8 @@ export interface EmbedderOptions {
   threads?: number;
   /** Texts per ONNX forward pass (default from config, else 16). */
   batchSize?: number;
+  /** Model-download deadlines from the caller-supplied RAGConfig (ms); unset fields keep the default resolution. */
+  modelDownloadTimeouts?: ModelDownloadOptions;
 }
 
 /** Optional controls for a single model-file download. */
@@ -401,6 +406,7 @@ export class Embedder implements IEmbedder {
   private modelName: string;
   private threads: number;
   private batchSize: number;
+  private modelDownloadTimeouts?: ModelDownloadOptions;
 
   constructor(modelOrOptions?: string | EmbedderOptions) {
     const opts: EmbedderOptions =
@@ -430,6 +436,7 @@ export class Embedder implements IEmbedder {
     this.modelName = opts.model ?? cfgModel ?? DEFAULT_ONNX_MODEL;
     this.threads = Math.max(1, Math.min(64, opts.threads ?? cfgThreads));
     this.batchSize = Math.max(1, Math.min(256, opts.batchSize ?? cfgBatch));
+    this.modelDownloadTimeouts = opts.modelDownloadTimeouts;
   }
 
   /**
@@ -519,7 +526,7 @@ export class Embedder implements IEmbedder {
    */
   private async _embedBatch(texts: string[]): Promise<Float32Array[]> {
     try {
-      return await runOnnxEmbedding(texts, this.modelName, this.threads);
+      return await runOnnxEmbedding(texts, this.modelName, this.threads, this.modelDownloadTimeouts);
     } catch (err) {
       if (err instanceof EmbeddingError) throw err;
       throw new EmbeddingError(
@@ -754,6 +761,26 @@ function modelDownloadTimeouts(): {
   }
 }
 
+/**
+ * Map the caller-supplied RAGConfig's model-download timeouts (seconds) to
+ * download options (ms). Absent or non-positive fields stay unset so the
+ * default resolution (`modelDownloadTimeouts`) still applies.
+ */
+export function modelDownloadOptionsFromConfig(
+  rag?: Partial<RAGConfig>,
+): ModelDownloadOptions {
+  const inactivity = rag?.model_download_inactivity_timeout;
+  const total = rag?.model_download_total_timeout;
+  return {
+    ...(typeof inactivity === 'number' && inactivity > 0
+      ? { inactivityTimeoutMs: inactivity * 1000 }
+      : {}),
+    ...(typeof total === 'number' && total > 0
+      ? { totalTimeoutMs: total * 1000 }
+      : {}),
+  };
+}
+
 /** Remove incomplete model downloads after an interrupted index worker exits. */
 export async function removeModelDownloadTemps(modelName: string): Promise<void> {
   const fs = await import('node:fs');
@@ -802,6 +829,7 @@ async function runOnnxEmbedding(
   texts: string[],
   modelName: string,
   threads: number,
+  downloadOptions?: ModelDownloadOptions,
 ): Promise<Float32Array[]> {
   // Dynamic import — onnxruntime-node is an optional native dependency
   let ort: typeof import('onnxruntime-node');
@@ -814,7 +842,7 @@ async function runOnnxEmbedding(
   }
 
   // Inference runs inline with a hard-capped thread pool (see SessionOptions).
-  const session = await getOrCreateSession(ort, modelName, threads);
+  const session = await getOrCreateSession(ort, modelName, threads, downloadOptions);
 
   // Tokenize using proper BPE tokenizer, falling back to simpleTokenize.
   // Current local models (BGE / MiniLM) all use a 512-token window.
@@ -953,6 +981,7 @@ async function getOrCreateSession(
   ort: typeof import('onnxruntime-node'),
   modelName: string,
   threads: number,
+  downloadOptions?: ModelDownloadOptions,
 ): Promise<import('onnxruntime-node').InferenceSession> {
   // Cache key includes thread count so changing config takes effect after restart
   // (or after the cache entry is recreated on next process boot).
@@ -961,7 +990,7 @@ async function getOrCreateSession(
     return sessionCache.get(cacheKey)!;
   }
 
-  const modelPath = await resolveModelPath(modelName);
+  const modelPath = await resolveModelPath(modelName, downloadOptions);
   // Limit CPU: ORT defaults to "all physical cores" when threads are unset.
   // sequential executionMode avoids extra inter-op fan-out across graph nodes.
   const session = await ort.InferenceSession.create(modelPath, {
@@ -983,7 +1012,10 @@ async function getOrCreateSession(
  *
  * If not found, auto-downloads the model files from Hugging Face into storageId.
  */
-async function resolveModelPath(modelName: string): Promise<string> {
+async function resolveModelPath(
+  modelName: string,
+  downloadOptions?: ModelDownloadOptions,
+): Promise<string> {
   const fs = await import('node:fs');
   const path = await import('node:path');
 
@@ -1003,7 +1035,7 @@ async function resolveModelPath(modelName: string): Promise<string> {
   }
 
   // Auto-download on first use into the storageId directory
-  await downloadModel(modelName);
+  await downloadModel(modelName, undefined, downloadOptions);
 
   const primary = candidates[0]!;
   if (fs.existsSync(primary)) {

--- a/electron/src/main/rag/indexer.ts
+++ b/electron/src/main/rag/indexer.ts
@@ -285,7 +285,7 @@ export async function runIndexProjectImpl(
     store.initDb();
 
   if (!embedder) {
-    embedder = await createEmbedderFromConfig();
+    embedder = await createEmbedderFromConfig(cfg.rag);
   }
 
   // Verify vector/chunk alignment BEFORE reading file hashes. DB rows commit
@@ -337,7 +337,7 @@ export async function runIndexProjectImpl(
 
     try {
       // Read + hash
-      const result = await readAndHash(filepath);
+      const result = await readAndHash(filepath, cfg.rag.max_file_size);
       if (!result) {
         if (existingHashes.has(rel)) {
           store.deleteByFileBatch(vectorState, rel);
@@ -679,11 +679,11 @@ function shouldInclude(filepath: string): boolean {
 
 async function readAndHash(
   filepath: string,
+  maxFileSize: number,
 ): Promise<{ content: string; hash: string } | null> {
-  const cfg = getConfig();
   try {
     const stat = await fs.promises.stat(filepath);
-    if (stat.size > cfg.rag.max_file_size) return null;
+    if (stat.size > maxFileSize) return null;
     if (stat.size === 0) return null;
 
     const content = await fs.promises.readFile(filepath, 'utf-8');

--- a/electron/src/main/tools/ast/index-tool.ts
+++ b/electron/src/main/tools/ast/index-tool.ts
@@ -6,7 +6,7 @@
 import { z } from 'zod';
 import type { ToolDefinition, ToolHandler } from '../types';
 import { RiskClass } from '../../../shared/types/permission';
-import { genericToolResultMetadata } from '../types';
+import { genericToolResultMetadata, getToolConfig } from '../types';
 import { genericBuiltInToolOutcome, type GenericBuiltInToolOutcome } from '../result';
 import { indexProject } from '../../ast/indexer';
 import { ASTStore } from '../../ast/store';
@@ -81,6 +81,7 @@ export const astIndexHandler: ToolHandler = async (
       const result = await indexProject({
         projectPath,
         force: force === true,
+        config: getToolConfig(ctx),
       });
       return genericBuiltInToolOutcome('ast_index', {
         action: 'index',

--- a/electron/src/main/tools/rag/search.ts
+++ b/electron/src/main/tools/rag/search.ts
@@ -92,10 +92,11 @@ export const ragSearchHandler: ToolHandler = async (
       );
     }
 
-    // Search
+    // Search — pass the effective top_k explicitly; the store's internal
+    // fallback reads process-global config and would ignore project overrides.
     const results = store.search(
       Array.from(queryEmbedding),
-      top_k,
+      top_k ?? cfg.rag.top_k,
       file_pattern,
     );
 

--- a/electron/src/renderer/components/ConfigView.tsx
+++ b/electron/src/renderer/components/ConfigView.tsx
@@ -908,6 +908,7 @@ function renderTab(
           mcpResultMaxBytes={config.mcp_result_max_bytes}
           toolWorkerPoolSize={config.tool_worker_pool_size}
           toolWorkerPoolMainAgentReserved={config.tool_worker_pool_main_agent_reserved}
+          sessionTitleMaxWaitSeconds={config.session_title_max_wait_seconds}
           onChange={updateDraft}
         />
       );

--- a/electron/src/renderer/components/Preferences/GeneralTab.tsx
+++ b/electron/src/renderer/components/Preferences/GeneralTab.tsx
@@ -63,6 +63,8 @@ export interface GeneralTabProps {
   mcpResultMaxBytes: number;
   toolWorkerPoolSize: number;
   toolWorkerPoolMainAgentReserved: number;
+  /** Max seconds to wait mid-turn before auto-naming a default-named session. */
+  sessionTitleMaxWaitSeconds: number;
   onChange: (updates: ConfigPatch) => void;
 }
 
@@ -105,6 +107,7 @@ export function GeneralTab({
   mcpResultMaxBytes,
   toolWorkerPoolSize,
   toolWorkerPoolMainAgentReserved,
+  sessionTitleMaxWaitSeconds,
   onChange,
 }: GeneralTabProps) {
   const personalityOptions =
@@ -330,6 +333,23 @@ export function GeneralTab({
               className="w-full"
               min={0}
               max={8}
+            />
+          </FormField>
+          <FormField
+            label="Session Title Max Wait (s)"
+            htmlFor="general-session-title-wait"
+            hint="Deadline after a turn starts before auto-naming a default-named session from the conversation. 0 disables the deadline."
+            className="config-field"
+          >
+            <TextInput
+              id="general-session-title-wait"
+              type="number"
+              value={sessionTitleMaxWaitSeconds}
+              onChange={(e) => handleNumberChange('session_title_max_wait_seconds', e.target.value, 0)}
+              bordered
+              className="w-full"
+              min={0}
+              max={3600}
             />
           </FormField>
         </div>

--- a/electron/src/renderer/components/Preferences/GeneralTab.tsx
+++ b/electron/src/renderer/components/Preferences/GeneralTab.tsx
@@ -116,8 +116,8 @@ export function GeneralTab({
       : [...personalities];
 
   const handleNumberChange = useCallback(
-    (field: NumericConfigKey, value: string, min = 1) => {
-      const num = parseConfigNumber(value, min);
+    (field: NumericConfigKey, value: string, min = 1, max?: number) => {
+      const num = parseConfigNumber(value, min, { max });
       if (num !== null) {
         onChange(configNumberPatch(field, num));
       }
@@ -345,7 +345,7 @@ export function GeneralTab({
               id="general-session-title-wait"
               type="number"
               value={sessionTitleMaxWaitSeconds}
-              onChange={(e) => handleNumberChange('session_title_max_wait_seconds', e.target.value, 0)}
+              onChange={(e) => handleNumberChange('session_title_max_wait_seconds', e.target.value, 0, 3600)}
               bordered
               className="w-full"
               min={0}

--- a/electron/src/renderer/components/Preferences/MCPServersTab.tsx
+++ b/electron/src/renderer/components/Preferences/MCPServersTab.tsx
@@ -32,8 +32,17 @@ export interface MCPServerEntry {
 }
 
 export interface MCPServersTabProps {
+  /** Servers owned by this scope (global: every server; project: overrides). */
   mcpServers: Record<string, Record<string, unknown>>;
   onChange: (servers: Record<string, Record<string, unknown>>) => void;
+  /**
+   * Project scope: home-layer servers not overridden by this project. Shown
+   * read-only with an "Override" action; cannot be deleted here because the
+   * layer merge cannot mask a home alias.
+   */
+  inheritedServers?: Record<string, Record<string, unknown>>;
+  /** Aliases in `mcpServers` that override a same-named home server. */
+  overridingAliases?: ReadonlySet<string>;
 }
 
 interface EditingServer {
@@ -128,7 +137,28 @@ function withoutAuth(headers: Record<string, string>): Record<string, string> {
 
 // ── Component ────────────────────────────────────────────────────────────────
 
-export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
+/** Build the edit form state for one server entry (shared by edit/override/add). */
+function toEditForm(s: MCPServerEntry): EditingServer {
+  return {
+    id: s.id,
+    transport: s.transport,
+    command: s.command ?? '',
+    url: s.url ?? '',
+    argsText: s.args.join(' '),
+    envText: Object.entries(s.env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('\n'),
+    authToken: extractAuthToken(s.headers),
+    headers: withoutAuth(s.headers),
+  };
+}
+
+export function MCPServersTab({
+  mcpServers,
+  onChange,
+  inheritedServers,
+  overridingAliases,
+}: MCPServersTabProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<EditingServer | null>(null);
   const [isAdding, setIsAdding] = useState(false);
@@ -136,21 +166,13 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
   const serverList = Object.entries(mcpServers).map(([id, data]) =>
     parseServer(id, data),
   );
+  const inheritedList = Object.entries(inheritedServers ?? {}).map(([id, data]) =>
+    parseServer(id, data),
+  );
 
   const startEdit = useCallback((s: MCPServerEntry) => {
     setEditingId(s.id);
-    setEditForm({
-      id: s.id,
-      transport: s.transport,
-      command: s.command ?? '',
-      url: s.url ?? '',
-      argsText: s.args.join(' '),
-      envText: Object.entries(s.env)
-        .map(([k, v]) => `${k}=${v}`)
-        .join('\n'),
-      authToken: extractAuthToken(s.headers),
-      headers: withoutAuth(s.headers),
-    });
+    setEditForm(toEditForm(s));
     setIsAdding(false);
   }, []);
 
@@ -161,7 +183,9 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
   }, []);
 
   const saveEdit = useCallback(() => {
-    if (!editForm || !editingId) return;
+    // New servers (add / override) have no editingId — they commit through
+    // the same path once the form is valid.
+    if (!editForm || (!editingId && !isAdding)) return;
 
     const server: MCPServerEntry = {
       id: editForm.id,
@@ -184,7 +208,7 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
     }
 
     const updated = { ...mcpServers };
-    if (editingId !== editForm.id && editingId in updated) {
+    if (editingId && editingId !== editForm.id && editingId in updated) {
       delete updated[editingId];
     }
     updated[editForm.id] = serverToDict(server);
@@ -193,7 +217,7 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
     setEditingId(null);
     setEditForm(null);
     setIsAdding(false);
-  }, [editForm, editingId, mcpServers, onChange]);
+  }, [editForm, editingId, isAdding, mcpServers, onChange]);
 
   const deleteServer = useCallback(
     (id: string) => {
@@ -206,16 +230,20 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
 
   const startAdd = useCallback(() => {
     setEditingId(null);
-    setEditForm({
+    setEditForm(toEditForm({
       id: '',
       transport: 'stdio',
-      command: '',
-      url: '',
-      argsText: '',
-      envText: '',
-      authToken: '',
+      args: [],
+      env: {},
       headers: {},
-    });
+    }));
+    setIsAdding(true);
+  }, []);
+
+  /** Seed the add-editor with an inherited entry to create a project override. */
+  const startOverride = useCallback((s: MCPServerEntry) => {
+    setEditingId(null);
+    setEditForm(toEditForm(s));
     setIsAdding(true);
   }, []);
 
@@ -376,15 +404,57 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
         />
 
         <div className="config-card-list">
-          {serverList.map((s) => (
+          {inheritedList.map((s) => (
             <ConfigCard key={s.id}>
+              <ConfigCard.Body>
+                <div className="config-card-row flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="config-card-title font-semibold">
+                      {s.id}
+                      <span className="ml-2 align-middle text-xs font-normal text-base-content/60">
+                        inherited from global
+                      </span>
+                    </div>
+                    <p className="config-card-desc truncate text-sm text-base-content/70">
+                      {s.command ?? s.url ?? '(no command/url)'}
+                    </p>
+                    {s.args.length > 0 && (
+                      <p className="config-card-desc mt-1 font-mono truncate text-xs text-base-content/60">
+                        {s.args.join(' ')}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      type="button"
+                      onClick={() => startOverride(s)}
+                    >
+                      Override
+                    </Button>
+                  </div>
+                </div>
+              </ConfigCard.Body>
+            </ConfigCard>
+          ))}
+
+          {serverList.map((s) => (
+            <ConfigCard key={s.id} variant={overridingAliases?.has(s.id) ? 'active' : undefined}>
               <ConfigCard.Body>
                 {editingId === s.id && editForm ? (
                   renderEditor(editForm, null)
                 ) : (
                   <div className="config-card-row flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <div className="config-card-title font-semibold">{s.id}</div>
+                      <div className="config-card-title font-semibold">
+                        {s.id}
+                        {overridingAliases?.has(s.id) && (
+                          <span className="ml-2 align-middle text-xs font-normal text-primary">
+                            overrides global
+                          </span>
+                        )}
+                      </div>
                       <p className="config-card-desc truncate text-sm text-base-content/70">
                         {s.command ?? s.url ?? '(no command/url)'}
                       </p>
@@ -410,10 +480,14 @@ export function MCPServersTab({ mcpServers, onChange }: MCPServersTabProps) {
             </ConfigCard>
           )}
 
-          {!isAdding && serverList.length === 0 && (
+          {!isAdding && serverList.length === 0 && inheritedList.length === 0 && (
             <StateMessage
               kind="empty"
-              title="No MCP servers configured"
+              title={
+                inheritedServers
+                  ? 'No MCP servers configured for this project'
+                  : 'No MCP servers configured'
+              }
               className="py-4"
             />
           )}

--- a/electron/src/renderer/components/Preferences/MCPServersTab.tsx
+++ b/electron/src/renderer/components/Preferences/MCPServersTab.tsx
@@ -137,7 +137,7 @@ function withoutAuth(headers: Record<string, string>): Record<string, string> {
 
 // ── Component ────────────────────────────────────────────────────────────────
 
-/** Build the edit form state for one server entry (shared by edit/override/add). */
+// Build the edit form state for one server entry (shared by edit/override/add).
 function toEditForm(s: MCPServerEntry): EditingServer {
   return {
     id: s.id,
@@ -240,7 +240,7 @@ export function MCPServersTab({
     setIsAdding(true);
   }, []);
 
-  /** Seed the add-editor with an inherited entry to create a project override. */
+  // Seed the add-editor with an inherited entry to create a project override.
   const startOverride = useCallback((s: MCPServerEntry) => {
     setEditingId(null);
     setEditForm(toEditForm(s));

--- a/electron/src/renderer/components/Preferences/ModelAssignments.tsx
+++ b/electron/src/renderer/components/Preferences/ModelAssignments.tsx
@@ -97,7 +97,7 @@ export function ModelAssignments({
     [options],
   );
 
-  /** Human label for a selection, falling back to its raw ids. */
+  // Human label for a selection, falling back to its raw ids.
   const selectionLabel = (selection: ModelSelection | null | undefined): string => {
     if (!selection) return '';
     return optionLabels[selectionKey(selection)]

--- a/electron/src/renderer/components/Preferences/ModelAssignments.tsx
+++ b/electron/src/renderer/components/Preferences/ModelAssignments.tsx
@@ -42,6 +42,19 @@ export interface ModelAssignmentsProps {
   ) => void;
   readonly disabled?: boolean;
   readonly className?: string;
+  /**
+   * Project-scope mode: the maps hold explicit project overrides only, the
+   * empty picker entry means "inherit the global (home) assignment", and tier
+   * overrides are reset through {@link onTierReset} rather than null entries.
+   */
+  readonly projectScope?: boolean;
+  /** Home-layer values shown as inherit targets (project scope only). */
+  readonly inheritedDefaultModel?: ModelSelection | null;
+  readonly inheritedTierModels?: Record<string, ModelSelection | null>;
+  /** Remove one tier's project override — revert to the home assignment. */
+  readonly onTierReset?: (tierId: string) => void;
+  /** Remove the project default-model override — revert to the home default. */
+  readonly onDefaultModelReset?: () => void;
 }
 
 function optionSelection(option: ProviderModelOption): ModelSelection {
@@ -62,6 +75,11 @@ export function ModelAssignments({
   onTierReasoningEffortChange,
   disabled = false,
   className = '',
+  projectScope = false,
+  inheritedDefaultModel = null,
+  inheritedTierModels = {},
+  onTierReset,
+  onDefaultModelReset,
 }: ModelAssignmentsProps) {
   const byKey = useMemo(
     () => new Map(options.map((option) => [providerModelOptionKey(option), option])),
@@ -79,6 +97,17 @@ export function ModelAssignments({
     [options],
   );
 
+  /** Human label for a selection, falling back to its raw ids. */
+  const selectionLabel = (selection: ModelSelection | null | undefined): string => {
+    if (!selection) return '';
+    return optionLabels[selectionKey(selection)]
+      ?? `${selection.connectionId} · ${selection.modelId}`;
+  };
+  const inheritLabel = (selection: ModelSelection | null | undefined, fallback: string): string => {
+    const label = selectionLabel(selection);
+    return label ? `Inherit global (${label})` : `Inherit global (${fallback})`;
+  };
+
   const updateSelection = (
     value: string,
     onChange: (selection: ModelSelection | null) => void,
@@ -95,7 +124,9 @@ export function ModelAssignments({
       <Panel as="section" className="config-fieldset flex flex-col gap-3">
         <SectionHeader
           title="Default model"
-          description="This model is selected for new chats. Each tier can override it for agent work."
+          description={projectScope
+            ? 'Project default for chats in this workspace. Inherits the global default when unset.'
+            : 'This model is selected for new chats. Each tier can override it for agent work.'}
         />
         {!defaultAvailable && (
           <Alert tone="warning" className="text-sm">
@@ -107,20 +138,33 @@ export function ModelAssignments({
           options={options.map(providerModelOptionKey)}
           optionLabels={optionLabels}
           optionDetails={optionDetails}
-          additionalOptions={[{ value: '', label: 'Not configured' }]}
+          additionalOptions={[{
+            value: '',
+            label: projectScope
+              ? inheritLabel(inheritedDefaultModel, 'not configured')
+              : 'Not configured',
+          }]}
           label="Default model"
           align="start"
           className="w-full"
           disabled={disabled || options.length === 0}
           emptyMessage="No ready chat models available"
-          onChange={(value) => updateSelection(value, onDefaultModelChange)}
+          onChange={(value) => {
+            if (projectScope && value === '') {
+              onDefaultModelReset?.();
+              return;
+            }
+            updateSelection(value, onDefaultModelChange);
+          }}
         />
       </Panel>
 
       <Panel as="section" className="config-fieldset flex flex-col gap-3">
         <SectionHeader
           title="Tier Models"
-          description="Assign a model to each tier. A tier left unconfigured falls back to the default model."
+          description={projectScope
+            ? 'Project tier assignments override the global ones for this workspace. Unset tiers inherit the global assignment.'
+            : 'Assign a model to each tier. A tier left unconfigured falls back to the default model.'}
         />
         {options.length === 0 && (
           <StateMessage
@@ -135,16 +179,26 @@ export function ModelAssignments({
             const selected = tierModels[tier.id] ?? null;
             const currentKey = selectionKey(selected);
             const currentAvailable = !selected || byKey.has(currentKey);
-            const reasoning = reasoningConfigForSelection(selected, connections, options);
+            const overridden = projectScope && tier.id in tierModels;
+            const inheritedSelection = inheritedTierModels[tier.id] ?? null;
+            const reasoningSelection = projectScope
+              ? (selected ?? inheritedSelection)
+              : selected;
+            const reasoning = reasoningConfigForSelection(reasoningSelection, connections, options);
             const showReasoning = onTierReasoningEffortChange !== undefined
               && reasoning.supportsReasoning
               && reasoning.levels.length > 0;
             return (
-              <ConfigCard key={tier.id}>
+              <ConfigCard key={tier.id} variant={overridden ? 'active' : undefined}>
                 <ConfigCard.Body variant="row">
                   <div className="min-w-0 flex-1">
                     <div className="config-card-title font-semibold">{tier.label}</div>
                     <p className="config-card-desc text-sm text-base-content/70">{tier.description}</p>
+                    {projectScope && !overridden && (
+                      <p className="config-card-desc mt-1 text-xs text-base-content/60">
+                        {inheritLabel(inheritedSelection, 'default model')}
+                      </p>
+                    )}
                     {!currentAvailable && (
                       <p className="mt-1 text-xs text-warning">
                         Current selection is unavailable; choose a ready connection.
@@ -157,13 +211,22 @@ export function ModelAssignments({
                       options={options.map(providerModelOptionKey)}
                       optionLabels={optionLabels}
                       optionDetails={optionDetails}
-                      additionalOptions={[{ value: '', label: 'Use default model' }]}
+                      additionalOptions={[{
+                        value: '',
+                        label: projectScope
+                          ? inheritLabel(inheritedSelection, 'default model')
+                          : 'Use default model',
+                      }]}
                       label={`${tier.label} tier model`}
                       align="end"
                       className="tier-model-picker"
                       disabled={disabled || options.length === 0}
                       emptyMessage="No ready chat models available"
                       onChange={(value) => {
+                        if (projectScope && value === '') {
+                          onTierReset?.(tier.id);
+                          return;
+                        }
                         const next = { ...tierModels };
                         const option = byKey.get(value);
                         next[tier.id] = option ? optionSelection(option) : null;

--- a/electron/src/renderer/components/Preferences/ProjectTierModelsTab.tsx
+++ b/electron/src/renderer/components/Preferences/ProjectTierModelsTab.tsx
@@ -52,22 +52,25 @@ function coerceSelection(value: unknown): ModelSelection | null {
   return null;
 }
 
-/**
- * Explicit-null tier entries ("mask the home tier, use the default model")
- * are a file-level state the project UI does not model — the picker is
- * inherit-or-selection. Treat them as absent so a save through this view
- * normalizes them away instead of mislabeling them "Inherit global".
- */
+// Explicit-null tier entries mask the home assignment ("use the default
+// model") — a file-level state the inherit-or-selection picker cannot
+// express. Preserve them as-is so a later save through this view keeps the
+// exact tier map instead of silently deleting the mask. Invalid non-null
+// entries still normalize away.
 function selectionRecord(value: unknown): Record<string, ModelSelection | null> {
   const out: Record<string, ModelSelection | null> = {};
   for (const [key, entry] of Object.entries(plainRecord(value))) {
+    if (entry === null) {
+      out[key] = null;
+      continue;
+    }
     const selection = coerceSelection(entry);
     if (selection !== null) out[key] = selection;
   }
   return out;
 }
 
-/** Null efforts are runtime-equivalent to absent for our two-state UI; drop. */
+// Null efforts are runtime-equivalent to absent for our two-state UI; drop.
 function effortRecord(value: unknown): Record<string, string | number | null> {
   const out: Record<string, string | number | null> = {};
   for (const [key, entry] of Object.entries(plainRecord(value))) {

--- a/electron/src/renderer/components/Preferences/ProjectTierModelsTab.tsx
+++ b/electron/src/renderer/components/Preferences/ProjectTierModelsTab.tsx
@@ -1,0 +1,164 @@
+/**
+ * ProjectTierModelsTab — per-project tier model / default model / reasoning
+ * effort overrides.
+ *
+ * The runtime already resolves these from the project layer
+ * (`ProjectRuntime.config` → `tier_models` → `default_model`), so this editor
+ * makes that capability explicit instead of the old "global only" notice.
+ * Overrides replace the project file's tier maps exactly; unset tiers inherit
+ * the global (home) assignment.
+ */
+import { useEffect, useMemo } from 'react';
+import type { ModelSelection } from '../../../shared/types/provider';
+import type { Config } from '../../../shared/types/ipc-boundary';
+import { useProviders } from '../../hooks/useProviders';
+import { onOrchidEvent } from '../../utils/events';
+import { isTextGenerationModel } from '../../utils/models';
+import { ModelAssignments } from './ModelAssignments';
+
+/** Explicit project overrides for the tier assignment surface. */
+export interface ProjectTierOverrides {
+  /** null = clear the override (inherit the home default). */
+  defaultModel: ModelSelection | null;
+  tierModels: Record<string, ModelSelection | null>;
+  tierReasoningEffort: Record<string, string | number | null>;
+}
+
+export interface ProjectTierModelsTabProps {
+  /** Global (home-only) config providing inherit targets. */
+  readonly homeConfig: Config | null;
+  /** Tier overrides stored in the project `.orchid.json`. */
+  readonly stored: ProjectTierOverrides;
+  /** Draft edits; `null` parts mean "no change from stored". */
+  readonly draft: ProjectTierOverrides | null;
+  readonly onDraftChange: (draft: ProjectTierOverrides | null) => void;
+}
+
+function plainRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/** Shape-validate a raw `.orchid.json` value as a ModelSelection (or null). */
+function coerceSelection(value: unknown): ModelSelection | null {
+  if (
+    value !== null && typeof value === 'object'
+    && typeof (value as Record<string, unknown>)['connectionId'] === 'string'
+    && typeof (value as Record<string, unknown>)['modelId'] === 'string'
+  ) {
+    return value as unknown as ModelSelection;
+  }
+  return null;
+}
+
+/**
+ * Explicit-null tier entries ("mask the home tier, use the default model")
+ * are a file-level state the project UI does not model — the picker is
+ * inherit-or-selection. Treat them as absent so a save through this view
+ * normalizes them away instead of mislabeling them "Inherit global".
+ */
+function selectionRecord(value: unknown): Record<string, ModelSelection | null> {
+  const out: Record<string, ModelSelection | null> = {};
+  for (const [key, entry] of Object.entries(plainRecord(value))) {
+    const selection = coerceSelection(entry);
+    if (selection !== null) out[key] = selection;
+  }
+  return out;
+}
+
+/** Null efforts are runtime-equivalent to absent for our two-state UI; drop. */
+function effortRecord(value: unknown): Record<string, string | number | null> {
+  const out: Record<string, string | number | null> = {};
+  for (const [key, entry] of Object.entries(plainRecord(value))) {
+    if (typeof entry === 'string' || typeof entry === 'number') {
+      out[key] = entry;
+    }
+  }
+  return out;
+}
+
+/** Read tier overrides out of raw project-config overrides. */
+export function readTierOverrides(overrides: Record<string, unknown>): ProjectTierOverrides {
+  return {
+    defaultModel: coerceSelection(overrides['default_model']),
+    tierModels: selectionRecord(overrides['tier_models']),
+    tierReasoningEffort: effortRecord(overrides['tier_reasoning_effort']),
+  };
+}
+
+function stripNullEfforts(
+  map: Record<string, string | number | null>,
+): Record<string, string | number | null> {
+  const out: Record<string, string | number | null> = {};
+  for (const [key, value] of Object.entries(map)) {
+    if (value !== null) out[key] = value;
+  }
+  return out;
+}
+
+export function ProjectTierModelsTab({
+  homeConfig,
+  stored,
+  draft,
+  onDraftChange,
+}: ProjectTierModelsTabProps) {
+  const providers = useProviders();
+
+  useEffect(() => {
+    void providers.ensureModelList();
+  }, [providers.ensureModelList]);
+
+  useEffect(() => {
+    return onOrchidEvent('orchid:providers-updated', () => {
+      void providers.refresh().then(() => providers.ensureModelList());
+    });
+  }, [providers.refresh, providers.ensureModelList]);
+
+  const options = useMemo(
+    () => (providers.modelOptions ?? []).filter(
+      (option) => option.available && isTextGenerationModel(option.model),
+    ),
+    [providers.modelOptions],
+  );
+
+  const effective = draft ?? stored;
+
+  const resetTier = (tierId: string): void => {
+    const next = { ...effective.tierModels };
+    delete next[tierId];
+    onDraftChange({ ...effective, tierModels: next });
+  };
+  const setDefault = (selection: ModelSelection | null): void => {
+    onDraftChange({ ...effective, defaultModel: selection });
+  };
+  const clearDefault = (): void => {
+    onDraftChange({ ...effective, defaultModel: null });
+  };
+
+  return (
+    <div className="config-form">
+      <ModelAssignments
+        options={options}
+        connections={providers.overview?.connections ?? []}
+        defaultModel={effective.defaultModel}
+        tierModels={effective.tierModels}
+        tierReasoningEffort={effective.tierReasoningEffort}
+        projectScope
+        inheritedDefaultModel={homeConfig?.default_model ?? null}
+        inheritedTierModels={homeConfig?.tier_models ?? {}}
+        onDefaultModelChange={setDefault}
+        onDefaultModelReset={clearDefault}
+        onTierModelsChange={(next) => {
+          // ModelAssignments sends the complete desired map; only explicit
+          // selections reach here ('' routes to resetTier in project scope).
+          onDraftChange({ ...effective, tierModels: next });
+        }}
+        onTierReset={resetTier}
+        onTierReasoningEffortChange={(next) => {
+          onDraftChange({ ...effective, tierReasoningEffort: stripNullEfforts(next) });
+        }}
+      />
+    </div>
+  );
+}

--- a/electron/src/renderer/components/ProjectConfigView.tsx
+++ b/electron/src/renderer/components/ProjectConfigView.tsx
@@ -1,13 +1,28 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { DefinitionsListResult } from '../../shared/types/definitions';
-import type { Config, PermissionRule, RAGConfig } from '../../shared/types/ipc-boundary';
+import type { Config, PermissionRule } from '../../shared/types/ipc-boundary';
 import type { ConfigPatch, ConfigPatchMap } from '../../shared/types/ipc';
 import { useGlobalShortcuts } from '../keyboard';
-import { THEMES, THEME_NAMES, type ThemeName } from '../themes';
 import { parseConfigNumber } from '../utils/config-draft';
+import {
+  deepEqual,
+  fieldInputId,
+  isPlainRecord,
+  readGlobalValue,
+  readStoredOverride,
+  toInputValue,
+  toServerMap,
+  withMcpTombstones,
+} from '../utils/project-config';
 import { AgentsTab } from './Preferences/AgentsTab';
+import { MCPServersTab } from './Preferences/MCPServersTab';
 import { PermissionsTab } from './Preferences/PermissionsTab';
 import { PersonalitiesTab } from './Preferences/PersonalitiesTab';
+import {
+  ProjectTierModelsTab,
+  readTierOverrides,
+  type ProjectTierOverrides,
+} from './Preferences/ProjectTierModelsTab';
 import { SkillsTab } from './Preferences/SkillsTab';
 import { Keycaps } from './Keycaps';
 import { Alert } from './ui/Alert';
@@ -37,6 +52,7 @@ type ProjectTab =
   | 'mcp'
   | 'tiers'
   | 'rag'
+  | 'agents-md'
   | 'skills'
   | 'agents'
   | 'personalities'
@@ -53,6 +69,7 @@ const PROJECT_TABS: ProjectTabDef[] = [
   { id: 'mcp', label: 'MCP Servers' },
   { id: 'tiers', label: 'Tier Models' },
   { id: 'rag', label: 'RAG' },
+  { id: 'agents-md', label: 'AGENTS.md' },
   { id: 'compaction', label: 'Compaction' },
   { id: 'skills', label: 'Skills' },
   { id: 'agents', label: 'Agents' },
@@ -65,7 +82,6 @@ type ProjectFieldKind =
   | 'text'
   | 'string-list'
   | 'boolean'
-  | 'theme'
   | 'personality'
   | 'select';
 
@@ -94,10 +110,17 @@ const TAB_SECTIONS: Partial<Record<ProjectTab, ProjectConfigSection[]>> = {
     {
       title: 'General',
       fields: [
-        { key: 'theme', label: 'Theme', kind: 'theme' },
         { key: 'personality', label: 'Personality', kind: 'personality' },
         { key: 'ignored_dirs', label: 'Ignored Directories', kind: 'string-list', fullWidth: true },
         { key: 'always_expand_tool_groups', label: 'Always Expand Tool Groups', kind: 'boolean' },
+        {
+          key: 'session_title_max_wait_seconds',
+          label: 'Session Title Max Wait (s)',
+          kind: 'number',
+          min: 0,
+          max: 3600,
+          hint: 'Deadline after a turn starts before auto-naming from the conversation. 0 disables the deadline.',
+        },
       ],
     },
     {
@@ -178,6 +201,31 @@ const TAB_SECTIONS: Partial<Record<ProjectTab, ProjectConfigSection[]>> = {
       ],
     },
   ],
+  'agents-md': [
+    {
+      title: 'AGENTS.md Discovery',
+      fields: [
+        { key: 'agents_md.enabled', label: 'Enabled', kind: 'boolean' },
+        { key: 'agents_md.inject_on_read', label: 'Inject On Read', kind: 'boolean' },
+        { key: 'agents_md.include_local', label: 'Include Local', kind: 'boolean' },
+        {
+          key: 'agents_md.enforce_on_write',
+          label: 'Enforce On Write',
+          kind: 'select',
+          options: ['block', 'inject', 'warn', 'off'],
+        },
+        {
+          key: 'agents_md.filenames',
+          label: 'Filenames',
+          kind: 'string-list',
+          fullWidth: true,
+          hint: 'Up to 16 filenames.',
+        },
+        { key: 'agents_md.max_file_bytes', label: 'Max File Bytes', kind: 'integer', min: 1, max: 2_097_152 },
+        { key: 'agents_md.max_chain_depth', label: 'Max Chain Depth', kind: 'integer', min: 1, max: 32 },
+      ],
+    },
+  ],
   compaction: [
     {
       title: 'Main Scope',
@@ -212,66 +260,6 @@ const ALL_FIELD_KEYS = Object.values(TAB_SECTIONS).flatMap((sections) => (
   (sections ?? []).flatMap((section) => section.fields.map((field) => field.key))
 ));
 
-/** Type guard for a non-null, non-array plain object. */
-export function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-/** Read a stored project override by field key, resolving `rag.*` and `compaction.*` into nested maps. */
-export function readStoredOverride(overrides: Record<string, unknown>, key: string): unknown {
-  if (key === 'compaction') {
-    return overrides['compaction'];
-  }
-  if (key.startsWith('compaction.')) {
-    const parts = key.slice('compaction.'.length).split('.');
-    let cur: unknown = overrides['compaction'];
-    for (const part of parts) {
-      if (!isPlainRecord(cur)) return undefined;
-      cur = (cur as Record<string, unknown>)[part];
-    }
-    return cur;
-  }
-  if (key.startsWith('rag.')) {
-    const rag = overrides['rag'];
-    return isPlainRecord(rag) ? rag[key.slice(4)] : undefined;
-  }
-  return overrides[key];
-}
-
-/** Read a value from the global (home) config by field key, resolving `rag.*` and `compaction.*` into nested maps. */
-export function readGlobalValue(config: Config | null, key: string): unknown {
-  if (!config) return undefined;
-  if (key === 'compaction') {
-    return (config as unknown as Record<string, unknown>)['compaction'];
-  }
-  if (key.startsWith('compaction.')) {
-    const parts = key.slice('compaction.'.length).split('.');
-    let cur: unknown = (config as unknown as Record<string, unknown>)['compaction'];
-    for (const part of parts) {
-      if (cur == null || typeof cur !== 'object') return undefined;
-      cur = (cur as Record<string, unknown>)[part];
-    }
-    return cur;
-  }
-  if (key.startsWith('rag.')) {
-    return config.rag[key.slice(4) as keyof RAGConfig];
-  }
-  return config[key as keyof Config];
-}
-
-/** Coerce a config value into an editable form input value (arrays become comma-separated). */
-export function toInputValue(value: unknown): string | number {
-  if (value === null || value === undefined) return '';
-  if (typeof value === 'number') return value;
-  if (Array.isArray(value)) return value.map(String).join(', ');
-  return String(value);
-}
-
-/** Derive a stable, DOM-safe input element id from a config field key. */
-export function fieldInputId(key: string): string {
-  return `project-config-${key.replace(/[^a-zA-Z0-9]+/g, '-')}`;
-}
-
 function toPlaceholder(value: unknown): string {
   if (value === null || value === undefined) return '';
   if (Array.isArray(value)) return value.map(String).join(', ');
@@ -297,6 +285,8 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
   const [homeConfig, setHomeConfig] = useState<Config | null>(null);
   const [draft, setDraft] = useState<Record<string, unknown>>({});
   const [permissionDraft, setPermissionDraft] = useState<ConfigPatchMap<PermissionRule>>({});
+  const [tierDraft, setTierDraft] = useState<ProjectTierOverrides | null>(null);
+  const [mcpDraft, setMcpDraft] = useState<Record<string, Record<string, unknown>> | null>(null);
   const [definitions, setDefinitions] = useState<DefinitionsListResult | null>(null);
   const [defsLoading, setDefsLoading] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -329,6 +319,8 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
     setError(null);
     setDraft({});
     setPermissionDraft({});
+    setTierDraft(null);
+    setMcpDraft(null);
     setDefsLoading(true);
     async function load() {
       try {
@@ -384,14 +376,50 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
     [permissionDraft, storedProjectPermissions],
   );
 
-  const dirty = configDirty || permissionDirty;
+  const storedTierOverrides = useMemo(() => readTierOverrides(overrides), [overrides]);
+
+  const tierDirty = useMemo(
+    () => tierDraft !== null && !(
+      deepEqual(tierDraft.defaultModel, storedTierOverrides.defaultModel)
+      && deepEqual(tierDraft.tierModels, storedTierOverrides.tierModels)
+      && deepEqual(tierDraft.tierReasoningEffort, storedTierOverrides.tierReasoningEffort)
+    ),
+    [tierDraft, storedTierOverrides],
+  );
+
+  const storedMcpServers = useMemo(
+    () => toServerMap(overrides['mcp_servers']),
+    [overrides],
+  );
+
+  const mcpDirty = useMemo(
+    () => mcpDraft !== null && !deepEqual(mcpDraft, storedMcpServers),
+    [mcpDraft, storedMcpServers],
+  );
+
+  const dirty = configDirty || permissionDirty || tierDirty || mcpDirty;
 
   const overrideCount = useMemo(
     () => ALL_FIELD_KEYS.filter((key) => effectiveValue(key) != null).length,
     [effectiveValue],
   );
 
-  const totalOverrideCount = overrideCount + Object.keys(effectiveProjectPermissions).length;
+  const tierOverrideCount = useMemo(
+    () => (storedTierOverrides.defaultModel ? 1 : 0)
+      + Object.keys(storedTierOverrides.tierModels).length
+      + Object.keys(storedTierOverrides.tierReasoningEffort).length,
+    [storedTierOverrides],
+  );
+
+  const mcpOverrideCount = useMemo(
+    () => Object.keys(storedMcpServers).length,
+    [storedMcpServers],
+  );
+
+  const totalOverrideCount = overrideCount
+    + Object.keys(effectiveProjectPermissions).length
+    + tierOverrideCount
+    + mcpOverrideCount;
 
   const personalityNames = useMemo(() => {
     const names = new Set<string>();
@@ -419,7 +447,6 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
       if (trimmed === '') return { ...previous, [field.key]: null };
       switch (field.kind) {
         case 'text':
-        case 'theme':
         case 'personality':
         case 'select':
           return { ...previous, [field.key]: trimmed };
@@ -470,6 +497,8 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
       for (const key of Object.keys(effectiveProjectPermissions)) next[key] = null;
       return next;
     });
+    setTierDraft({ defaultModel: null, tierModels: {}, tierReasoningEffort: {} });
+    setMcpDraft({});
   }, [effectiveProjectPermissions]);
 
   const handleSave = useCallback(async () => {
@@ -487,11 +516,15 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
     try {
       const updates: Record<string, unknown> = {};
       const ragUpdates: Record<string, unknown> = {};
+      const agentsMdUpdates: Record<string, unknown> = {};
       const compactionUpdates: Record<string, Record<string, unknown>> = {};
       for (const [key, value] of Object.entries(draft)) {
         const stored = readStoredOverride(overrides, key);
         if ((value ?? undefined) === (stored ?? undefined)) continue;
         if (key.startsWith('rag.')) ragUpdates[key.slice(4)] = value;
+        else if (key.startsWith('agents_md.')) {
+          agentsMdUpdates[key.slice('agents_md.'.length)] = value;
+        }
         else if (key.startsWith('compaction.')) {
           const remainder = key.slice('compaction.'.length);
           const parts = remainder.split('.');
@@ -508,7 +541,23 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
         else updates[key] = value;
       }
       if (Object.keys(ragUpdates).length > 0) updates['rag'] = ragUpdates;
+      if (Object.keys(agentsMdUpdates).length > 0) updates['agents_md'] = agentsMdUpdates;
       if (Object.keys(compactionUpdates).length > 0) updates['compaction'] = compactionUpdates;
+
+      if (tierDraft !== null) {
+        if (!deepEqual(tierDraft.defaultModel, storedTierOverrides.defaultModel)) {
+          updates['default_model'] = tierDraft.defaultModel;
+        }
+        if (!deepEqual(tierDraft.tierModels, storedTierOverrides.tierModels)) {
+          updates['tier_models'] = tierDraft.tierModels;
+        }
+        if (!deepEqual(tierDraft.tierReasoningEffort, storedTierOverrides.tierReasoningEffort)) {
+          updates['tier_reasoning_effort'] = tierDraft.tierReasoningEffort;
+        }
+      }
+      if (mcpDraft !== null && !deepEqual(mcpDraft, storedMcpServers)) {
+        updates['mcp_servers'] = withMcpTombstones(mcpDraft, storedMcpServers);
+      }
 
       const permissionUpdates: Record<string, PermissionRule | null> = {};
       for (const [key, value] of Object.entries(permissionDraft)) {
@@ -532,12 +581,26 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
       setOverrides(isPlainRecord(result.overrides) ? result.overrides : {});
       setDraft({});
       setPermissionDraft({});
+      setTierDraft(null);
+      setMcpDraft(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save project configuration.');
     } finally {
       setSaving(false);
     }
-  }, [dirty, saving, draft, overrides, permissionDraft, storedProjectPermissions, projectDir]);
+  }, [
+    dirty,
+    saving,
+    draft,
+    overrides,
+    permissionDraft,
+    storedProjectPermissions,
+    storedTierOverrides,
+    storedMcpServers,
+    tierDraft,
+    mcpDraft,
+    projectDir,
+  ]);
 
   useGlobalShortcuts({
     handlers: {
@@ -555,7 +618,9 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
     activeTab === 'general' ||
     activeTab === 'permissions' ||
     activeTab === 'mcp' ||
+    activeTab === 'tiers' ||
     activeTab === 'rag' ||
+    activeTab === 'agents-md' ||
     activeTab === 'compaction';
 
   const renderSelectOptions = (field: ProjectFieldSpec, homeValue: unknown) => {
@@ -568,22 +633,6 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
           {opts.map((opt) => (
             <option key={opt} value={opt}>
               {opt}
-            </option>
-          ))}
-        </>
-      );
-    }
-    if (field.kind === 'theme') {
-      const homeLabel =
-        typeof homeValue === 'string' && homeValue in THEMES
-          ? THEMES[homeValue as ThemeName]
-          : toPlaceholder(homeValue);
-      return (
-        <>
-          <option value="">{homeLabel ? `Inherit global (${homeLabel})` : 'Inherit global'}</option>
-          {THEME_NAMES.map((name) => (
-            <option key={name} value={name}>
-              {THEMES[name]}
             </option>
           ))}
         </>
@@ -618,7 +667,6 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
     const inputId = fieldInputId(field.key);
     const isSelect =
       field.kind === 'boolean' ||
-      field.kind === 'theme' ||
       field.kind === 'personality' ||
       field.kind === 'select';
     return (
@@ -693,10 +741,46 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
   const renderTab = () => {
     switch (activeTab) {
       case 'general':
-      case 'mcp':
       case 'rag':
+      case 'agents-md':
       case 'compaction':
         return renderConfigTab(activeTab);
+      case 'mcp': {
+        const effectiveMcp = mcpDraft ?? storedMcpServers;
+        const homeServers = toServerMap(homeConfig?.mcp_servers);
+        const inheritedServers = Object.fromEntries(
+          Object.entries(homeServers).filter(([alias]) => !(alias in effectiveMcp)),
+        );
+        const overridingAliases = new Set(
+          Object.keys(effectiveMcp).filter((alias) => alias in homeServers),
+        );
+        return (
+          <>
+            {renderConfigTab('mcp')}
+            <MCPServersTab
+              mcpServers={effectiveMcp}
+              inheritedServers={inheritedServers}
+              overridingAliases={overridingAliases}
+              onChange={setMcpDraft}
+            />
+            <p className="px-1 text-xs text-base-content/60">
+              Server changes take effect for new turns in this project; running turns keep
+              their current servers. Project stdio servers run from this directory. Note:
+              entries (including auth tokens and env values) are stored in{' '}
+              <code>.orchid.json</code>, which is usually committed — avoid secrets here.
+            </p>
+          </>
+        );
+      }
+      case 'tiers':
+        return (
+          <ProjectTierModelsTab
+            homeConfig={homeConfig}
+            stored={storedTierOverrides}
+            draft={tierDraft}
+            onDraftChange={setTierDraft}
+          />
+        );
       case 'permissions':
         if (!permissionConfig) {
           return (
@@ -711,13 +795,6 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
             projectDir={projectDir}
             inheritedPermissions={homeConfig?.permissions ?? {}}
           />
-        );
-      case 'tiers':
-        return (
-          <StateMessage kind="info" title="Tier models are configured globally">
-            Model and reasoning effort assignments apply to every project. Open the global
-            Configuration view to change them.
-          </StateMessage>
         );
       case 'skills':
         if (!definitions) {

--- a/electron/src/renderer/utils/config-save.ts
+++ b/electron/src/renderer/utils/config-save.ts
@@ -252,6 +252,8 @@ function deepEqual(left: unknown, right: unknown): boolean {
   );
 }
 
+export { deepEqual };
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object';
 }

--- a/electron/src/renderer/utils/project-config.ts
+++ b/electron/src/renderer/utils/project-config.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure helpers for the project-scoped configuration editor
+ * (ProjectConfigView). Extracted so the override read/coerce/tombstone logic
+ * is unit-testable without mounting the component.
+ */
+import type { Config, RAGConfig } from '../../shared/types/ipc-boundary';
+import { deepEqual } from './config-save';
+
+/** Type guard for a non-null, non-array plain object. */
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export { deepEqual };
+
+/** Read a stored project override by field key, resolving `rag.*`, `agents_md.*` and `compaction.*` into nested maps. */
+export function readStoredOverride(overrides: Record<string, unknown>, key: string): unknown {
+  if (key === 'compaction') {
+    return overrides['compaction'];
+  }
+  if (key.startsWith('compaction.')) {
+    const parts = key.slice('compaction.'.length).split('.');
+    let cur: unknown = overrides['compaction'];
+    for (const part of parts) {
+      if (!isPlainRecord(cur)) return undefined;
+      cur = (cur as Record<string, unknown>)[part];
+    }
+    return cur;
+  }
+  if (key.startsWith('rag.')) {
+    const rag = overrides['rag'];
+    return isPlainRecord(rag) ? rag[key.slice(4)] : undefined;
+  }
+  if (key.startsWith('agents_md.')) {
+    const agentsMd = overrides['agents_md'];
+    return isPlainRecord(agentsMd) ? agentsMd[key.slice('agents_md.'.length)] : undefined;
+  }
+  return overrides[key];
+}
+
+/** Read a value from the global (home) config by field key, resolving `rag.*`, `agents_md.*` and `compaction.*` into nested maps. */
+export function readGlobalValue(config: Config | null, key: string): unknown {
+  if (!config) return undefined;
+  if (key === 'compaction') {
+    return (config as unknown as Record<string, unknown>)['compaction'];
+  }
+  if (key.startsWith('compaction.')) {
+    const parts = key.slice('compaction.'.length).split('.');
+    let cur: unknown = (config as unknown as Record<string, unknown>)['compaction'];
+    for (const part of parts) {
+      if (cur == null || typeof cur !== 'object') return undefined;
+      cur = (cur as Record<string, unknown>)[part];
+    }
+    return cur;
+  }
+  if (key.startsWith('rag.')) {
+    return config.rag[key.slice(4) as keyof RAGConfig];
+  }
+  if (key.startsWith('agents_md.')) {
+    const agentsMd = (config as unknown as Record<string, unknown>)['agents_md'];
+    return isPlainRecord(agentsMd)
+      ? agentsMd[key.slice('agents_md.'.length)]
+      : undefined;
+  }
+  return config[key as keyof Config];
+}
+
+/** Coerce a config value into an editable form input value (arrays become comma-separated). */
+export function toInputValue(value: unknown): string | number {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number') return value;
+  if (Array.isArray(value)) return value.map(String).join(', ');
+  return String(value);
+}
+
+/** Derive a stable, DOM-safe input element id from a config field key. */
+export function fieldInputId(key: string): string {
+  return `project-config-${key.replace(/[^a-zA-Z0-9]+/g, '-')}`;
+}
+
+/** Coerce a raw config value into a `Record<string, Record<string, unknown>>`. */
+export function toServerMap(value: unknown): Record<string, Record<string, unknown>> {
+  if (!isPlainRecord(value)) return {};
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const [alias, entry] of Object.entries(value)) {
+    if (isPlainRecord(entry)) out[alias] = entry;
+  }
+  return out;
+}
+
+/**
+ * Build a project `mcp_servers` update from a desired override map: removed
+ * aliases become `null` tombstones so the per-alias merge deletes them from
+ * the project file (a home alias then resurfaces).
+ */
+export function withMcpTombstones(
+  desired: Record<string, Record<string, unknown>>,
+  stored: Record<string, Record<string, unknown>>,
+): Record<string, Record<string, unknown> | null> {
+  const updates: Record<string, Record<string, unknown> | null> = { ...desired };
+  for (const alias of Object.keys(stored)) {
+    if (!(alias in updates)) updates[alias] = null;
+  }
+  return updates;
+}

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -559,6 +559,14 @@ export interface ProjectConfigReadResult {
 
 export interface ProjectConfigSaveMessage {
   projectDir: string;
+  /**
+   * Project-config overrides. Keys outside the per-project allow-list are
+   * rejected (fail-loud), not filtered. Special semantics: `mcp_servers`
+   * merges per alias with `null` tombstones for removed aliases;
+   * `tier_models`/`tier_reasoning_effort` replace the stored map exactly
+   * (absent tier = inherit global); `default_model: null` clears the
+   * override instead of storing an explicit null.
+   */
   updates: Record<string, unknown>;
 }
 

--- a/electron/tests/unit/config-ipc.test.ts
+++ b/electron/tests/unit/config-ipc.test.ts
@@ -372,39 +372,163 @@ describe('config:read_project', () => {
 });
 
 describe('config:save_project', () => {
+  const SELECTION = { connectionId: '123e4567-e89b-12d3-a456-426614174000', modelId: 'model-x' };
+
   it('merges updates and writes to the project config path', async () => {
-    await callSaveProject({ theme: 'project-theme', command_timeout: 42 });
+    await callSaveProject({ personality: 'project-persona', command_timeout: 42 });
 
     const write = lastProjectWrite();
     expect(write.path).toBe(path.join(projectDir, '.orchid.json'));
-    expect(write.data['theme']).toBe('project-theme');
+    expect(write.data['personality']).toBe('project-persona');
     expect(write.data['command_timeout']).toBe(42);
     expect(write.options).toEqual({ hardenDirectory: false });
   });
 
   it('deletes a key with a null tombstone from an existing config', async () => {
-    writeProjectConfig({ theme: 'kept', command_timeout: 99 });
+    writeProjectConfig({ personality: 'kept', command_timeout: 99 });
 
     await callSaveProject({ command_timeout: null });
 
     const write = lastProjectWrite();
-    expect(write.data['theme']).toBe('kept');
+    expect(write.data['personality']).toBe('kept');
     expect(write.data).not.toHaveProperty('command_timeout');
   });
 
-  it('filters out keys outside the project config allowlist', async () => {
+  it('persists per-project MCP servers and default model', async () => {
     await callSaveProject({
-      theme: 'visible',
-      mcp_servers: { evil: { command: 'rm' } },
-      permissions: { Bash: 'approve' },
-      default_model: { connectionId: 'c', modelId: 'm' },
+      mcp_servers: { docs: { command: 'npx', args: ['-y', 'docs-mcp'] } },
+      default_model: SELECTION,
     });
 
     const write = lastProjectWrite();
-    expect(write.data['theme']).toBe('visible');
-    expect(write.data).not.toHaveProperty('mcp_servers');
-    expect(write.data).not.toHaveProperty('permissions');
+    expect(write.data['mcp_servers']).toEqual({
+      docs: { command: 'npx', args: ['-y', 'docs-mcp'] },
+    });
+    expect(write.data['default_model']).toEqual(SELECTION);
+  });
+
+  it('deletes an MCP alias with a null tombstone from the project config', async () => {
+    writeProjectConfig({
+      mcp_servers: { keep: { command: 'keep' }, drop: { command: 'drop' } },
+    });
+
+    await callSaveProject({ mcp_servers: { drop: null } });
+
+    const write = lastProjectWrite();
+    expect(write.data['mcp_servers']).toEqual({ keep: { command: 'keep' } });
+  });
+
+  it('clears a default_model override with null instead of storing an explicit null', async () => {
+    writeProjectConfig({ default_model: SELECTION });
+
+    await callSaveProject({ default_model: null });
+
+    const write = lastProjectWrite();
     expect(write.data).not.toHaveProperty('default_model');
+  });
+
+  it('replaces tier maps exactly so removed overrides are deleted', async () => {
+    writeProjectConfig({
+      tier_models: {
+        seed: { ...SELECTION, modelId: 'seed-model' },
+        crown: { ...SELECTION, modelId: 'crown-model' },
+      },
+      tier_reasoning_effort: { seed: 'low', crown: 'high' },
+    });
+
+    await callSaveProject({
+      tier_models: { crown: { ...SELECTION, modelId: 'crown-model' } },
+      tier_reasoning_effort: { crown: 'high' },
+    });
+
+    const write = lastProjectWrite();
+    expect(write.data['tier_models']).toEqual({
+      crown: { ...SELECTION, modelId: 'crown-model' },
+    });
+    expect(write.data['tier_reasoning_effort']).toEqual({ crown: 'high' });
+  });
+
+  it('persists agents_md overrides', async () => {
+    await callSaveProject({ agents_md: { enforce_on_write: 'block' } });
+
+    const write = lastProjectWrite();
+    expect(write.data['agents_md']).toEqual({ enforce_on_write: 'block' });
+  });
+
+  it('rejects keys outside the project config allowlist without writing', async () => {
+    await expect(callSaveProject({
+      permissions: { Bash: 'approve' },
+      theme: 'light',
+    })).rejects.toThrow(/Not configurable per project/);
+    await expect(callSaveProject({
+      permissions: { Bash: 'approve' },
+    })).rejects.toThrow(/permissions/);
+
+    expect(mocks.writtenConfigs).toHaveLength(0);
+  });
+
+  it('rejects a mixed payload (allowed + disallowed) without a partial write', async () => {
+    await expect(callSaveProject({
+      command_timeout: 45,
+      subagents: { max_active_global: 2 },
+    })).rejects.toThrow(/Not configurable per project: subagents/);
+
+    expect(mocks.writtenConfigs).toHaveLength(0);
+  });
+
+  it('rejects null tier maps instead of silently ignoring them', async () => {
+    await expect(callSaveProject({ tier_models: null })).rejects.toThrow(
+      /tier_models must be an object map/,
+    );
+    await expect(callSaveProject({ tier_reasoning_effort: null })).rejects.toThrow(
+      /tier_reasoning_effort must be an object map/,
+    );
+    expect(mocks.writtenConfigs).toHaveLength(0);
+  });
+
+  it('drops prototype-pollution aliases from tier maps', async () => {
+    const poisoned = JSON.parse(
+      `{"tier_models":{"__proto__":{"connectionId":"x"},"seed":${JSON.stringify(SELECTION)}},"tier_reasoning_effort":{"constructor":"low"}}`,
+    ) as Record<string, unknown>;
+
+    await callSaveProject(poisoned);
+
+    const write = lastProjectWrite();
+    expect(write.data['tier_models']).toEqual({ seed: SELECTION });
+    expect(write.data['tier_reasoning_effort']).toEqual({});
+  });
+
+  it('preserves project permissions written through the permission-scope channel', async () => {
+    writeProjectConfig({
+      permissions: { grep: 'ask' },
+      command_timeout: 60,
+    });
+
+    await callSaveProject({ command_timeout: 45 });
+
+    const write = lastProjectWrite();
+    expect(write.data['permissions']).toEqual({ grep: 'ask' });
+    expect(write.data['command_timeout']).toBe(45);
+  });
+
+  it('unblocks unrelated saves when the project file was already invalid', async () => {
+    writeProjectConfig({ default_model: 'not-a-selection' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await callSaveProject({ command_timeout: 45 });
+      const write = lastProjectWrite();
+      expect(write.data['command_timeout']).toBe(45);
+      // The pre-existing invalid value is preserved, not silently dropped.
+      expect(write.data['default_model']).toBe('not-a-selection');
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+
+    // But a save that itself introduces an invalid value (on a clean file)
+    // still rejects.
+    writeProjectConfig({ command_timeout: 45 });
+    await expect(callSaveProject({ personality: 42 })).rejects.toThrow(/Invalid project config/);
   });
 
   it('rejects schema-violating values without writing', async () => {
@@ -419,7 +543,7 @@ describe('config:save_project', () => {
     vi.mocked(loader.ConfigManager.reset).mockClear();
     vi.mocked(loader.ConfigManager.load).mockClear();
 
-    await callSaveProject({ theme: 'cache-test' });
+    await callSaveProject({ command_timeout: 45 });
 
     expect(loader.ConfigManager.reset).toHaveBeenCalledTimes(1);
     expect(mocks.clearProjectRuntimeRegistry).toHaveBeenCalledTimes(1);
@@ -433,16 +557,16 @@ describe('config:save_project', () => {
     mocks.state.workspaceCwd = '/some/other/workspace';
     mocks.state.sessionCwds = [projectDir];
 
-    await callSaveProject({ theme: 'cross-project' });
+    await callSaveProject({ command_timeout: 45 });
     const write = lastProjectWrite();
     expect(write.path).toBe(path.join(projectDir, '.orchid.json'));
-    expect(write.data['theme']).toBe('cross-project');
+    expect(write.data['command_timeout']).toBe(45);
   });
 
   it('rejects a projectDir that is neither the selected workspace nor a session project', async () => {
     mocks.state.workspaceCwd = '/some/other/workspace';
 
-    await expect(callSaveProject({ theme: 'x' })).rejects.toThrow(
+    await expect(callSaveProject({ command_timeout: 45 })).rejects.toThrow(
       /selected workspace or any project with sessions/i,
     );
     expect(mocks.writtenConfigs).toHaveLength(0);

--- a/electron/tests/unit/config-ipc.test.ts
+++ b/electron/tests/unit/config-ipc.test.ts
@@ -531,6 +531,28 @@ describe('config:save_project', () => {
     await expect(callSaveProject({ personality: 42 })).rejects.toThrow(/Invalid project config/);
   });
 
+  it('rejects a newly invalid update when the project file already has an invalid key', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // New violation at a path the file did not already fail.
+      writeProjectConfig({ default_model: 'not-a-selection' });
+      await expect(callSaveProject({ personality: 42 })).rejects.toThrow(
+        /Invalid project config/,
+      );
+
+      // Changed value at the already-invalid path.
+      writeProjectConfig({ command_timeout: 0 });
+      await expect(callSaveProject({ command_timeout: -5 })).rejects.toThrow(
+        /Invalid project config/,
+      );
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(mocks.writtenConfigs).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it('rejects schema-violating values without writing', async () => {
     await expect(callSaveProject({ command_timeout: -5 })).rejects.toThrow(
       /Invalid project config/,

--- a/electron/tests/unit/project-config-view.test.tsx
+++ b/electron/tests/unit/project-config-view.test.tsx
@@ -7,6 +7,9 @@ import {
   ProjectConfigView,
 } from '../../src/renderer/components/ProjectConfigView';
 import {
+  readTierOverrides,
+} from '../../src/renderer/components/Preferences/ProjectTierModelsTab';
+import {
   fieldInputId,
   isPlainRecord,
   readGlobalValue,
@@ -29,6 +32,8 @@ const MOCK_CONFIG = {
   read_line_limit: 1000,
   grep_max_results: 100,
   directory_tree_depth: 2,
+  tool_worker_pool_size: 2,
+  tool_worker_pool_main_agent_reserved: 1,
   theme: 'default',
   personality: 'default',
   agents_md: {
@@ -50,13 +55,53 @@ const MOCK_CONFIG = {
     embedding_batch_size: 16,
     embedding_api_timeout: 30,
     embedding_api_retries: 3,
+    model_download_inactivity_timeout: 30,
+    model_download_total_timeout: 900,
     embedding_api_model: null,
+  },
+  subagents: {
+    event_max_per_flush: 200,
+    event_byte_budget_kb: 64,
+    usage_event_interval_ms: 1000,
+    hydration_buffer_kb: 256,
+    terminal_wave_ms: 250,
+    max_active_global: 8,
+    max_active_per_session: 4,
+    max_queued: 32,
+    terminal_retention: 25,
+    prompt_recent_terminal: 5,
+    prompt_task_max_chars: 200,
+  },
+  compaction: {
+    main: {
+      mode: 'simple',
+      threshold: 0.8,
+      model: null,
+      agent_name: 'compactor',
+      preserve_percent: 0.25,
+      min_compactable_tokens: 4000,
+      mechanical_reclaim: true,
+      hysteresis_delta: 0.1,
+      keep_last_user_messages: 10,
+      pin_first_user_message: true,
+    },
+    subagents: {
+      mode: 'simple',
+      threshold: 0.85,
+      model: null,
+      agent_name: 'compactor-subagent',
+      preserve_percent: 0.25,
+      min_compactable_tokens: 4000,
+      mechanical_reclaim: true,
+      hysteresis_delta: 0.1,
+      keep_last_user_messages: null,
+      pin_first_user_message: true,
+    },
   },
   ast_max_file_size: 1048576,
   mcp_startup_timeout: 60,
   mcp_per_server_timeout: 10,
   mcp_servers: {},
-  providers: {},
   llm_stream_idle_timeout: 300,
   llm_stream_retries: 3,
   background_command_idle_timeout: 900,
@@ -724,6 +769,20 @@ describe('ProjectConfigView helpers', () => {
   it('readStoredOverride returns undefined for rag keys when rag is not a record', () => {
     expect(readStoredOverride({ rag: [1] }, 'rag.chunk_size')).toBeUndefined();
     expect(readStoredOverride({ rag: 'bad' }, 'rag.chunk_size')).toBeUndefined();
+  });
+
+  it('readTierOverrides preserves explicit-null tier masks and drops invalid entries', () => {
+    const overrides = readTierOverrides({
+      tier_models: {
+        seed: null,
+        sprout: { connectionId: 'conn-a', modelId: 'model-b' },
+        bloom: 'not-a-selection',
+      },
+    });
+    expect(overrides.tierModels).toEqual({
+      seed: null,
+      sprout: { connectionId: 'conn-a', modelId: 'model-b' },
+    });
   });
 
   it('readGlobalValue reads top-level and nested rag values from config', () => {

--- a/electron/tests/unit/project-config-view.test.tsx
+++ b/electron/tests/unit/project-config-view.test.tsx
@@ -5,12 +5,14 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import userEvent from '@testing-library/user-event';
 import {
   ProjectConfigView,
+} from '../../src/renderer/components/ProjectConfigView';
+import {
   fieldInputId,
   isPlainRecord,
   readGlobalValue,
   readStoredOverride,
   toInputValue,
-} from '../../src/renderer/components/ProjectConfigView';
+} from '../../src/renderer/utils/project-config';
 import type { DefinitionsListResult } from '../../src/shared/types/definitions';
 import type { Config } from '../../src/shared/types/ipc-boundary';
 
@@ -29,6 +31,15 @@ const MOCK_CONFIG = {
   directory_tree_depth: 2,
   theme: 'default',
   personality: 'default',
+  agents_md: {
+    enabled: true,
+    filenames: ['AGENTS.md', 'CLAUDE.md'],
+    max_file_bytes: 32768,
+    max_chain_depth: 8,
+    enforce_on_write: 'warn',
+    inject_on_read: true,
+    include_local: false,
+  },
   rag: {
     chunk_size: 2000,
     chunk_overlap: 200,
@@ -66,6 +77,7 @@ const MOCK_CONFIG = {
   bg_prompt_tail_lines: 8,
   bg_prompt_tail_chars: 500,
   mcp_result_max_bytes: 5242880,
+  session_title_max_wait_seconds: 15,
   max_background_processes: 64,
   bg_output_head_bytes: 524288,
   bg_output_tail_bytes: 524288,
@@ -197,7 +209,7 @@ describe('ProjectConfigView', () => {
     expect(html).toContain('Back');
   });
 
-  it('renders all eight tab buttons', () => {
+  it('renders all ten tab buttons', () => {
     const html = renderStatic();
     for (const label of [
       'General',
@@ -205,6 +217,7 @@ describe('ProjectConfigView', () => {
       'MCP Servers',
       'Tier Models',
       'RAG',
+      'AGENTS.md',
       'Skills',
       'Agents',
       'Personalities',
@@ -257,11 +270,136 @@ describe('ProjectConfigView', () => {
     expect(inputById('mcp_result_max_bytes').placeholder).toBe('5242880');
   });
 
-  it('tier models tab points to global configuration', async () => {
+  it('mcp tab renders the project server editor and saves deletions as tombstones', async () => {
+    const user = userEvent.setup();
+    const { saveProject } = await renderLoaded({
+      mcp_servers: {
+        docs: { command: 'npx', args: ['-y', 'docs-mcp'] },
+      },
+    });
+    await switchTab(user, 'MCP Servers');
+
+    expect(screen.getByText('docs')).toBeTruthy();
+    expect(screen.getByText('+ Add Server')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.queryByText('docs')).toBeNull();
+    expect(screen.getByText('Unsaved')).toBeTruthy();
+
+    const saveButton = screen.getByText('Save').closest('button') as HTMLButtonElement;
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveProject).toHaveBeenCalledWith({
+        projectDir: PROJECT_DIR,
+        updates: { mcp_servers: { docs: null } },
+      });
+    });
+  });
+
+  it('mcp tab shows home-only servers as inherited and read-only', async () => {
+    const user = userEvent.setup();
+    const getHome = vi.fn().mockResolvedValue({
+      ...MOCK_CONFIG,
+      mcp_servers: { shared: { command: 'shared-mcp' } },
+    });
+    const readProject = vi.fn().mockResolvedValue({ projectDir: PROJECT_DIR, overrides: {} });
+    (window as Record<string, unknown>).orchid = {
+      config: {
+        readProject,
+        getHome,
+        saveProject: vi.fn(),
+        savePermissionScope: vi.fn().mockResolvedValue({ status: 'saved' }),
+      },
+      definitions: { list: vi.fn().mockResolvedValue(MOCK_DEFINITIONS) },
+    };
+    renderView();
+    await waitFor(() => {
+      expect(screen.queryByText('Loading project configuration…')).toBeNull();
+    });
+    await switchTab(user, 'MCP Servers');
+
+    expect(screen.getByText('shared')).toBeTruthy();
+    expect(screen.getByText('inherited from global')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Override' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+  });
+
+  it('mcp tab commits a new project server through the add editor', async () => {
+    const user = userEvent.setup();
+    const { saveProject } = await renderLoaded();
+    await switchTab(user, 'MCP Servers');
+
+    await user.click(screen.getByText('+ Add Server'));
+    await user.click(screen.getByLabelText('Server ID'));
+    await user.keyboard('docs');
+    await user.click(screen.getByLabelText('Command'));
+    await user.keyboard('npx');
+    await user.click(screen.getByText('Add Server'));
+
+    expect(screen.getByText('docs')).toBeTruthy();
+    expect(screen.getByText('Unsaved')).toBeTruthy();
+
+    const saveButton = screen.getByText('Save').closest('button') as HTMLButtonElement;
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveProject).toHaveBeenCalledWith({
+        projectDir: PROJECT_DIR,
+        updates: { mcp_servers: { docs: { command: 'npx' } } },
+      });
+    });
+  });
+
+  it('mcp tab commits an Override seeded from an inherited home server', async () => {
+    const user = userEvent.setup();
+    const getHome = vi.fn().mockResolvedValue({
+      ...MOCK_CONFIG,
+      mcp_servers: { shared: { command: 'shared-mcp', args: ['-v'] } },
+    });
+    const readProject = vi.fn().mockResolvedValue({ projectDir: PROJECT_DIR, overrides: {} });
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    (window as Record<string, unknown>).orchid = {
+      config: {
+        readProject,
+        getHome,
+        saveProject,
+        savePermissionScope: vi.fn().mockResolvedValue({ status: 'saved' }),
+      },
+      definitions: { list: vi.fn().mockResolvedValue(MOCK_DEFINITIONS) },
+    };
+    renderView();
+    await waitFor(() => {
+      expect(screen.queryByText('Loading project configuration…')).toBeNull();
+    });
+    await switchTab(user, 'MCP Servers');
+
+    await user.click(screen.getByRole('button', { name: 'Override' }));
+    expect((screen.getByLabelText('Command') as HTMLInputElement).value).toBe('shared-mcp');
+    await user.click(screen.getByText('Add Server'));
+
+    expect(screen.getByText('overrides global')).toBeTruthy();
+
+    const saveButton = screen.getByText('Save').closest('button') as HTMLButtonElement;
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveProject).toHaveBeenCalledWith({
+        projectDir: PROJECT_DIR,
+        updates: {
+          mcp_servers: { shared: { command: 'shared-mcp', args: ['-v'] } },
+        },
+      });
+    });
+  });
+
+  it('tier models tab renders project-scope assignments instead of a global-only notice', async () => {
     const user = userEvent.setup();
     await renderLoaded();
     await switchTab(user, 'Tier Models');
-    expect(screen.getByText('Tier models are configured globally')).toBeTruthy();
+    expect(screen.queryByText('Tier models are configured globally')).toBeNull();
+    expect(screen.getByText('Default model')).toBeTruthy();
+    expect(screen.getByText(/Unset tiers inherit the global assignment/)).toBeTruthy();
   });
 
   it('field change updates draft and shows dirty state', async () => {
@@ -368,15 +506,16 @@ describe('ProjectConfigView', () => {
     });
   });
 
-  it('theme select stages an override and saves it', async () => {
+  it('agents-md tab stages a nested agents_md override', async () => {
     const user = userEvent.setup();
     const { saveProject } = await renderLoaded();
-    const themeSelect = selectById('theme');
-    expect(themeSelect).not.toBeNull();
-    expect(themeSelect.value).toBe('');
-    expect(themeSelect.options[0].textContent).toBe('Inherit global (Default (Dark))');
+    await switchTab(user, 'AGENTS.md');
 
-    await user.selectOptions(themeSelect, 'light');
+    const enforceSelect = selectById('agents_md.enforce_on_write');
+    expect(enforceSelect).not.toBeNull();
+    expect(enforceSelect.options[0].textContent).toBe('Inherit global (warn)');
+
+    await user.selectOptions(enforceSelect, 'block');
     expect(screen.getByText('Unsaved')).toBeTruthy();
 
     const saveButton = screen.getByText('Save').closest('button') as HTMLButtonElement;
@@ -385,7 +524,7 @@ describe('ProjectConfigView', () => {
     await waitFor(() => {
       expect(saveProject).toHaveBeenCalledWith({
         projectDir: PROJECT_DIR,
-        updates: { theme: 'light' },
+        updates: { agents_md: { enforce_on_write: 'block' } },
       });
     });
   });

--- a/electron/tests/unit/rag-pipeline.test.ts
+++ b/electron/tests/unit/rag-pipeline.test.ts
@@ -1036,6 +1036,27 @@ describe('Model Download', () => {
     expect(typeof embedderModule.getModelDir).toBe('function');
   });
 
+  it('maps RAGConfig model-download timeouts to per-download options', async () => {
+    const { modelDownloadOptionsFromConfig } = await import('../../src/main/rag/embedder');
+
+    expect(
+      modelDownloadOptionsFromConfig({
+        model_download_inactivity_timeout: 2,
+        model_download_total_timeout: 60,
+      }),
+    ).toEqual({ inactivityTimeoutMs: 2000, totalTimeoutMs: 60000 });
+
+    // Absent or non-positive fields fall back to the default resolution.
+    expect(modelDownloadOptionsFromConfig({})).toEqual({});
+    expect(
+      modelDownloadOptionsFromConfig({
+        model_download_inactivity_timeout: 0,
+        model_download_total_timeout: -5,
+      }),
+    ).toEqual({});
+    expect(modelDownloadOptionsFromConfig(undefined)).toEqual({});
+  });
+
   it('should export DownloadProgressCallback type', async () => {
     // Type-only test: ensure the type is exported and usable
     const embedderModule = await import('../../src/main/rag/embedder');


### PR DESCRIPTION
## Summary

Projects can now configure MCP servers, tier model assignments, AGENTS.md behavior, and their default model through the UI — the runtime already honored all of these from `.orchid.json`, but the save IPC silently discarded them and the project settings view claimed they were global-only (issue #144). The audit that followed surfaced (and fixes) a wider set of places where the config surface, the runtime, and the settings UI disagreed.

**Before:** a project MCP server defined in `.orchid.json` worked when hand-edited, but there was no way to create one from the app — the project "MCP Servers" tab only exposed three timeout numbers. The Tier Models tab said assignments were global-only even though hand-written project tier models took effect. A per-project `theme` override was accepted by the UI but consumed by nothing. `session_title_max_wait_seconds` was configurable but exposed nowhere.

**After:** every project-config key the runtime consumes is editable per project, and keys that are process-global by implementation (`subagents` admission/batching, worker pool, onboarding) are rejected with a clear error instead of being silently dropped on save.

| Area | Change |
|---|---|
| Project MCP servers | Full editor in project settings: home servers render as *inherited* (read-only, with one-click **Override** seeding), project servers show an *overrides global* badge; deleting emits null tombstones so the home server resurfaces. Changes apply to new turns — no app restart. |
| Tier models | Project Tier Models editor replacing the "global only" notice — per-tier inherit/reset, project default model, reasoning-effort overrides. Stored maps replace exactly, so removing an override deletes it. |
| AGENTS.md | New per-project AGENTS.md tab (discovery, injection, write-enforcement policy). |
| RAG / AST | Per-project `rag.*` and `ast_max_file_size` overrides now actually reach the indexers and search (previously several knobs silently read process-global config). |
| Save semantics | `config:save_project` rejects disallowed keys fail-loud; `default_model: null` clears an override; null/non-object tier maps are rejected. |
| Cleanup | No-op per-project `theme` override removed; `session_title_max_wait_seconds` exposed in global and project settings; `subagents` documented as process-global. |

## Bugs fixed along the way (found by a 9-agent review pass)

- **Add Server / Override were silent no-ops** in the MCP editor: `saveEdit` early-returned when no server was being edited, so the form could never commit a new entry. This also broke Add Server in the global Configuration view (pre-existing on main).
- **Project saves wiped project permission rules**: the write path filtered the whole merged file against the project allow-list, deleting `permissions` (owned by the separate permission-scope channel) from `.orchid.json` on every project-config save.
- **A hand-broken `.orchid.json` bricked all project saves**: newly allow-listed keys now reach schema validation, so one invalid pre-existing value (e.g. `default_model: "foo"`) blocked unrelated edits. Already-invalid files now warn and write; newly-introduced invalid values still reject.
- Tier maps gained prototype-pollution alias filtering (`__proto__`/`constructor`/`prototype`) matching the rest of the config pipeline, and `default_model` is shape-validated instead of blind-cast when read from a hand-edited file.

## Notes for reviewers

- Project `.orchid.json` is part of the trust fingerprint, so any project-config save trips the existing trusted→changed re-prompt on next send. Pre-accepted product behavior; the learning doc now calls out the increased frequency.
- MCP server entries (auth tokens, env values) are stored in the committed `.orchid.json`; the project editor warns about this inline. Trust gating already prevents project servers from starting for untrusted projects.
- Known residuals deliberately not addressed: cross-window concurrent tier saves (last-writer-wins; needs config versioning), and agent tool-writes to `.orchid.json` not invalidating the runtime cache until the next IPC-driven invalidation — both good follow-ups.

## Tests

- `config-ipc.test.ts`: allow-list persistence for all new keys, MCP alias tombstones, exact tier-map replacement, `default_model: null` clearing, fail-loud rejection (incl. mixed payloads), prototype-pollution filtering, permission-scope key survival, already-invalid-file unblocking.
- `project-config-view.test.tsx`: project MCP editor flows (add/override/delete→tombstone, inherited read-only rendering), tier-tab project scope, AGENTS.md nested override payload, `session_title_max_wait_seconds` field.
- Full suite: 4639 tests passing; `tsc --noEmit` (renderer + node configs) and `eslint src/` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-level settings for AGENTS.md behavior, MCP servers, model assignments, tier models, reasoning effort, and session-title timeout.
  * Project settings now clearly show inherited values, overrides, and reset options.
  * Added support for overriding inherited MCP servers without removing global configurations.
* **Bug Fixes**
  * Project-specific indexing and embedding settings are now respected.
  * RAG searches use the configured result limit when none is specified.
* **Changes**
  * Removed project-level theme customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->