### PR TITLE
fix(tools): expand JSON-stringified todo batch inputs (#171)

### DIFF
--- a/docs/solutions/logic-errors/todo-batch-input-treated-as-one-stringified-task.md
+++ b/docs/solutions/logic-errors/todo-batch-input-treated-as-one-stringified-task.md
@@ -1,0 +1,100 @@
+---
+title: "Todo batch input treated as one stringified task"
+date: 2026-08-21
+category: logic-errors
+module: todo tools
+problem_type: logic_error
+component: assistant
+severity: medium
+symptoms:
+  - "todo_create called with an array of eight titles created only one task"
+  - "The created task's title was the raw JSON-encoded array text"
+  - "Subsequent todo_update calls mutated the single mega-task instead of individual tasks"
+root_cause: missing_validation
+resolution_type: code_fix
+tags: [todo-tools, stringified-json, batch-input, zod-schema, tool-dispatch]
+---
+
+# Todo batch input treated as one stringified task
+
+## Problem
+
+`todo_create` batch support existed (issue #110), but some model/provider tool surfaces serialize array arguments as JSON strings. Because the input schema accepted either a string or an array, a serialized batch was silently treated as one task title instead of being expanded into multiple todos (issue #171).
+
+## Symptoms
+
+- Calling `todo_create` with eight titles created only one task.
+- The task title was the raw JSON array text: `["Main: allow-list + project save semantics (...)", ...]`.
+- The agent then adapted to the single mega-task and repeatedly updated it — the visible "confusion" in the issue screenshot.
+- The model-facing tool declaration exposed `title` as `{"type":"string"}` even though the schema description documented array support.
+- JSON-stringified arrays passed validation through the union's string branch, so the failure was silent.
+
+## What Didn't Work
+
+- **Batch-handler suspicion:** `electron/src/main/tools/todo/create.ts` already had an `Array.isArray(title)` branch creating one task per title (batch support landed in `8f89b6f6`/`45071389`).
+- **zod-to-json-schema suspicion:** isolated conversion preserved the union as `anyOf`.
+- **AI SDK suspicion:** `asSchema` conversion also preserved the array alternative.
+- **Anthropic driver suspicion:** `sanitizeJsonSchema` preserves `anyOf`; it was not collapsing the schema.
+- **Actual boundary:** the model-facing tool declaration had already simplified `title` to a string, so arrays arrived as JSON-encoded strings before app dispatch — upstream of app-owned converters and outside app control.
+- **Dispatch confirmation:** `electron/src/main/llm/tool-dispatch.ts:367` passes `validation.data` to handlers, so a schema-boundary preprocess reaches SDK execution, eager-tool execution, and IPC paths alike.
+
+## Solution
+
+Schema-boundary normalization in `electron/src/main/tools/todo/create.ts`:
+
+```ts
+export function expandStringifiedBatch(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('[')) return value;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (Array.isArray(parsed) && parsed.every((el) => typeof el === 'string')) {
+      return parsed;
+    }
+  } catch {
+    // Not JSON — treat as a literal string value.
+  }
+  return value;
+}
+
+title: z.preprocess(
+  expandStringifiedBatch,
+  z.union([z.string(), z.array(z.string()).min(1).max(TODO_BATCH_MAX_SIZE)]).describe(
+    'Task title or array of task titles for batch creation.',
+  ),
+),
+```
+
+`electron/src/main/tools/todo/update.ts` applies the same preprocessing to `id` and `title`; `status` additionally uppercases expanded elements before its enum union. `todo_delete` is single-id only — unaffected.
+
+The existing handler then receives normalized data and keeps its batch behavior unchanged:
+
+```ts
+const titles = Array.isArray(title) ? title : [title];
+const created = titles.map((t) => todoStore.create(t, owner));
+```
+
+## Why This Works
+
+- **Root cause:** a JSON-stringified array matched `z.string()` in the `string | string[]` union, so validation succeeded without revealing that transport had changed the intended type.
+- **Fix mapping:** `z.preprocess(expandStringifiedBatch, ...)` converts only valid JSON arrays of strings into actual arrays before the union runs.
+- **Literal strings stay safe:** `'[not json'`, `'[1, 2]'`, and `'["a", 2]'` remain single titles (malformed JSON, or parsed elements not all strings).
+- **Empty batches fail clearly:** `'[]'` expands to an array, then the existing `.min(1)` rejects it with a schema error.
+- **Provider schema compatibility preserved:** the underlying union and descriptions are unchanged, so provider-facing schema output still exposes the same `anyOf` structure when the consumer supports it.
+- **Single convergence point:** every dispatch path funnels through `registry.validate` → `validation.data`, so one preprocess covers SDK, eager-bridge, and IPC callers.
+
+## Prevention
+
+- Any tool argument modeled as a `string | array` union should tolerate JSON-stringified batches via a preprocess at the schema boundary — not handler-side parsing.
+- Audit for vulnerable unions with: `z.union([z.string(), z.array(`
+- Reuse the shared normalizer (`expandStringifiedBatch` from `todo/create.ts`) rather than duplicating parse logic.
+- Preserve literal bracketed strings by requiring: trimmed leading `[`, successful JSON parse, array result, all elements of the expected primitive type.
+- Keep cardinality constraints (`.min(1)`/`.max(N)`) on the array branch so normalized empty/oversized batches fail during validation.
+- For enum arrays, expand the array first, then apply per-element normalization/validation.
+- Schema-boundary test set: stringified valid batches, native arrays, literal bracketed strings, malformed JSON, mixed-type arrays, empty serialized arrays, index-matched update arrays. Regression tests live in `electron/tests/unit/todo-web-tools.test.ts` (stringified batch inputs section).
+
+## Related Issues
+
+- GitHub #171 — Agent getting confused when creating multiple todos with one call (the bug)
+- GitHub #110 — Batch todo operations: create/update multiple tasks in one tool call (the feature whose transport quirk surfaced this)

--- a/electron/src/main/tools/todo/create.ts
+++ b/electron/src/main/tools/todo/create.ts
@@ -38,6 +38,31 @@ export function resolveTodoStore(
 }
 
 /**
+ * Expand a JSON-encoded batch string into its array form.
+ *
+ * Some model/provider paths transport array arguments as JSON-encoded strings,
+ * so a batch like '["a","b"]' arrives as a single title string. The schema
+ * union's string branch accepts it and the store would create one task titled
+ * with the raw array text (#171). Only strings that parse to an array whose
+ * elements are all strings are expanded; everything else passes through
+ * unchanged so literal bracketed titles survive.
+ */
+export function expandStringifiedBatch(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('[')) return value;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (Array.isArray(parsed) && parsed.every((el) => typeof el === 'string')) {
+      return parsed;
+    }
+  } catch {
+    // Not JSON — treat as a literal string value.
+  }
+  return value;
+}
+
+/**
  * Resolve ownership for a new todo under the calling agent scope.
  * - Subagents: always own the todo (caller cannot forge another scope).
  * - Main: may optionally tag a subagent_id (assigns ownership to that subagent).
@@ -76,9 +101,12 @@ export function buildCreateTool(
       'modify their own tasks. Accepts a single title or an array of titles ' +
       'for batch creation.',
     inputSchema: z.object({
-      title: z
-        .union([z.string(), z.array(z.string()).min(1).max(TODO_BATCH_MAX_SIZE)])
-        .describe('Task title or array of task titles for batch creation.'),
+      title: z.preprocess(
+        expandStringifiedBatch,
+        z.union([z.string(), z.array(z.string()).min(1).max(TODO_BATCH_MAX_SIZE)]).describe(
+          'Task title or array of task titles for batch creation.',
+        ),
+      ),
       subagent_id: z
         .string()
         .optional()

--- a/electron/src/main/tools/todo/update.ts
+++ b/electron/src/main/tools/todo/update.ts
@@ -10,7 +10,7 @@ import { RiskClass } from '../../../shared/types/permission';
 import { genericToolResultMetadata } from '../types';
 import { genericBuiltInToolOutcome } from '../result';
 import type { TodoToolResult, NotifyTodoChanged, TodoStoreSource } from './create';
-import { resolveTodoStore, TODO_BATCH_MAX_SIZE } from './create';
+import { resolveTodoStore, TODO_BATCH_MAX_SIZE, expandStringifiedBatch } from './create';
 import { TodoStatus, type Todo } from '../../../shared/types/todo';
 import {
   isMainAgentScope,
@@ -43,22 +43,35 @@ export function buildUpdateTool(
       'Accepts a single id or an array of ids for batch updates. When using ' +
       'arrays, title/status arrays are matched by index to id arrays.',
     inputSchema: z.object({
-      id: z
-        .union([z.string(), z.array(z.string()).min(1).max(TODO_BATCH_MAX_SIZE)])
-        .describe('The ID of the task to update, or an array of IDs for batch update.'),
+      id: z.preprocess(
+        expandStringifiedBatch,
+        z.union([z.string(), z.array(z.string()).min(1).max(TODO_BATCH_MAX_SIZE)]).describe(
+          'The ID of the task to update, or an array of IDs for batch update.',
+        ),
+      ),
       title: z
-        .union([z.string(), z.array(z.string()).max(TODO_BATCH_MAX_SIZE)])
-        .optional()
-        .describe(
-          'New title (optional). A single value is applied to every id; an array is matched by index.',
-        ),
+        .preprocess(
+          expandStringifiedBatch,
+          z.union([z.string(), z.array(z.string()).max(TODO_BATCH_MAX_SIZE)]).describe(
+            'New title (optional). A single value is applied to every id; an array is matched by index.',
+          ),
+        )
+        .optional(),
       status: z
-        .union([todoStatusSchema, z.array(todoStatusSchema).max(TODO_BATCH_MAX_SIZE)])
-        .optional()
-        .describe(
-          `New status. Must be one of: ${Object.values(TodoStatus).join(', ')}. ` +
-            'A single value is applied to every id; an array is matched by index.',
-        ),
+        .preprocess(
+          (v) => {
+            const expanded = expandStringifiedBatch(v);
+            if (Array.isArray(expanded)) {
+              return expanded.map((el) => (typeof el === 'string' ? el.toUpperCase() : el));
+            }
+            return expanded;
+          },
+          z.union([todoStatusSchema, z.array(todoStatusSchema).max(TODO_BATCH_MAX_SIZE)]).describe(
+            `New status. Must be one of: ${Object.values(TodoStatus).join(', ')}. ` +
+              'A single value is applied to every id; an array is matched by index.',
+          ),
+        )
+        .optional(),
       subagent_id: z
         .string()
         .optional()

--- a/electron/tests/unit/todo-web-tools.test.ts
+++ b/electron/tests/unit/todo-web-tools.test.ts
@@ -303,6 +303,53 @@ describe('Todo Tools', () => {
       expect(store.get(ids[1])!.status).toBe(TodoStatus.OPEN);
       expect(notifyCount).toBe(0);
     });
+
+    // -- stringified batch inputs (#171) ---------------------------------------
+
+    it('todo_create expands a JSON-encoded title array string into a batch', async () => {
+      const { definition, handler } = buildCreateTool(store);
+      const parsed = definition.inputSchema.parse({
+        title: JSON.stringify(['First', 'Second', 'Third']),
+      });
+      expect(parsed.title).toEqual(['First', 'Second', 'Third']);
+
+      const result = (await callTool(handler, parsed)) as ToolExecutionResult;
+      expect(result.canonical.status).toBe('complete');
+      expect(result.agentProjection.content).toContain('count="3"');
+      expect(store.list().map((t) => t.title).sort()).toEqual(['First', 'Second', 'Third']);
+    });
+
+    it('todo_create leaves non-batch bracketed strings as single titles', () => {
+      const { definition } = buildCreateToolRaw(store);
+      for (const title of ['[not json', '[1, 2]', '["a", 2]']) {
+        expect(definition.inputSchema.parse({ title }).title).toBe(title);
+      }
+    });
+
+    it('todo_create rejects an empty JSON-encoded title array string at schema boundary', () => {
+      const { definition } = buildCreateToolRaw(store);
+      expect(definition.inputSchema.safeParse({ title: '[]' }).success).toBe(false);
+    });
+
+    it('todo_update expands JSON-encoded id/title/status array strings', async () => {
+      const ids = await createTwoTasks();
+      const { definition, handler } = buildUpdateTool(store);
+      const parsed = definition.inputSchema.parse({
+        id: JSON.stringify(ids),
+        title: JSON.stringify(['A2', 'B2']),
+        status: JSON.stringify(['in_progress', 'done']),
+      });
+      expect(parsed.id).toEqual(ids);
+      expect(parsed.title).toEqual(['A2', 'B2']);
+      expect(parsed.status).toEqual([TodoStatus.IN_PROGRESS, TodoStatus.DONE]);
+
+      const result = (await callTool(handler, parsed)) as ToolExecutionResult;
+      expect(result.canonical.status).toBe('complete');
+      expect(store.get(ids[0])!.title).toBe('A2');
+      expect(store.get(ids[0])!.status).toBe(TodoStatus.IN_PROGRESS);
+      expect(store.get(ids[1])!.title).toBe('B2');
+      expect(store.get(ids[1])!.status).toBe(TodoStatus.DONE);
+    });
   });
 
   // -- todo_update ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Asking the agent to create a batch of todos in one call could silently produce a single task whose title was the raw JSON array text (e.g. `["Main: allow-list…", "Main: thread config…", …]`); the agent would then keep mutating that one mega-task — the "confusion" in #171. The same call now creates one task per title.

The batch reached the tool as a JSON-encoded **string**: some model/provider tool surfaces simplify `string | string[]` unions to `string` (app-owned converters — zod-to-json-schema, AI SDK `asSchema`, the Anthropic driver — all emit correct `anyOf`, verified in isolation), so the union's string branch matched and validation passed silently. The fix normalizes at the schema boundary with `expandStringifiedBatch` (`z.preprocess`) on `todo_create.title` and `todo_update.{id,title,status}` — the single point every dispatch path funnels through (`registry.validate` → `validation.data`). Strings expand only when they parse to an all-string array: `'[]'` still fails `min(1)` clearly, while `'[not json'`, `'[1, 2]'`, and `'["a", 2]'` remain literal titles. Provider-facing schemas keep their `anyOf` shape.

## Test plan

- 4 new cases in `electron/tests/unit/todo-web-tools.test.ts`: stringified title batch expands (`count="3"`), literal bracketed strings stay single titles, `'[]'` rejected at the schema boundary, stringified id/title/status arrays expand index-matched.
- Full suite 4629 passed; ESLint and `tsc --noEmit` clean.

Fixes #171
