### PR TITLE
fix(llm): bucket tool-call generation tokens as tool use, not respons…

### DIFF
--- a/electron/src/main/llm/context-snapshot.ts
+++ b/electron/src/main/llm/context-snapshot.ts
@@ -2,6 +2,7 @@ import type { ModelMessage, Tool } from 'ai';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ContextSnapshot } from '../../shared/types/message';
 import { compactedMarkerFromUnknown } from '../../shared/types/message';
+import type { ReasoningChars } from './reasoning-tokens';
 
 interface ContextSnapshotInput {
   systemPrompt: string;
@@ -11,11 +12,19 @@ interface ContextSnapshotInput {
   outputTokens: number | undefined;
   /** Provider-reported reasoning tokens, already included in `outputTokens`. */
   reasoningTokens?: number | undefined;
+  /**
+   * Observed output character mix for the step being snapshotted (visible
+   * text / reasoning / tool-call input). When present, tool-call generation
+   * tokens are bucketed into tool use instead of the assistant bucket —
+   * output tokens cover everything the model generated, including the
+   * tool-call name + arguments JSON of tool-only steps.
+   */
+  outputChars?: ReasoningChars | undefined;
 }
 
 type DynamicContextSnapshotInput = Pick<
   ContextSnapshotInput,
-  'messages' | 'inputTokens' | 'outputTokens' | 'reasoningTokens'
+  'messages' | 'inputTokens' | 'outputTokens' | 'reasoningTokens' | 'outputChars'
 >;
 
 interface ContextChars {
@@ -137,6 +146,28 @@ function allocateInputTokens(chars: ContextChars, inputTokens: number): ContextC
   return allocated;
 }
 
+/**
+ * Split the provider's output total by the observed output characters.
+ * Tool-call generation (name + arguments JSON) is tool use, not an assistant
+ * response; without this every tool-only step lands entirely in the assistant
+ * bucket, which the renderer labels "Response". Chars absent or zero → no
+ * split, preserving the legacy whole-output attribution.
+ */
+function splitOutputTokens(
+  output: number,
+  chars: ReasoningChars | undefined,
+): { assistant: number; toolUse: number } {
+  if (output <= 0 || !chars || chars.tool <= 0) {
+    return { assistant: output, toolUse: 0 };
+  }
+  const totalChars = chars.reasoning + chars.text + chars.tool;
+  if (totalChars <= 0) {
+    return { assistant: output, toolUse: 0 };
+  }
+  const toolUse = Math.min(output, Math.round((output * chars.tool) / totalChars));
+  return { assistant: output - toolUse, toolUse };
+}
+
 /** Precompute fixed prompt/tool weights for repeated snapshots in one turn. */
 export function createContextSnapshotBuilder(
   systemPrompt: string,
@@ -149,6 +180,7 @@ export function createContextSnapshotBuilder(
     inputTokens,
     outputTokens,
     reasoningTokens,
+    outputChars,
   }: DynamicContextSnapshotInput): ContextSnapshot => {
     const input = Math.max(0, inputTokens ?? 0);
     const output = Math.max(0, outputTokens ?? 0);
@@ -166,7 +198,8 @@ export function createContextSnapshotBuilder(
       input,
     );
 
-    const assistantTokens = allocated.assistant + output;
+    const outputSplit = splitOutputTokens(output, outputChars);
+    const assistantTokens = allocated.assistant + outputSplit.assistant;
     // Provider-reported reasoning is authoritative: visible reasoning text
     // may be a summary, so character ratios can misattribute it. Omit the
     // field entirely when the provider did not report a count, so consumers
@@ -182,7 +215,7 @@ export function createContextSnapshotBuilder(
       used_tokens: input + output,
       system_tokens: allocated.system,
       tools_tokens: allocated.tools,
-      tool_use_tokens: allocated.toolUse,
+      tool_use_tokens: allocated.toolUse + outputSplit.toolUse,
       user_tokens: allocated.user,
       assistant_tokens: assistantTokens,
       summary_tokens: allocated.summary,
@@ -199,11 +232,13 @@ export function buildContextSnapshot({
   inputTokens,
   outputTokens,
   reasoningTokens,
+  outputChars,
 }: ContextSnapshotInput): ContextSnapshot {
   return createContextSnapshotBuilder(systemPrompt, tools)({
     messages,
     inputTokens,
     outputTokens,
     reasoningTokens,
+    outputChars,
   });
 }

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -159,6 +159,7 @@ function buildStepUsage(
       messages,
       inputTokens,
       outputTokens,
+      ...(chars ? { outputChars: chars } : {}),
       ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
     }),
   };

--- a/electron/tests/unit/agents-md-enforcement.test.ts
+++ b/electron/tests/unit/agents-md-enforcement.test.ts
@@ -358,7 +358,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerWriteTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     _setAgentsMdStoreResolverForTests(() => store);
@@ -391,7 +391,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerWriteTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     _setAgentsMdStoreResolverForTests(() => store);
@@ -420,7 +420,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerWriteTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     _setAgentsMdStoreResolverForTests(() => store);
@@ -452,7 +452,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerWriteTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     _setAgentsMdStoreResolverForTests(() => store);
@@ -485,7 +485,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerWriteTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     // Simulate the no-session degradation: the store resolver yields nothing.
@@ -527,7 +527,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const config = agentsConfig({ enforce_on_write: 'block' });
     const diskWrite = diskWritingHandler();
     const registry = await registerWriteTool(diskWrite);
@@ -573,7 +573,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const config = agentsConfig({ enforce_on_write: 'block' });
     // The parent pkg/AGENTS.md already governs pkg/new; mark it seen so this test
     // isolates the creation-gap behavior of the brand-new pkg/new/AGENTS.md.
@@ -621,7 +621,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerWriteTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     _setAgentsMdStoreResolverForTests(() => store);
@@ -650,7 +650,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const failingHandler = vi.fn(async () => ({
       status: 'error' as const,
       data: { value: 'old_string not found' },
@@ -683,7 +683,7 @@ describe('dispatch-level write enforcement', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const failingHandler = vi.fn(async () => ({
       status: 'error' as const,
       data: { value: 'old_string not found' },

--- a/electron/tests/unit/agents-md-injection.test.ts
+++ b/electron/tests/unit/agents-md-injection.test.ts
@@ -341,7 +341,7 @@ describe('dispatch-level read-path injection', () => {
     );
     const { ToolRegistry } = await import('../../src/main/tools/registry');
     const { genericToolResultDataSchema } = await import('../../src/shared/types/tool-result');
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
 
     const registry = new ToolRegistry();
     registry.register(

--- a/electron/tests/unit/agents-md-subagent.test.ts
+++ b/electron/tests/unit/agents-md-subagent.test.ts
@@ -215,7 +215,7 @@ describe('dispatch-level UI gating (agentsMdDisabled)', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerReadTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     _setAgentsMdStoreResolverForTests(() => store);
@@ -251,7 +251,7 @@ describe('dispatch-level UI gating (agentsMdDisabled)', () => {
     const { executeToolCall, _setAgentsMdStoreResolverForTests } = await import(
       '../../src/main/llm/tool-dispatch'
     );
-    const { sessionPermissionOverrides } = await import('../../src/main/ipc/permission');
+    const { sessionPermissionOverrides } = await import('../../src/main/permissions/session-overrides');
     const registry = await registerWriteTool();
     sessionPermissionOverrides.set(sessionId, 'allow');
     _setAgentsMdStoreResolverForTests(() => store);

--- a/electron/tests/unit/context-snapshot.test.ts
+++ b/electron/tests/unit/context-snapshot.test.ts
@@ -105,4 +105,68 @@ describe('context snapshot', () => {
 
     expect(snapshot.reasoning_tokens).toBe(snapshot.assistant_tokens);
   });
+
+  it('buckets tool-only output into tool use, not the assistant bucket', () => {
+    const snapshot = buildContextSnapshot({
+      systemPrompt: 'System instructions',
+      tools: {},
+      messages: [{ role: 'user', content: 'Open the file' }] as ModelMessage[],
+      inputTokens: 1_000,
+      outputTokens: 200,
+      outputChars: { reasoning: 0, text: 0, tool: 800 },
+    });
+
+    expect(snapshot.tool_use_tokens).toBe(200);
+    expect(snapshot.assistant_tokens).toBe(0);
+    expect(
+      snapshot.system_tokens +
+        snapshot.tools_tokens +
+        snapshot.tool_use_tokens +
+        snapshot.user_tokens +
+        snapshot.assistant_tokens,
+    ).toBe(snapshot.used_tokens);
+  });
+
+  it('splits mixed text and tool-call output proportionally', () => {
+    const snapshot = buildContextSnapshot({
+      systemPrompt: 'System instructions',
+      tools: {},
+      messages: [{ role: 'user', content: 'Open the file' }] as ModelMessage[],
+      inputTokens: 1_000,
+      outputTokens: 300,
+      outputChars: { reasoning: 0, text: 100, tool: 300 },
+    });
+
+    expect(snapshot.tool_use_tokens).toBe(225);
+    expect(snapshot.assistant_tokens).toBe(75);
+  });
+
+  it('keeps the whole output in the assistant bucket when chars are absent', () => {
+    const snapshot = buildContextSnapshot({
+      systemPrompt: 'System instructions',
+      tools: {},
+      messages: [{ role: 'user', content: 'Open the file' }] as ModelMessage[],
+      inputTokens: 1_000,
+      outputTokens: 200,
+    });
+
+    expect(snapshot.tool_use_tokens).toBe(0);
+    expect(snapshot.assistant_tokens).toBe(200);
+  });
+
+  it('does not shift reasoning output into tool use', () => {
+    const snapshot = buildContextSnapshot({
+      systemPrompt: 'System instructions',
+      tools: {},
+      messages: [{ role: 'user', content: 'Open the file' }] as ModelMessage[],
+      inputTokens: 1_000,
+      outputTokens: 300,
+      reasoningTokens: 150,
+      outputChars: { reasoning: 150, text: 0, tool: 300 },
+    });
+
+    expect(snapshot.reasoning_tokens).toBe(100);
+    expect(snapshot.assistant_tokens).toBe(100);
+    expect(snapshot.tool_use_tokens).toBe(200);
+  });
 });

--- a/electron/tests/unit/llm-orchestrator.test.ts
+++ b/electron/tests/unit/llm-orchestrator.test.ts
@@ -2371,14 +2371,16 @@ describe('streamChat', () => {
         ));
         return {
           fullStream: {
-            async *[Symbol.asyncIterator]() {
-              await new Promise<void>((_resolve, reject) => {
-                params.abortSignal.addEventListener(
-                  'abort',
-                  () => reject(new DOMException('Aborted', 'AbortError')),
-                  { once: true },
-                );
-              });
+            [Symbol.asyncIterator]() {
+              return {
+                next: () => new Promise<never>((_resolve, reject) => {
+                  params.abortSignal.addEventListener(
+                    'abort',
+                    () => reject(new DOMException('Aborted', 'AbortError')),
+                    { once: true },
+                  );
+                }),
+              };
             },
           },
           textStream: createAsyncIterable<string>([]),

--- a/electron/tests/unit/llm-orchestrator.test.ts
+++ b/electron/tests/unit/llm-orchestrator.test.ts
@@ -2044,6 +2044,46 @@ describe('streamChat', () => {
     });
   });
 
+  it('buckets tool-call generation output into the context tool-use category', async () => {
+    setupStreamText({
+      fullStreamParts: [
+        {
+          type: 'start-step',
+          request: { messages: [{ role: 'user', content: 'Read the file' }] },
+          warnings: [],
+        },
+        { type: 'tool-input-start', toolCallId: 'tc-1', toolName: 'read' },
+        { type: 'tool-input-delta', toolCallId: 'tc-1', inputTextDelta: '{"path":"README.md"}' },
+        {
+          type: 'finish-step',
+          finishReason: 'tool-calls',
+          usage: { inputTokens: 1_000, outputTokens: 200, totalTokens: 1_200 },
+        },
+      ],
+      finishReason: 'tool-calls',
+    });
+
+    const events = await collectStreamEvents(streamChat(makeStreamChatParams()));
+    const usageEvent = events.find((event) => event.type === 'usage');
+    if (usageEvent?.type !== 'usage' || !usageEvent.usage.context) {
+      throw new Error('Expected a context snapshot');
+    }
+    const context = usageEvent.usage.context;
+
+    // The step emitted only a tool call: its output tokens are tool use,
+    // so the assistant ("Response") bucket must stay at its prompt-side
+    // allocation of zero assistant messages.
+    expect(context.tool_use_tokens).toBe(200);
+    expect(context.assistant_tokens).toBe(0);
+    expect(
+      context.system_tokens +
+        context.tools_tokens +
+        context.tool_use_tokens +
+        context.user_tokens +
+        context.assistant_tokens,
+    ).toBe(context.used_tokens);
+  });
+
   it('captures provider cache reads and the latest request context snapshot', async () => {
     setupStreamText({
       fullStreamError: new Error('fullStream unavailable'),

--- a/electron/tests/unit/provider-native-adapters.test.ts
+++ b/electron/tests/unit/provider-native-adapters.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { importESM } from '../../src/main/utils/esm-import';
 import type { ProviderConnection, ProviderDefinition } from '../../src/shared/types/provider';
 import { MessageRole, MessageType, type Message } from '../../src/shared/types/message';
@@ -153,6 +153,14 @@ describe('native provider adapters', () => {
 });
 
 describe('OpenAI Responses protocol end-to-end', () => {
+  // Warm the real AI SDK packages and the orchestrator import graph once in a
+  // hook (10s hook budget) instead of inside the first test (5s test budget).
+  beforeAll(async () => {
+    await vi.importActual('ai');
+    await vi.importActual('@ai-sdk/openai');
+    await import('../../src/main/llm/orchestrator');
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(importESM).mockImplementation(async (specifier: string) => {


### PR DESCRIPTION
…e (#173)

A provider step's outputTokens covers everything the model generated — visible text, reasoning, and the tool-call name + arguments JSON. In agentic turns most steps emit only tool calls, so adding the whole output total to the assistant bucket made the Context grid show "Response" tokens with no assistant text, and the analytics ledger recorded the same distortion.

Thread the per-step output char mix (reasoning/text/tool, already tracked by SdkEventAdapter) into the context snapshot and allocate the tool-char share of output tokens to tool_use_tokens. Absent chars keeps the legacy whole-output attribution (textStream fallback path); the sum-of-categories == used_tokens invariant is preserved.