### PR TITLE
feat(debug): per-session raw provider request/response capture

### DIFF
--- a/electron/src/main/agents/subagent-runner.ts
+++ b/electron/src/main/agents/subagent-runner.ts
@@ -245,6 +245,7 @@ export function createSubagentStreamRunner(): SubagentStreamRunner {
      attemptIdHolder: { value: null },
       pricingFacet,
       tierMechanism,
+      debugCapture: config.debug_capture_requests,
     };
     try {
       getSubagentAttributionStore().insert({

--- a/electron/src/main/config/schema.ts
+++ b/electron/src/main/config/schema.ts
@@ -251,6 +251,15 @@ export const configSchema = z
       .default({}),
     llm_stream_idle_timeout: z.number().positive().default(300.0),
     llm_stream_retries: z.number().int().nonnegative().default(3),
+    /**
+     * Raw request/response debug capture (issue 146). When true, every
+     * provider attempt from any agent origin (main, subagent, compactor,
+     * title namer, permission evaluator, web-fetch summarizer) persists the
+     * exact request sent and response received, viewable per session in the
+     * Requests inspector section. Off by default: captures duplicate full
+     * conversation payloads per attempt and grow accounting.db quickly.
+     */
+    debug_capture_requests: z.boolean().default(false),
     background_command_idle_timeout: z.number().positive().default(900.0),
     /**
      * Max seconds to wait after a turn starts before auto-naming a

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -69,6 +69,10 @@ import {
   resetContextSnapshotStore,
 } from './providers/accounting/context-snapshot-store';
 import {
+  initializeProviderAttemptCaptureStore,
+  resetProviderAttemptCaptureStore,
+} from './providers/accounting/capture-store';
+import {
   initializeSubagentAttributionStore,
   resetSubagentAttributionStore,
 } from './providers/accounting/subagent-attribution-store';
@@ -210,6 +214,12 @@ function initializeProviderAccounting(): void {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Subagent attribution telemetry is unavailable: ${message}`);
+  }
+  try {
+    initializeProviderAttemptCaptureStore();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Provider request debug capture is unavailable: ${message}`);
   }
 }
 
@@ -447,6 +457,7 @@ app.on('before-quit', async (event) => {
     resetToolAttemptStore();
     resetContextSnapshotStore();
     resetSubagentAttributionStore();
+    resetProviderAttemptCaptureStore();
 
     // 7. Now actually quit
     // Final safety flush after teardown, immediately before process exit.

--- a/electron/src/main/ipc/chat/send.ts
+++ b/electron/src/main/ipc/chat/send.ts
@@ -305,6 +305,7 @@ export async function startChatTurn(
     store: accountingStore, sessionId, chainId, turnId, snapshot: providerSnapshot,
     agentScope: 'main', agentName: agent.name, agentType: agent.type, agentTier: agent.tier,
    attemptIdHolder: { value: null }, pricingFacet, tierMechanism,
+    debugCapture: runtime.config.debug_capture_requests,
   };
   const mcpManager = acquireProjectMCPManager(runtime);
   let resourcesReleased = false;

--- a/electron/src/main/ipc/chat/title.ts
+++ b/electron/src/main/ipc/chat/title.ts
@@ -78,6 +78,7 @@ export function createGenerateTitleCallback(input: {
             snapshot: execution.snapshot,
             pricingFacet: execution.pricingFacet,
            attemptIdHolder: { value: null },
+            debugCapture: input.runtime.config.debug_capture_requests,
           },
         }),
       });

--- a/electron/src/main/ipc/config.ts
+++ b/electron/src/main/ipc/config.ts
@@ -57,6 +57,7 @@ const PROJECT_CONFIG_ALLOWED_KEYS = new Set([
   'llm_retry_backoff_base',
   'llm_retry_max_delay',
   'max_tool_steps',
+  'debug_capture_requests',
   'background_command_idle_timeout',
   'session_title_max_wait_seconds',
   'approval_timeout',

--- a/electron/src/main/ipc/debug.ts
+++ b/electron/src/main/ipc/debug.ts
@@ -8,10 +8,15 @@
 import { ipcMain } from 'electron';
 import { z } from 'zod';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
-import { getProviderAttemptCaptureStore } from '../providers/accounting/capture-store';
+import {
+  DEBUG_CAPTURE_LIST_DEFAULT_LIMIT,
+  DEBUG_CAPTURE_LIST_MAX_LIMIT,
+  getProviderAttemptCaptureStore,
+} from '../providers/accounting/capture-store';
 
 const sessionRequestsParamsSchema = z.object({
   sessionId: z.string().min(1),
+  limit: z.number().int().positive().max(DEBUG_CAPTURE_LIST_MAX_LIMIT).optional(),
 }).strict();
 
 const requestCaptureParamsSchema = z.object({
@@ -24,8 +29,8 @@ export function registerDebugIPC(): void {
     if (!parsed.success) throw new Error('Invalid debug:session_requests payload');
     try {
       const store = getProviderAttemptCaptureStore();
-      if (!store) return { requests: [] };
-      return { requests: store.listForSession(parsed.data.sessionId) };
+      if (!store) return { requests: [], total: 0 };
+      return store.listForSession(parsed.data.sessionId, parsed.data.limit ?? DEBUG_CAPTURE_LIST_DEFAULT_LIMIT);
     } catch (error) {
       console.error('[debug] Session requests query failed', { error });
       throw new Error(`Debug session requests query failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });

--- a/electron/src/main/ipc/debug.ts
+++ b/electron/src/main/ipc/debug.ts
@@ -1,0 +1,51 @@
+/**
+ * Debug IPC — per-session raw provider request/response captures (issue 146).
+ *
+ * Read-only queries over the capture store. Captures exist only while the
+ * `debug_capture_requests` config gate is enabled; the handlers themselves
+ * are always registered so the renderer can show an empty state.
+ */
+import { ipcMain } from 'electron';
+import { z } from 'zod';
+import { IPC_CHANNELS } from '../../shared/types/ipc';
+import { getProviderAttemptCaptureStore } from '../providers/accounting/capture-store';
+
+const sessionRequestsParamsSchema = z.object({
+  sessionId: z.string().min(1),
+}).strict();
+
+const requestCaptureParamsSchema = z.object({
+  attemptId: z.string().min(1),
+}).strict();
+
+export function registerDebugIPC(): void {
+  ipcMain.handle(IPC_CHANNELS.DEBUG_SESSION_REQUESTS, async (_event, payload: unknown) => {
+    const parsed = sessionRequestsParamsSchema.safeParse(payload);
+    if (!parsed.success) throw new Error('Invalid debug:session_requests payload');
+    try {
+      const store = getProviderAttemptCaptureStore();
+      if (!store) return { requests: [] };
+      return { requests: store.listForSession(parsed.data.sessionId) };
+    } catch (error) {
+      console.error('[debug] Session requests query failed', { error });
+      throw new Error(`Debug session requests query failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+    }
+  });
+
+  ipcMain.handle(IPC_CHANNELS.DEBUG_REQUEST_CAPTURE, async (_event, payload: unknown) => {
+    const parsed = requestCaptureParamsSchema.safeParse(payload);
+    if (!parsed.success) throw new Error('Invalid debug:request_capture payload');
+    try {
+      const store = getProviderAttemptCaptureStore();
+      return { capture: store ? store.getCapture(parsed.data.attemptId) : null };
+    } catch (error) {
+      console.error('[debug] Request capture query failed', { error });
+      throw new Error(`Debug request capture query failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+    }
+  });
+}
+
+export function unregisterDebugIPC(): void {
+  ipcMain.removeHandler(IPC_CHANNELS.DEBUG_SESSION_REQUESTS);
+  ipcMain.removeHandler(IPC_CHANNELS.DEBUG_REQUEST_CAPTURE);
+}

--- a/electron/src/main/ipc/index.ts
+++ b/electron/src/main/ipc/index.ts
@@ -35,6 +35,7 @@ import { registerAskQuestionIPC, unregisterAskQuestionIPC } from './ask-question
 import { registerPermissionIPC, unregisterPermissionIPC } from './permission';
 import { registerTrustIPC, unregisterTrustIPC } from './trust';
 import { registerAnalyticsIPC, unregisterAnalyticsIPC } from './analytics';
+import { registerDebugIPC, unregisterDebugIPC } from './debug';
 
 /**
  * Register all IPC handlers.
@@ -58,6 +59,7 @@ export function registerAllIPC(): void {
   registerPermissionIPC();
   registerTrustIPC();
   registerAnalyticsIPC();
+  registerDebugIPC();
 }
 
 /**
@@ -82,4 +84,5 @@ export function unregisterAllIPC(): void {
   unregisterPermissionIPC();
   unregisterTrustIPC();
   unregisterAnalyticsIPC();
+  unregisterDebugIPC();
 }

--- a/electron/src/main/llm/compaction/selective/run.ts
+++ b/electron/src/main/llm/compaction/selective/run.ts
@@ -139,6 +139,7 @@ export function createLlmSelectiveCaller(params: {
       store, sessionId: accounting.sessionId, chainId: accounting.chainId, turnId: accounting.turnId,
       snapshot: execution.snapshot, agentScope, agentName: agent.name, agentType: agent.type, agentTier: agent.tier,
       pricingFacet: execution.pricingFacet, tierMechanism: execution.tierMechanism, attemptIdHolder: attemptHolder,
+      debugCapture: config.debug_capture_requests,
     };
     const { streamText, wrapLanguageModel } = await importESM<typeof import('ai')>('ai');
     const model = wrapLanguageModel({ model: execution.modelInstance, middleware: createMiddlewareStack({ retry: { maxRetries: config.llm_stream_retries }, accounting: ctx }) });
@@ -148,7 +149,11 @@ export function createLlmSelectiveCaller(params: {
     const userPrompt = buildSelectiveUserPrompt({ manifest, messages, bridgeContext, previousErrors });
     // Streamed so onTextDelta can surface the raw ops text as it arrives;
     // draining textStream reproduces generateText's semantics.
-    const stream = streamText({ model, instructions: agent.system_prompt, messages: [{ role: 'user', content: userPrompt }], abortSignal: combinedSignal, maxRetries: 0 });
+    const stream = streamText({
+      model, instructions: agent.system_prompt, messages: [{ role: 'user', content: userPrompt }],
+      abortSignal: combinedSignal, maxRetries: 0,
+      include: ctx.debugCapture === true ? { rawChunks: true } : undefined,
+    });
     let text = '';
     for await (const delta of stream.textStream) {
       text += delta;

--- a/electron/src/main/llm/compaction/summarize.ts
+++ b/electron/src/main/llm/compaction/summarize.ts
@@ -426,6 +426,7 @@ export async function summarizeCompactableRange(input: SummarizeInput): Promise<
     pricingFacet: execution.pricingFacet,
     tierMechanism: execution.tierMechanism,
     attemptIdHolder,
+    debugCapture: config.debug_capture_requests,
   };
 
   // 6. Build model with retry + accounting middleware (accounting sits inside retry, per middleware/index.ts)
@@ -482,6 +483,9 @@ export async function summarizeCompactableRange(input: SummarizeInput): Promise<
       instructions: agent.system_prompt,
       messages: [{ role: 'user', content: userPrompt }],
       abortSignal: combinedSignal,
+      include: accountingContext.debugCapture === true
+        ? { rawChunks: true }
+        : undefined,
       // Orchid's accounting-aware retry middleware owns retries.
       maxRetries: 0,
     });

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -350,7 +350,12 @@ export async function* streamChat(params: StreamChatParams): AsyncGenerator<Stre
       model: wrappedModel,
       system: placed.system,
       messages: placed.messages,
-      include: { requestMessages: true },
+      include: {
+        requestMessages: true,
+        // Raw provider chunks for the per-session debug capture (issue 146);
+        // drivers emit `{ type: 'raw' }` parts only when requested.
+        ...(accounting?.debugCapture ? { rawChunks: true } : {}),
+      },
       tools: placed.tools as Record<string, Tool> | undefined,
       stopWhen,
       abortSignal: attempt.signal,

--- a/electron/src/main/permissions/gate.ts
+++ b/electron/src/main/permissions/gate.ts
@@ -17,6 +17,11 @@ import {
 import { getRecentToolCallHistory } from './history';
 import { getProviderRuntime } from '../providers';
 import { createMiddlewareStack } from '../llm/middleware';
+import type { ProviderAttemptAccountingContext } from '../providers/accounting/middleware';
+import {
+  getProviderAccountingStore,
+  initializeProviderAccountingStore,
+} from '../providers/accounting/store';
 import { getTierModelSelection } from '../config/loader';
 import { importESM } from '../utils/esm-import';
 import { AgentType } from '../../shared/types/agent';
@@ -99,11 +104,43 @@ async function runEvaluator(
     if (abortSignal?.aborted) {
       return { decision: 'cancelled', reason: 'parent turn cancelled' };
     }
+    // The evaluator is an attributable provider request: give it a durable
+    // ledger row (usage/cost analytics + the issue-146 debug capture). If the
+    // ledger is unavailable, fail open to an unattributed evaluator call —
+    // parity with pre-accounting behavior.
+    let accountingStore: ReturnType<typeof getProviderAccountingStore> | undefined;
+    try {
+      accountingStore = getProviderAccountingStore();
+    } catch {
+      try {
+        accountingStore = initializeProviderAccountingStore();
+      } catch {
+        accountingStore = undefined;
+      }
+    }
+    const accounting: ProviderAttemptAccountingContext | undefined = accountingStore && sessionId
+      ? {
+          store: accountingStore,
+          sessionId,
+          chainId: null,
+          turnId: null,
+          snapshot: execution.snapshot,
+          agentScope: agentScopeId ?? null,
+          agentName: evaluatorAgent.name,
+          agentType: evaluatorAgent.type,
+          agentTier: evaluatorAgent.tier,
+          attemptIdHolder: { value: null },
+          pricingFacet: execution.pricingFacet,
+          tierMechanism: execution.tierMechanism,
+          debugCapture: config.debug_capture_requests,
+        }
+      : undefined;
     const { generateText, wrapLanguageModel } = await importESM<typeof import('ai')>('ai');
     const model = wrapLanguageModel({
       model: execution.modelInstance,
       middleware: createMiddlewareStack({
         retry: { maxRetries: config.llm_stream_retries },
+        ...(accounting ? { accounting } : {}),
       }),
     });
 

--- a/electron/src/main/providers/accounting/capture-store.ts
+++ b/electron/src/main/providers/accounting/capture-store.ts
@@ -41,6 +41,7 @@ const CAPTURE_REDACTED_HEADERS = new Set([
   'x-api-key',
   'x-goog-api-key',
   'cookie',
+  'set-cookie',
   'proxy-authorization',
 ]);
 

--- a/electron/src/main/providers/accounting/capture-store.ts
+++ b/electron/src/main/providers/accounting/capture-store.ts
@@ -1,0 +1,341 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type {
+  DebugRequestCapture,
+  DebugRequestSummary,
+} from '../../../shared/types/debug';
+import { HOME_CONFIG_DIR } from '../../config/loader';
+import { openSqliteDb, type SqliteDatabase } from '../../utils/sqlite';
+import { ACCOUNTING_SCHEMA_SQL, applyAccountingSchemaMigrations } from './schema';
+
+export const PROVIDER_ATTEMPT_CAPTURE_DB_PATH = path.join(HOME_CONFIG_DIR, 'accounting.db');
+
+/**
+ * Per-field serialization cap. Captures are a debug affordance, not an
+ * archive: one giant history payload must never balloon accounting.db
+ * unboundedly. Over-cap fields are replaced by a truncation marker that
+ * records the original size.
+ */
+export const DEBUG_CAPTURE_MAX_FIELD_BYTES = 4 * 1024 * 1024;
+
+export interface ProviderAttemptCaptureStoreOptions {
+  readonly dbPath?: string;
+  readonly now?: () => Date;
+}
+
+export interface InsertCaptureRequestInput {
+  readonly attemptId: string;
+  readonly sessionId: string;
+  readonly request: unknown;
+}
+
+export interface FinalizeCaptureInput {
+  readonly response: unknown;
+  readonly rawChunks: readonly unknown[];
+}
+
+/** Header names whose values are credentials and must never persist. */
+const CAPTURE_REDACTED_HEADERS = new Set([
+  'authorization',
+  'api-key',
+  'x-api-key',
+  'x-goog-api-key',
+  'cookie',
+  'proxy-authorization',
+]);
+
+interface SerializedField {
+  readonly text: string;
+  readonly bytes: number;
+  readonly truncated: boolean;
+}
+
+/**
+ * Capture-specific serialization. Unlike the accounting ledger's sanitizer
+ * (which redacts body-like keys outright), captures exist to preserve exact
+ * request/response payloads — so only credential-bearing headers and
+ * non-serializable runtime values (abort signals, functions) are stripped.
+ */
+function captureReplacer(this: unknown, key: string, value: unknown): unknown {
+  if (key === 'abortSignal' || key === 'signal') return undefined;
+  if (typeof value === 'function') return '[Function]';
+  if (typeof value === 'bigint' || typeof value === 'symbol') return String(value);
+  // Error parts carry live Error instances; preserve their diagnostic shape.
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, ...(value.stack ? { stack: value.stack } : {}) };
+  }
+  if (key === 'headers' && value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const redacted: Record<string, unknown> = {};
+    for (const [name, headerValue] of Object.entries(value as Record<string, unknown>)) {
+      redacted[name] = CAPTURE_REDACTED_HEADERS.has(name.toLowerCase())
+        ? '[REDACTED]'
+        : headerValue;
+    }
+    return redacted;
+  }
+  return value;
+}
+
+function serializeField(value: unknown): SerializedField {
+  let text: string;
+  try {
+    text = JSON.stringify(value, captureReplacer) ?? 'null';
+  } catch {
+    text = JSON.stringify(String(value));
+  }
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes <= DEBUG_CAPTURE_MAX_FIELD_BYTES) {
+    return { text, bytes, truncated: false };
+  }
+  const marker = JSON.stringify({
+    __truncated: true,
+    originalBytes: bytes,
+    capBytes: DEBUG_CAPTURE_MAX_FIELD_BYTES,
+  });
+  return {
+    text: marker,
+    bytes: Buffer.byteLength(marker, 'utf8'),
+    truncated: true,
+  };
+}
+
+type CaptureRow = {
+  attempt_id: string;
+  session_id: string;
+  request_json: string;
+  request_bytes: number;
+  response_json: string | null;
+  response_bytes: number | null;
+  raw_chunks_json: string | null;
+  raw_available: number;
+  truncated: number;
+  captured_at: string;
+};
+
+type SummaryJoinRow = CaptureRow & {
+  chain_id: string | null;
+  turn_id: string | null;
+  provider_id: string;
+  connection_name: string;
+  model_id: string;
+  protocol: string;
+  outcome: DebugRequestSummary['outcome'];
+  started_at: string;
+  completed_at: string | null;
+  first_token_at: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  agent_scope: string | null;
+  agent_name: string | null;
+  agent_type: string | null;
+  agent_tier: string | null;
+  error: string | null;
+};
+
+function joinRowToSummary(row: SummaryJoinRow): DebugRequestSummary {
+  return {
+    attemptId: row.attempt_id,
+    sessionId: row.session_id,
+    chainId: row.chain_id,
+    turnId: row.turn_id,
+    providerId: row.provider_id,
+    connectionName: row.connection_name,
+    modelId: row.model_id,
+    protocol: row.protocol,
+    agentScope: row.agent_scope,
+    agentName: row.agent_name,
+    agentType: row.agent_type,
+    agentTier: row.agent_tier,
+    outcome: row.outcome,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    firstTokenAt: row.first_token_at,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    requestBytes: row.request_bytes,
+    responseBytes: row.response_bytes,
+    truncated: row.truncated === 1,
+    rawAvailable: row.raw_available === 1,
+    error: row.error,
+  };
+}
+
+/** The frozen attempt snapshot JSON carries the connection display name. */
+function snapshotConnectionName(snapshotJson: string): string {
+  try {
+    return (JSON.parse(snapshotJson) as { connectionName?: string }).connectionName ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Raw provider request/response capture store (issue 146). Shares the
+ * accounting.db file. All writes are best-effort by contract: a capture
+ * failure must never break a provider attempt — callers wrap in try/catch.
+ */
+export class ProviderAttemptCaptureStore {
+  private readonly dbPath: string;
+  private readonly now: () => Date;
+  private db: SqliteDatabase | null = null;
+
+  constructor(options: ProviderAttemptCaptureStoreOptions = {}) {
+    this.dbPath = options.dbPath ?? PROVIDER_ATTEMPT_CAPTURE_DB_PATH;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  close(): void {
+    this.db?.close();
+    this.db = null;
+  }
+
+  /** Persist the request half before network I/O. Idempotent per attempt. */
+  insertRequest(input: InsertCaptureRequestInput): void {
+    const field = serializeField(input.request);
+    this.connection().prepare(`
+      INSERT OR IGNORE INTO provider_attempt_captures (
+        attempt_id, session_id, request_json, request_bytes,
+        response_json, response_bytes, raw_chunks_json, raw_available, truncated, captured_at
+      ) VALUES (?, ?, ?, ?, NULL, NULL, NULL, 0, ?, ?)
+    `).run(
+      input.attemptId,
+      input.sessionId,
+      field.text,
+      field.bytes,
+      field.truncated ? 1 : 0,
+      this.now().toISOString(),
+    );
+  }
+
+  /** Persist the response half once the attempt settles. Idempotent. */
+  finalizeResponse(attemptId: string, input: FinalizeCaptureInput): void {
+    const response = serializeField(input.response);
+    const rawChunks = input.rawChunks.length > 0 ? serializeField(input.rawChunks) : null;
+    this.connection().prepare(`
+      UPDATE provider_attempt_captures
+      SET response_json = ?, response_bytes = ?, raw_chunks_json = ?,
+          raw_available = ?, truncated = MAX(truncated, ?)
+      WHERE attempt_id = ? AND response_json IS NULL
+    `).run(
+      response.text,
+      response.bytes,
+      rawChunks === null ? null : rawChunks.text,
+      input.rawChunks.length > 0 ? 1 : 0,
+      (response.truncated || (rawChunks?.truncated ?? false)) ? 1 : 0,
+      attemptId,
+    );
+  }
+
+  /**
+   * Captured attempts for one session joined with their ledger metadata.
+   * Only attempts that have a capture row are listed — the capture gate
+   * (not the ledger) defines the debug view's population.
+   */
+  listForSession(sessionId: string): readonly DebugRequestSummary[] {
+    const rows = this.connection().prepare(`
+      SELECT cap.attempt_id, cap.session_id, cap.request_bytes, cap.response_bytes,
+             cap.raw_available, cap.truncated, cap.captured_at,
+             pa.chain_id, pa.turn_id, pa.provider_id, pa.model_id, pa.protocol,
+             pa.outcome, pa.started_at, pa.completed_at, pa.first_token_at,
+             json_extract(pa.usage_json, '$.inputTokens') as input_tokens,
+             json_extract(pa.usage_json, '$.outputTokens') as output_tokens,
+             pa.agent_scope, pa.agent_name, pa.agent_type, pa.agent_tier, pa.error,
+             pa.snapshot_json
+      FROM provider_attempt_captures cap
+      JOIN provider_attempts pa ON pa.attempt_id = cap.attempt_id
+      WHERE cap.session_id = ?
+      ORDER BY pa.started_at, pa.attempt_id
+    `).all(sessionId) as Array<SummaryJoinRow & { snapshot_json: string }>;
+    // connection_name lives inside the frozen snapshot JSON, not a column.
+    return rows.map((row) => joinRowToSummary({
+      ...row,
+      connection_name: snapshotConnectionName(row.snapshot_json),
+    }));
+  }
+
+  /** Full capture (request + response + raw chunks) for one attempt. */
+  getCapture(attemptId: string): DebugRequestCapture | null {
+    const row = this.connection().prepare(`
+      SELECT cap.attempt_id, cap.session_id, cap.request_json, cap.request_bytes,
+             cap.response_json, cap.response_bytes, cap.raw_chunks_json, cap.raw_available,
+             cap.truncated, cap.captured_at,
+             pa.chain_id, pa.turn_id, pa.provider_id, pa.model_id, pa.protocol,
+             pa.outcome, pa.started_at, pa.completed_at, pa.first_token_at,
+             json_extract(pa.usage_json, '$.inputTokens') as input_tokens,
+             json_extract(pa.usage_json, '$.outputTokens') as output_tokens,
+             pa.agent_scope, pa.agent_name, pa.agent_type, pa.agent_tier, pa.error,
+             pa.snapshot_json
+      FROM provider_attempt_captures cap
+      JOIN provider_attempts pa ON pa.attempt_id = cap.attempt_id
+      WHERE cap.attempt_id = ?
+    `).get(attemptId) as (SummaryJoinRow & { snapshot_json: string; request_json: string }) | undefined;
+    if (!row) return null;
+
+    const summary = joinRowToSummary({
+      ...row,
+      connection_name: snapshotConnectionName(row.snapshot_json),
+    });
+    let request: unknown;
+    try {
+      request = JSON.parse(row.request_json);
+    } catch {
+      request = null;
+    }
+    let response: unknown = null;
+    if (row.response_json !== null) {
+      try {
+        response = JSON.parse(row.response_json);
+      } catch {
+        response = null;
+      }
+    }
+    let rawChunks: readonly unknown[] = [];
+    if (row.raw_chunks_json !== null) {
+      try {
+        const parsed = JSON.parse(row.raw_chunks_json);
+        rawChunks = Array.isArray(parsed) ? parsed : [];
+      } catch {
+        rawChunks = [];
+      }
+    }
+    return { attemptId, summary, request, response, rawChunks };
+  }
+
+  private connection(): SqliteDatabase {
+    if (this.db) return this.db;
+    const dir = path.dirname(this.dbPath);
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try { fs.chmodSync(dir, 0o700); } catch { /* best effort */ }
+    const db = openSqliteDb(this.dbPath, { schema: ACCOUNTING_SCHEMA_SQL, recovery: 'preserve' });
+    try { fs.chmodSync(this.dbPath, 0o600); } catch { /* best effort */ }
+    db.pragma('foreign_keys = ON');
+    applyAccountingSchemaMigrations(db);
+    this.db = db;
+    return db;
+  }
+}
+
+let runtimeStore: ProviderAttemptCaptureStore | null = null;
+
+/**
+ * Best-effort access: unlike the attempt ledger (fail-closed), a missing
+ * capture store only means no captures — the provider attempt proceeds.
+ * Lazily created once so repeated calls share one SQLite connection.
+ */
+export function getProviderAttemptCaptureStore(): ProviderAttemptCaptureStore | null {
+  if (!runtimeStore) runtimeStore = new ProviderAttemptCaptureStore();
+  return runtimeStore;
+}
+
+export function initializeProviderAttemptCaptureStore(
+  options: ProviderAttemptCaptureStoreOptions = {},
+): ProviderAttemptCaptureStore {
+  runtimeStore?.close();
+  runtimeStore = new ProviderAttemptCaptureStore(options);
+  return runtimeStore;
+}
+
+export function resetProviderAttemptCaptureStore(): void {
+  runtimeStore?.close();
+  runtimeStore = null;
+}

--- a/electron/src/main/providers/accounting/capture-store.ts
+++ b/electron/src/main/providers/accounting/capture-store.ts
@@ -18,6 +18,12 @@ export const PROVIDER_ATTEMPT_CAPTURE_DB_PATH = path.join(HOME_CONFIG_DIR, 'acco
  */
 export const DEBUG_CAPTURE_MAX_FIELD_BYTES = 4 * 1024 * 1024;
 
+/** Session list window when the caller does not request one explicitly. */
+export const DEBUG_CAPTURE_LIST_DEFAULT_LIMIT = 200;
+
+/** Hard ceiling on the requested window (Show more growth is bounded). */
+export const DEBUG_CAPTURE_LIST_MAX_LIMIT = 10_000;
+
 export interface ProviderAttemptCaptureStoreOptions {
   readonly dbPath?: string;
   readonly now?: () => Date;
@@ -231,8 +237,18 @@ export class ProviderAttemptCaptureStore {
    * Captured attempts for one session joined with their ledger metadata.
    * Only attempts that have a capture row are listed — the capture gate
    * (not the ledger) defines the debug view's population.
+   *
+   * Windowed newest-first: long debugged sessions accumulate hundreds of
+   * attempts (one per tool-loop step, retry, and background origin), so the
+   * renderer pages through a growing window instead of shipping every row
+   * over IPC on each poll. Returns the newest `limit` summaries plus the
+   * unwindowed total so the UI can render "N of M".
    */
-  listForSession(sessionId: string): readonly DebugRequestSummary[] {
+  listForSession(
+    sessionId: string,
+    limit: number = DEBUG_CAPTURE_LIST_DEFAULT_LIMIT,
+  ): { requests: readonly DebugRequestSummary[]; total: number } {
+    const cappedLimit = Math.min(DEBUG_CAPTURE_LIST_MAX_LIMIT, Math.max(1, Math.floor(limit)));
     const rows = this.connection().prepare(`
       SELECT cap.attempt_id, cap.session_id, cap.request_bytes, cap.response_bytes,
              cap.raw_available, cap.truncated, cap.captured_at,
@@ -245,13 +261,20 @@ export class ProviderAttemptCaptureStore {
       FROM provider_attempt_captures cap
       JOIN provider_attempts pa ON pa.attempt_id = cap.attempt_id
       WHERE cap.session_id = ?
-      ORDER BY pa.started_at, pa.attempt_id
-    `).all(sessionId) as Array<SummaryJoinRow & { snapshot_json: string }>;
+      ORDER BY pa.started_at DESC, pa.attempt_id DESC
+      LIMIT ?
+    `).all(sessionId, cappedLimit) as Array<SummaryJoinRow & { snapshot_json: string }>;
+    const totalRow = this.connection().prepare(
+      'SELECT COUNT(*) as total FROM provider_attempt_captures WHERE session_id = ?',
+    ).get(sessionId) as { total: number };
     // connection_name lives inside the frozen snapshot JSON, not a column.
-    return rows.map((row) => joinRowToSummary({
-      ...row,
-      connection_name: snapshotConnectionName(row.snapshot_json),
-    }));
+    return {
+      requests: rows.map((row) => joinRowToSummary({
+        ...row,
+        connection_name: snapshotConnectionName(row.snapshot_json),
+      })),
+      total: totalRow.total,
+    };
   }
 
   /** Full capture (request + response + raw chunks) for one attempt. */

--- a/electron/src/main/providers/accounting/middleware.ts
+++ b/electron/src/main/providers/accounting/middleware.ts
@@ -22,6 +22,7 @@ import {
 } from '../../llm/reasoning-tokens';
 import { calculateAttemptCost, type AttemptCostEvidence } from './cost';
 import { ProviderAccountingStore } from './store';
+import { getProviderAttemptCaptureStore } from './capture-store';
 
 export interface ProviderAttemptAccountingContext {
   readonly store: ProviderAccountingStore;
@@ -39,6 +40,15 @@ export interface ProviderAttemptAccountingContext {
   readonly pricingFacet?: DriverPricingFacet;
   /** Driver tier mechanism for served-tier evidence capture (R22). */
   readonly tierMechanism?: import('../../../shared/types/provider-facets').TierMechanism;
+  /**
+   * Raw request/response debug capture gate (issue 146), frozen per turn from
+   * the `debug_capture_requests` config. When true, every attempt persisted by
+   * this middleware also writes its exact provider request and response into
+   * the capture store. Callers should additionally pass
+   * `include: { rawChunks: true }` to the AI SDK call so raw provider chunks
+   * are captured alongside the normalized stream parts.
+   */
+  readonly debugCapture?: boolean;
 }
 
 function normalizeUsage(usage: LanguageModelV4Usage | undefined): NormalizedProviderUsage | null {
@@ -187,6 +197,45 @@ function errorMessage(error: unknown): string {
 }
 
 /**
+ * Best-effort raw capture plumbing (issue 146). Every entry point swallows
+ * its errors: a capture failure must never alter provider behavior.
+ */
+function captureRequest(context: ProviderAttemptAccountingContext, attemptId: string, params: LanguageModelV4CallOptions): void {
+  if (!context.debugCapture) return;
+  try {
+    getProviderAttemptCaptureStore()?.insertRequest({
+      attemptId,
+      sessionId: context.sessionId,
+      request: {
+        callOptions: params,
+        identity: {
+          providerId: context.snapshot.providerId,
+          connectionId: context.snapshot.connectionId,
+          modelId: context.snapshot.modelId,
+          protocol: context.snapshot.protocol,
+        },
+      },
+    });
+  } catch (error) {
+    console.warn('[accounting] Request capture failed', { error });
+  }
+}
+
+function captureResponse(
+  context: ProviderAttemptAccountingContext,
+  attemptId: string,
+  response: unknown,
+  rawChunks: readonly unknown[],
+): void {
+  if (!context.debugCapture) return;
+  try {
+    getProviderAttemptCaptureStore()?.finalizeResponse(attemptId, { response, rawChunks });
+  } catch (error) {
+    console.warn('[accounting] Response capture failed', { error });
+  }
+}
+
+/**
  * Middleware inserted immediately inside retry middleware. Each doStream or
  * doGenerate invocation gets its own pending ledger row, including retries and
  * AI SDK tool-loop steps. Failure to create that row aborts transport before I/O.
@@ -207,6 +256,7 @@ export function createAttemptAccountingMiddleware(
       const attemptId = randomUUID();
       if (context.attemptIdHolder) context.attemptIdHolder.value = attemptId;
       context.store.insertPending({ ...context, attemptId, sdkCallId: attemptId });
+      captureRequest(context, attemptId, params);
       try {
         const result = await doGenerate();
         const chars = emptyOutputChars();
@@ -224,6 +274,9 @@ export function createAttemptAccountingMiddleware(
           providerEvidence: extracted.providerEvidence,
           cost: calculateAttemptCost({ snapshot: context.snapshot, usage: extracted.usage, evidence: extracted.evidence }),
         });
+        // Generate results carry the exact request/response HTTP bodies in
+        // their telemetry fields — no rawChunks flag needed on this path.
+        captureResponse(context, attemptId, result, []);
         return result;
       } catch (error) {
         context.store.finalize(attemptId, {
@@ -249,6 +302,7 @@ export function createAttemptAccountingMiddleware(
       const attemptId = randomUUID();
       if (context.attemptIdHolder) context.attemptIdHolder.value = attemptId;
       context.store.insertPending({ ...context, attemptId, sdkCallId: attemptId });
+      captureRequest(context, attemptId, params);
       let result: LanguageModelV4StreamResult;
       try {
         result = await doStream();
@@ -266,6 +320,12 @@ export function createAttemptAccountingMiddleware(
       let finalized = false;
       let firstTokenMarked = false;
       const chars = emptyOutputChars();
+      // Debug capture accumulators (issue 146): normalized parts in arrival
+      // order plus raw provider chunks when the driver honors the
+      // includeRawChunks call option.
+      const capturedParts: LanguageModelV4StreamPart[] = [];
+      const capturedRawChunks: unknown[] = [];
+      const captureEnabled = context.debugCapture === true;
       const finalize = (outcome: 'succeeded' | 'failed' | 'interrupted', part?: LanguageModelV4StreamPart, error?: unknown) => {
         if (finalized) return;
         finalized = true;
@@ -285,6 +345,16 @@ export function createAttemptAccountingMiddleware(
             ? calculateAttemptCost({ snapshot: context.snapshot, usage: extracted.usage, evidence: extracted.evidence })
             : { state: 'unknown', source: 'unknown', reason: 'Provider stream did not complete with authoritative cost' },
           ...(error === undefined ? {} : { error: errorMessage(error) }),
+        });
+        // Deferred off the settle path: a multi-MiB serialize + synchronous
+        // UPDATE here can busy-wait the SQLite write lock and stall the turn
+        // handoff (same hazard the TTFT write defers around). The parts array
+        // is complete at finalize time and never mutated afterwards; the
+        // response_json IS NULL guard makes the late write idempotent-safe.
+        const responseSnapshot = { http: result.response, parts: capturedParts };
+        const rawSnapshot = [...capturedRawChunks];
+        queueMicrotask(() => {
+          captureResponse(context, attemptId, responseSnapshot, rawSnapshot);
         });
       };
 
@@ -327,6 +397,14 @@ export function createAttemptAccountingMiddleware(
                   console.warn('[accounting] markFirstToken failed', { error });
                 }
               });
+            }
+            // Capture before finalize: the finalize() below flushes the
+            // accumulated parts, so the finish/error part currently being
+            // processed must be in the buffer first — a successful stream's
+            // capture must include its terminal part (usage, finishReason).
+            if (captureEnabled) {
+              if (next.value.type === 'raw') capturedRawChunks.push(next.value.rawValue);
+              else capturedParts.push(next.value);
             }
             if (next.value.type === 'finish') finalize('succeeded', next.value);
             if (next.value.type === 'error') {

--- a/electron/src/main/providers/accounting/schema.ts
+++ b/electron/src/main/providers/accounting/schema.ts
@@ -1,7 +1,7 @@
 import type { SqliteDatabase } from '../../utils/sqlite';
 
 /** SQLite schema version for append-only provider attempt records. */
-export const ACCOUNTING_SCHEMA_VERSION = 6;
+export const ACCOUNTING_SCHEMA_VERSION = 7;
 
 export const ACCOUNTING_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -129,6 +129,26 @@ CREATE TABLE IF NOT EXISTS session_names (
   name TEXT NOT NULL,
   deleted_at TEXT NOT NULL
 );
+
+-- Raw request/response captures (issue 146). Written only when the
+-- debug_capture_requests config gate is enabled; one row per provider
+-- attempt (see accounting middleware). The request half is written before
+-- network I/O; the response half is finalized when the attempt settles.
+-- Payloads may be truncated to the per-field byte cap — see capture-store.
+CREATE TABLE IF NOT EXISTS provider_attempt_captures (
+  attempt_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  request_json TEXT NOT NULL,
+  request_bytes INTEGER NOT NULL,
+  response_json TEXT,
+  response_bytes INTEGER,
+  raw_chunks_json TEXT,
+  raw_available INTEGER NOT NULL DEFAULT 0,
+  truncated INTEGER NOT NULL DEFAULT 0,
+  captured_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_attempt_captures_session ON provider_attempt_captures(session_id, captured_at);
 `;
 
 /**

--- a/electron/src/main/tools/index.ts
+++ b/electron/src/main/tools/index.ts
@@ -53,6 +53,11 @@ import { getSessionManager } from '../session/singleton';
 import { getTierModelSelection } from '../config/loader';
 import { getProviderRuntime } from '../providers';
 import { createMiddlewareStack } from '../llm/middleware';
+import type { ProviderAttemptAccountingContext } from '../providers/accounting/middleware';
+import {
+  getProviderAccountingStore,
+  initializeProviderAccountingStore,
+} from '../providers/accounting/store';
 import { importESM } from '../utils/esm-import';
 import { IPC_CHANNELS } from '../../shared/types/ipc';
 
@@ -176,10 +181,42 @@ function buildWebFetchSummarizer(
 
     const execution = await getProviderRuntime().resolveExecution(selection);
     const { generateText, wrapLanguageModel } = await importESM<typeof import('ai')>('ai');
+
+    // The summarizer is an attributable provider request: give it a durable
+    // ledger row (usage/cost analytics + the issue-146 debug capture). Best
+    // effort — a telemetry outage degrades to an unattributed call.
+    let accountingStore: ReturnType<typeof getProviderAccountingStore> | undefined;
+    try {
+      accountingStore = getProviderAccountingStore();
+    } catch {
+      try {
+        accountingStore = initializeProviderAccountingStore();
+      } catch {
+        accountingStore = undefined;
+      }
+    }
+    const accounting: ProviderAttemptAccountingContext | undefined = accountingStore && context.sessionId
+      ? {
+          store: accountingStore,
+          sessionId: context.sessionId,
+          chainId: null,
+          turnId: null,
+          snapshot: execution.snapshot,
+          agentScope: context.agentScopeId ?? null,
+          agentName: agent.name,
+          agentType: agent.type,
+          agentTier: agent.tier,
+          attemptIdHolder: { value: null },
+          pricingFacet: execution.pricingFacet,
+          tierMechanism: execution.tierMechanism,
+          debugCapture: config.debug_capture_requests,
+        }
+      : undefined;
     const model = wrapLanguageModel({
       model: execution.modelInstance,
       middleware: createMiddlewareStack({
         retry: { maxRetries: config.llm_stream_retries },
+        ...(accounting ? { accounting } : {}),
       }),
     });
 

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -129,6 +129,10 @@ import type {
   ContextSessionsResult,
   AnalyticsTimeRange,
 } from '../shared/types/analytics';
+import type {
+  DebugSessionRequestsResult,
+  DebugRequestCaptureResult,
+} from '../shared/types/debug';
 import {
   chatChunkEventSchema,
   chatThinkingEventSchema,
@@ -756,6 +760,14 @@ const orchidAPI: OrchidAPI = {
 
     contextSessions: (params?: { readonly timeRange?: AnalyticsTimeRange }) =>
       invoke<ContextSessionsResult>(IPC_CHANNELS.ANALYTICS_CONTEXT_SESSIONS, params),
+  },
+
+  debug: {
+    sessionRequests: (params: { readonly sessionId: string }) =>
+      invoke<DebugSessionRequestsResult>(IPC_CHANNELS.DEBUG_SESSION_REQUESTS, params),
+
+    requestCapture: (params: { readonly attemptId: string }) =>
+      invoke<DebugRequestCaptureResult>(IPC_CHANNELS.DEBUG_REQUEST_CAPTURE, params),
   },
 };
 

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -769,7 +769,7 @@ const orchidAPI: OrchidAPI = {
   },
 
   debug: {
-    sessionRequests: (params: { readonly sessionId: string }) =>
+    sessionRequests: (params: { readonly sessionId: string; readonly limit?: number }) =>
       invoke<DebugSessionRequestsResult>(IPC_CHANNELS.DEBUG_SESSION_REQUESTS, params),
 
     requestCapture: (params: { readonly attemptId: string }) =>

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -129,6 +129,10 @@ import type {
   ContextSessionsResult,
   AnalyticsTimeRange,
 } from '../shared/types/analytics';
+import {
+  debugSessionRequestsResultSchema,
+  debugRequestCaptureResultSchema,
+} from '../shared/types/debug';
 import type {
   DebugSessionRequestsResult,
   DebugRequestCaptureResult,
@@ -225,6 +229,8 @@ const INVOKE_RESULT_SCHEMAS: Partial<Record<string, z.ZodTypeAny>> = {
   [IPC_CHANNELS.PROJECT_TRUST_GET]: projectTrustInfoSchema,
   [IPC_CHANNELS.PROJECT_TRUST_SET]: projectTrustInfoSchema,
   [IPC_CHANNELS.PROJECT_TRUST_LIST]: z.array(trustedProjectEntrySchema),
+  [IPC_CHANNELS.DEBUG_SESSION_REQUESTS]: debugSessionRequestsResultSchema,
+  [IPC_CHANNELS.DEBUG_REQUEST_CAPTURE]: debugRequestCaptureResultSchema,
 };
 
 async function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -1454,6 +1454,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
           onRefreshCommands={commands.refresh}
           requestsState={debugRequests.state}
           onRefreshRequests={debugRequests.refresh}
+          onShowMoreRequests={debugRequests.showMore}
           selectedRequestId={debugRequests.selectedId}
           onSelectRequest={debugRequests.select}
           requestCapture={debugRequests.capture}

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -15,6 +15,7 @@ import {
 import { useChat } from '../hooks/useChat';
 import { useSession } from '../hooks/useSession';
 import { useBackgroundCommands } from '../hooks/useBackgroundCommands';
+import { useDebugRequests } from '../hooks/useDebugRequests';
 import { useInspectorHydration } from '../hooks/useInspectorHydration';
 import { useSubagents } from '../hooks/useSubagents';
 import { useTodos } from '../hooks/useTodos';
@@ -241,6 +242,14 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
     latestPersistedUsage: sessionUsage.latest,
     onUntrustedProject: trustSend.onUntrustedProject,
   });
+
+  // Debug request captures (inspector Requests section). Polls only while the
+  // inspector is open; paces at the subagents tick while a turn is streaming.
+  const debugRequests = useDebugRequests(
+    session.activeSession?.id ?? null,
+    sidebarOpen,
+    chat.status === 'streaming',
+  );
 
   useEffect(() => {
     const element = chatContentRef.current;
@@ -1443,6 +1452,12 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
           onRefreshTodos={todos.refresh}
           commandsState={commands.state}
           onRefreshCommands={commands.refresh}
+          requestsState={debugRequests.state}
+          onRefreshRequests={debugRequests.refresh}
+          selectedRequestId={debugRequests.selectedId}
+          onSelectRequest={debugRequests.select}
+          requestCapture={debugRequests.capture}
+          onRetryRequestCapture={debugRequests.retryCapture}
           sessionId={session.activeSession?.id ?? null}
           mcpServers={mcpServers}
           ragStatus={ragStatus}

--- a/electron/src/renderer/components/CommandPalette.tsx
+++ b/electron/src/renderer/components/CommandPalette.tsx
@@ -222,6 +222,7 @@ export const CommandPalette = memo(function CommandPalette({
         { name: 'Todos', desc: 'Task list' },
         { name: 'MCP Servers', desc: 'MCP server status' },
         { name: 'Index Status', desc: 'RAG and AST index status' },
+        { name: 'Requests', desc: 'Captured provider requests (debug)' },
       ];
       for (const item of navItems) {
         const score = Math.max(

--- a/electron/src/renderer/components/ConfigView.tsx
+++ b/electron/src/renderer/components/ConfigView.tsx
@@ -881,6 +881,7 @@ function renderTab(
           llmStreamIdleTimeout={config.llm_stream_idle_timeout}
           llmStreamRetries={config.llm_stream_retries}
           maxToolSteps={config.max_tool_steps}
+          debugCaptureRequests={config.debug_capture_requests}
           mcpStartupTimeout={config.mcp_startup_timeout}
           mcpPerServerTimeout={config.mcp_per_server_timeout}
           personality={config.personality}

--- a/electron/src/renderer/components/Preferences/GeneralTab.tsx
+++ b/electron/src/renderer/components/Preferences/GeneralTab.tsx
@@ -41,6 +41,8 @@ export interface GeneralTabProps {
    * Default 100.
    */
   maxToolSteps: number;
+  /** Raw provider request/response debug capture (issue 146). */
+  debugCaptureRequests: boolean;
   /** When true, compact tool-activity groups start expanded. */
   alwaysExpandToolGroups: boolean;
   commandMaxOutputBytes: number;
@@ -86,6 +88,7 @@ export function GeneralTab({
   llmStreamRetries,
   backgroundCommandIdleTimeout,
   maxToolSteps,
+  debugCaptureRequests,
   alwaysExpandToolGroups,
   commandMaxOutputBytes,
   toolOutputInlineThreshold,
@@ -562,6 +565,21 @@ export function GeneralTab({
               className="w-full"
               min={1}
               max={256}
+            />
+          </FormField>
+          <FormField
+            label="Capture raw provider requests and responses"
+            htmlFor="general-debug-capture"
+            hint="Save the exact request sent and response received for every LLM call in every session (main agent, subagents, compactors, title namer, evaluators) and inspect them in the Requests inspector section. Increases disk usage — leave off unless debugging."
+            className="config-field config-form-grid-full"
+          >
+            <Checkbox
+              id="general-debug-capture"
+              size="sm"
+              checked={debugCaptureRequests}
+              onChange={(e) =>
+                onChange({ debug_capture_requests: e.target.checked })
+              }
             />
           </FormField>
         </div>

--- a/electron/src/renderer/components/ProjectConfigView.tsx
+++ b/electron/src/renderer/components/ProjectConfigView.tsx
@@ -152,6 +152,7 @@ const TAB_SECTIONS: Partial<Record<ProjectTab, ProjectConfigSection[]>> = {
         { key: 'llm_retry_backoff_base', label: 'Retry Backoff Base (s)', kind: 'number', min: 0.01, step: 0.01 },
         { key: 'llm_retry_max_delay', label: 'Retry Max Delay (s)', kind: 'number', min: 1 },
         { key: 'max_tool_steps', label: 'Max Tool Steps', kind: 'integer', min: 1, max: 1000 },
+        { key: 'debug_capture_requests', label: 'Capture Raw Provider Requests', kind: 'boolean', hint: 'Save the exact request/response for every LLM call in this project (Requests inspector section). Increases disk usage.' },
         { key: 'background_command_idle_timeout', label: 'BG Command Idle Timeout (s)', kind: 'number', min: 30, max: 3600 },
       ],
     },

--- a/electron/src/renderer/components/Sidebar.tsx
+++ b/electron/src/renderer/components/Sidebar.tsx
@@ -2,7 +2,7 @@
  * Sidebar — right inspector panel (Todos, Subagents, Commands, Context, Usage, Index, MCP).
  * Iteration 012 mock-aligned collapse blocks.
  */
-import { memo, useEffect, useState, type ReactNode } from 'react';
+import { memo, useEffect, useMemo, useState, type ReactNode } from 'react';
 import type {
   MCPServerStatus,
   MCPServerStatusValue,
@@ -11,6 +11,7 @@ import type {
   RAGIndexProgress,
   ASTIndexProgress,
 } from '../../shared/types/ipc-boundary';
+import type { DebugRequestSummary } from '../../shared/types/debug';
 import { ContextGrid, contextPercent as getContextPercent } from './ContextGrid';
 import { contextUsedTokens } from '../../shared/usage';
 import type { Message, Usage } from '../../shared/types/message';
@@ -19,6 +20,11 @@ import type { SubagentSummary } from '../../shared/types/subagent';
 import type { SubagentListState, SubagentDetail } from '../hooks/useSubagents';
 import type { TodoListState } from '../hooks/useTodos';
 import type { BackgroundCommandsState } from '../hooks/useBackgroundCommands';
+import type {
+  DebugRequestCaptureState,
+  DebugRequestsListState,
+} from '../hooks/useDebugRequests';
+import { countRequestAgentOrigins } from '../hooks/useDebugRequests';
 import { formatShortcut } from '../keyboard';
 import {
   nextForceOpenEpoch,
@@ -35,7 +41,12 @@ import { IconButton } from './ui/IconButton';
 import { Spinner } from './ui/Spinner';
 import { StateMessage } from './ui/StateMessage';
 import { StatusBadge } from './ui/StatusBadge';
+import { Tabs, type TabItem } from './ui/Tabs';
 import { CommandsSection, countRunningCommands } from './Sidebar/CommandsSection';
+
+/** Stable prop defaults so the memoized Sidebar never churns on re-renders. */
+const EMPTY_REQUESTS_LIST: DebugRequestsListState = { status: 'empty' };
+const EMPTY_REQUEST_CAPTURE: DebugRequestCaptureState = { status: 'idle' };
 
 interface SidebarProps {
   isOpen: boolean;
@@ -52,6 +63,13 @@ interface SidebarProps {
   /** Session-wide background command fleet (main + subagent scopes). */
   commandsState: BackgroundCommandsState;
   onRefreshCommands: () => void;
+  /** Per-session captured provider requests (debug inspector section). */
+  requestsState?: DebugRequestsListState;
+  onRefreshRequests?: () => void;
+  selectedRequestId?: string | null;
+  onSelectRequest?: (attemptId: string | null) => void;
+  requestCapture?: DebugRequestCaptureState;
+  onRetryRequestCapture?: () => void;
   /** Active session the command widgets resolve visibility and controls against. */
   sessionId: string | null;
   mcpServers: MCPServerStatus[];
@@ -88,6 +106,12 @@ export const Sidebar = memo(function Sidebar({
   onRefreshTodos,
   commandsState,
   onRefreshCommands,
+  requestsState = EMPTY_REQUESTS_LIST,
+  onRefreshRequests = () => {},
+  selectedRequestId = null,
+  onSelectRequest = () => {},
+  requestCapture = EMPTY_REQUEST_CAPTURE,
+  onRetryRequestCapture = () => {},
   sessionId = null,
   mcpServers,
   ragStatus = null,
@@ -113,6 +137,11 @@ export const Sidebar = memo(function Sidebar({
   const runningCommandCount = commandsState.status === 'ready'
     ? countRunningCommands(commandsState.commands)
     : 0;
+  const debugRequests = requestsState.status === 'ready' ? requestsState.requests : [];
+  const debugRequestOrigins = useMemo(
+    () => countRequestAgentOrigins(debugRequests),
+    [debugRequests],
+  );
 
   useEffect(() => {
     if (!focusSection) return;
@@ -258,6 +287,26 @@ export const Sidebar = memo(function Sidebar({
           badge={<MCPStatusBadges servers={mcpServers} />}
         >
           <MCPSection servers={mcpServers} />
+        </CollapseBlock>
+
+        <CollapseBlock
+          title="Requests"
+          sectionId="inspector-requests"
+          forceOpenToken={forcedSection === 'inspector-requests' ? forceOpenEpoch : 0}
+          badge={
+            debugRequests.length > 0
+              ? <RequestsBadge count={debugRequests.length} origins={debugRequestOrigins} />
+              : null
+          }
+        >
+          <RequestsSection
+            state={requestsState}
+            onRefresh={onRefreshRequests}
+            selectedId={selectedRequestId}
+            onSelect={onSelectRequest}
+            capture={requestCapture}
+            onRetryCapture={onRetryRequestCapture}
+          />
         </CollapseBlock>
       </div>
     </aside>
@@ -1116,4 +1165,390 @@ function formatTokenCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
+}
+
+// ── Requests Section (debug captures) ────────────────────────────────────────
+
+const REQUEST_OUTCOME_CONFIG: Readonly<
+  Record<DebugRequestSummary['outcome'], { tone: 'neutral' | 'success' | 'warning' | 'error'; label: string }>
+> = {
+  pending: { tone: 'neutral', label: 'pending' },
+  succeeded: { tone: 'success', label: 'ok' },
+  failed: { tone: 'error', label: 'failed' },
+  interrupted: { tone: 'warning', label: 'interrupted' },
+};
+
+/** Header count; flags multi-origin sessions (main + subagents/internals). */
+function RequestsBadge({ count, origins }: { count: number; origins: number }) {
+  return (
+    <StatusBadge tone="neutral" size="xs" outline>
+      {origins > 1 ? `${count} · ${origins} agents` : count}
+    </StatusBadge>
+  );
+}
+
+interface RequestsSectionProps {
+  state: DebugRequestsListState;
+  onRefresh: () => void;
+  selectedId: string | null;
+  onSelect: (attemptId: string | null) => void;
+  capture: DebugRequestCaptureState;
+  onRetryCapture: () => void;
+}
+
+function RequestsSection({
+  state,
+  onRefresh,
+  selectedId,
+  onSelect,
+  capture,
+  onRetryCapture,
+}: RequestsSectionProps) {
+  if (state.status === 'loading') {
+    return <StateMessage kind="loading" className="inspector-empty py-4" title="Loading requests…" />;
+  }
+
+  if (state.status === 'error') {
+    return (
+      <StateMessage
+        kind="error"
+        className="inspector-empty py-4"
+        title={state.error}
+        action={
+          <Button variant="ghost" size="xs" onClick={onRefresh}>
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (state.status === 'empty') {
+    return (
+      <StateMessage className="inspector-empty py-4" kind="empty" title="No captured requests">
+        enable debug_capture_requests in settings.
+      </StateMessage>
+    );
+  }
+
+  // Newest attempt first; unparseable timestamps keep their arrival order.
+  const requests = [...state.requests].sort((a, b) => {
+    const left = Date.parse(a.startedAt);
+    const right = Date.parse(b.startedAt);
+    if (Number.isNaN(left) || Number.isNaN(right)) return 0;
+    return right - left;
+  });
+
+  return (
+    <div className="inspector-stack">
+      {requests.map((request) => (
+        <RequestRow
+          key={request.attemptId}
+          request={request}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          capture={capture}
+          onRetryCapture={onRetryCapture}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface RequestRowProps {
+  request: DebugRequestSummary;
+  selectedId: string | null;
+  onSelect: (attemptId: string | null) => void;
+  capture: DebugRequestCaptureState;
+  onRetryCapture: () => void;
+}
+
+function RequestRow({ request, selectedId, onSelect, capture, onRetryCapture }: RequestRowProps) {
+  // Mock-style compact row: mono agent + outcome badge, model + time + tokens.
+  const isSelected = selectedId === request.attemptId;
+  const scope = request.agentScope || 'main';
+  const tokens = formatRequestTokens(request);
+
+  return (
+    <div className="inspector-stack gap-0">
+      <button
+        type="button"
+        className={`inspector-row inspector-subagent-row rounded py-1 pr-0.5 ${isSelected ? 'inspector-row-active' : ''}`}
+        onClick={() => onSelect(isSelected ? null : request.attemptId)}
+      >
+        <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+          <span className="inline-flex min-w-0 items-center gap-1.5">
+            <span className="inspector-row-label mono truncate" title={request.agentName || scope}>
+              {request.agentName || scope}
+            </span>
+            {scope !== 'main' && (
+              <StatusBadge tone="info" size="xs" className="max-w-24 shrink-0 truncate" title={scope}>
+                {scope}
+              </StatusBadge>
+            )}
+            {request.truncated && (
+              <span className="subtle shrink-0 text-xs" title="A capture field exceeded the byte cap">
+                trunc
+              </span>
+            )}
+          </span>
+          <span className="inspector-row-label subtle truncate" title={request.modelId}>
+            {request.modelId}
+          </span>
+        </span>
+        <span className="inline-flex shrink-0 flex-col items-end gap-0.5">
+          <RequestOutcomeBadge outcome={request.outcome} />
+          <span className="subtle mono whitespace-nowrap" title={request.startedAt}>
+            {formatRelativeTime(request.startedAt)}
+            {tokens ? ` · ${tokens}` : ''}
+          </span>
+        </span>
+      </button>
+      {isSelected && (
+        <RequestDetail summary={request} capture={capture} onRetry={onRetryCapture} />
+      )}
+    </div>
+  );
+}
+
+function RequestOutcomeBadge({ outcome }: { outcome: DebugRequestSummary['outcome'] }) {
+  const { tone, label } = REQUEST_OUTCOME_CONFIG[outcome];
+  return (
+    <StatusBadge tone={tone} size="xs" withDot outline={tone === 'neutral'}>
+      {label}
+    </StatusBadge>
+  );
+}
+
+/** Compact in/out pair (e.g. `1.2k→300`); empty while the attempt is pending. */
+function formatRequestTokens(request: DebugRequestSummary): string {
+  if (request.inputTokens == null && request.outputTokens == null) return '';
+  const input = request.inputTokens != null ? formatTokenCount(request.inputTokens) : '–';
+  const output = request.outputTokens != null ? formatTokenCount(request.outputTokens) : '–';
+  return `${input}→${output}`;
+}
+
+function formatRequestClockTime(iso: string): string {
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return iso;
+  return new Date(ms).toLocaleTimeString([], { hour12: false });
+}
+
+function formatRequestDuration(request: DebugRequestSummary): string | null {
+  const start = new Date(request.startedAt).getTime();
+  const end = request.completedAt ? new Date(request.completedAt).getTime() : Number.NaN;
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  const seconds = Math.max(0, (end - start) / 1000);
+  return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
+}
+
+interface RequestDetailProps {
+  summary: DebugRequestSummary;
+  capture: DebugRequestCaptureState;
+  onRetry: () => void;
+}
+
+function RequestDetail({ summary, capture, onRetry }: RequestDetailProps) {
+  const duration = formatRequestDuration(summary);
+
+  return (
+    <div className="inspector-subagent-detail">
+      <div className="inspector-row">
+        <span className="subtle">outcome</span>
+        <RequestOutcomeBadge outcome={summary.outcome} />
+      </div>
+      <div className="inspector-row">
+        <span className="subtle">model</span>
+        <span
+          className="inspector-row-label mono truncate text-right"
+          title={`${summary.connectionName} · ${summary.providerId} · ${summary.protocol}`}
+        >
+          {summary.modelId}
+        </span>
+      </div>
+      {summary.agentTier && (
+        <div className="inspector-row">
+          <span className="subtle">tier</span>
+          <span className="subtle">{summary.agentTier}</span>
+        </div>
+      )}
+      <div className="inspector-row">
+        <span className="subtle">started</span>
+        <span className="subtle mono">{formatRequestClockTime(summary.startedAt)}</span>
+      </div>
+      {duration && (
+        <div className="inspector-row">
+          <span className="subtle">duration</span>
+          <span className="subtle mono">{duration}</span>
+        </div>
+      )}
+      {(summary.inputTokens != null || summary.outputTokens != null) && (
+        <div className="inspector-row">
+          <span className="subtle">tokens</span>
+          <span className="subtle mono">{formatRequestTokens(summary) || '–'}</span>
+        </div>
+      )}
+      {(summary.requestBytes != null || summary.responseBytes != null) && (
+        <div className="inspector-row">
+          <span className="subtle">bytes</span>
+          <span className="subtle mono">
+            {summary.requestBytes != null ? formatCompactCount(summary.requestBytes) : '–'}
+            {' / '}
+            {summary.responseBytes != null ? formatCompactCount(summary.responseBytes) : '–'}
+          </span>
+        </div>
+      )}
+      {summary.error && (
+        <div className="subtle text-error break-words" title={summary.error}>
+          {summary.error}
+        </div>
+      )}
+      <RequestCapturePane summary={summary} capture={capture} onRetry={onRetry} />
+    </div>
+  );
+}
+
+// ── Requests capture panes ───────────────────────────────────────────────────
+
+/** Cap the rendered string; multi-MB payloads must not hit the DOM in full. */
+const MAX_RENDER_CHARS = 500_000;
+
+function prettyPayload(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+interface RequestCapturePaneProps {
+  summary: DebugRequestSummary;
+  capture: DebugRequestCaptureState;
+  onRetry: () => void;
+}
+
+function RequestCapturePane({ summary, capture, onRetry }: RequestCapturePaneProps) {
+  const [tab, setTab] = useState('request');
+
+  if (capture.status === 'idle') return null;
+
+  if (capture.status === 'loading') {
+    return <div className="subtle">Loading capture…</div>;
+  }
+
+  if (capture.status === 'error') {
+    return (
+      <div className="inspector-stack gap-1">
+        <div className="subtle text-error break-words">{capture.error}</div>
+        <div>
+          <Button variant="ghost" size="xs" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (capture.status === 'unavailable') {
+    return (
+      <div className="subtle">
+        {summary.outcome === 'pending'
+          ? 'Capture pending — loads when the attempt settles.'
+          : 'Capture unavailable for this attempt.'}
+      </div>
+    );
+  }
+
+  const hasRaw = capture.capture.rawChunks.length > 0;
+  const activeTab = tab === 'raw' && !hasRaw ? 'request' : tab;
+  const items: TabItem[] = [
+    { id: 'request', label: 'Request' },
+    { id: 'response', label: 'Response' },
+    ...(hasRaw ? [{ id: 'raw' as const, label: 'Raw chunks' }] : []),
+  ];
+  const value = activeTab === 'request'
+    ? capture.capture.request
+    : activeTab === 'response'
+      ? capture.capture.response
+      : capture.capture.rawChunks;
+
+  return (
+    <CaptureTabs
+      items={items}
+      activeTab={activeTab}
+      onSelectTab={setTab}
+      value={value}
+    />
+  );
+}
+
+interface CaptureTabsProps {
+  items: readonly TabItem[];
+  activeTab: string;
+  onSelectTab: (id: string) => void;
+  value: unknown;
+}
+
+function CaptureTabs({ items, activeTab, onSelectTab, value }: CaptureTabsProps) {
+  // Pretty-print once per payload; the full string backs the copy action.
+  const text = useMemo(() => prettyPayload(value), [value]);
+
+  return (
+    <div className="inspector-stack">
+      <div className="flex items-center justify-between gap-1 pt-0.5">
+        <Tabs
+          items={items}
+          value={activeTab}
+          onValueChange={onSelectTab}
+          className="min-w-0 flex-1"
+          itemClassName="flex-1 text-xs"
+        />
+        <CopyPayloadButton text={text} />
+      </div>
+      <PayloadPane text={text} />
+    </div>
+  );
+}
+
+function CopyPayloadButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can be denied; the selection path still works.
+    }
+  };
+
+  return (
+    <IconButton
+      label={copied ? 'Copied' : 'Copy payload'}
+      tooltip={copied ? 'Copied' : 'Copy payload'}
+      icon="copy"
+      size="xs"
+      variant="ghost"
+      className="shrink-0"
+      onClick={() => void copy()}
+    />
+  );
+}
+
+function PayloadPane({ text }: { text: string }) {
+  const truncatedForDisplay = text.length > MAX_RENDER_CHARS;
+  const shown = truncatedForDisplay ? text.slice(0, MAX_RENDER_CHARS) : text;
+
+  return (
+    <div className="inspector-stack gap-0">
+      <pre className="orchid-tool-result-selectable m-0 max-h-96 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-base-300 bg-base-100 p-2 font-mono text-xs leading-relaxed text-base-content/80">
+        {shown.length > 0 ? shown : '(empty payload)'}
+      </pre>
+      {truncatedForDisplay && (
+        <div className="subtle text-xs">(truncated for display — use copy for full payload)</div>
+      )}
+    </div>
+  );
 }

--- a/electron/src/renderer/components/Sidebar.tsx
+++ b/electron/src/renderer/components/Sidebar.tsx
@@ -66,6 +66,7 @@ interface SidebarProps {
   /** Per-session captured provider requests (debug inspector section). */
   requestsState?: DebugRequestsListState;
   onRefreshRequests?: () => void;
+  onShowMoreRequests?: () => void;
   selectedRequestId?: string | null;
   onSelectRequest?: (attemptId: string | null) => void;
   requestCapture?: DebugRequestCaptureState;
@@ -108,6 +109,7 @@ export const Sidebar = memo(function Sidebar({
   onRefreshCommands,
   requestsState = EMPTY_REQUESTS_LIST,
   onRefreshRequests = () => {},
+  onShowMoreRequests = () => {},
   selectedRequestId = null,
   onSelectRequest = () => {},
   requestCapture = EMPTY_REQUEST_CAPTURE,
@@ -138,6 +140,8 @@ export const Sidebar = memo(function Sidebar({
     ? countRunningCommands(commandsState.commands)
     : 0;
   const debugRequests = requestsState.status === 'ready' ? requestsState.requests : [];
+  // Badge reports the session total, not the loaded window.
+  const debugRequestTotal = requestsState.status === 'ready' ? requestsState.total : 0;
   const debugRequestOrigins = useMemo(
     () => countRequestAgentOrigins(debugRequests),
     [debugRequests],
@@ -294,14 +298,15 @@ export const Sidebar = memo(function Sidebar({
           sectionId="inspector-requests"
           forceOpenToken={forcedSection === 'inspector-requests' ? forceOpenEpoch : 0}
           badge={
-            debugRequests.length > 0
-              ? <RequestsBadge count={debugRequests.length} origins={debugRequestOrigins} />
+            debugRequestTotal > 0
+              ? <RequestsBadge count={debugRequestTotal} origins={debugRequestOrigins} />
               : null
           }
         >
           <RequestsSection
             state={requestsState}
             onRefresh={onRefreshRequests}
+            onShowMore={onShowMoreRequests}
             selectedId={selectedRequestId}
             onSelect={onSelectRequest}
             capture={requestCapture}
@@ -1190,6 +1195,7 @@ function RequestsBadge({ count, origins }: { count: number; origins: number }) {
 interface RequestsSectionProps {
   state: DebugRequestsListState;
   onRefresh: () => void;
+  onShowMore: () => void;
   selectedId: string | null;
   onSelect: (attemptId: string | null) => void;
   capture: DebugRequestCaptureState;
@@ -1199,6 +1205,7 @@ interface RequestsSectionProps {
 function RequestsSection({
   state,
   onRefresh,
+  onShowMore,
   selectedId,
   onSelect,
   capture,
@@ -1231,13 +1238,9 @@ function RequestsSection({
     );
   }
 
-  // Newest attempt first; unparseable timestamps keep their arrival order.
-  const requests = [...state.requests].sort((a, b) => {
-    const left = Date.parse(a.startedAt);
-    const right = Date.parse(b.startedAt);
-    if (Number.isNaN(left) || Number.isNaN(right)) return 0;
-    return right - left;
-  });
+  // Rows arrive newest-first from the store's windowed query; no re-sort.
+  const requests = state.requests;
+  const hidden = Math.max(0, state.total - requests.length);
 
   return (
     <div className="inspector-stack">
@@ -1251,6 +1254,11 @@ function RequestsSection({
           onRetryCapture={onRetryCapture}
         />
       ))}
+      {hidden > 0 && (
+        <Button variant="ghost" size="xs" className="w-full" onClick={onShowMore}>
+          Show more ({hidden} older)
+        </Button>
+      )}
     </div>
   );
 }

--- a/electron/src/renderer/hooks/useDebugRequests.ts
+++ b/electron/src/renderer/hooks/useDebugRequests.ts
@@ -1,0 +1,218 @@
+/**
+ * useDebugRequests — per-session captured provider request debug list (issue 146).
+ *
+ * Provides:
+ * - Capture list from `debug:sessionRequests` (any agent origin: main,
+ *   subagent, compactor, title namer, permission evaluator)
+ * - Adaptive interval polling: fast while a chat turn is streaming (attempts
+ *   land continuously), slow when idle — pacing mirrors the subagents tick
+ * - Row selection with lazy full-capture loading via `debug:requestCapture`
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  DebugRequestCapture,
+  DebugRequestSummary,
+} from '../../shared/types/debug';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type DebugRequestsListState =
+  | { status: 'loading' }
+  | { status: 'empty' }
+  | { status: 'ready'; requests: readonly DebugRequestSummary[] }
+  | { status: 'error'; error: string };
+
+export type DebugRequestCaptureState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; capture: DebugRequestCapture }
+  | { status: 'unavailable' }
+  | { status: 'error'; error: string };
+
+export interface UseDebugRequestsReturn {
+  /** Capture list state with interaction states. */
+  state: DebugRequestsListState;
+  /** Flat capture list (empty unless the state is ready). */
+  requests: readonly DebugRequestSummary[];
+  /** Refresh the capture list for the active session. */
+  refresh: () => Promise<void>;
+  /** Currently selected attempt id (null when none). */
+  selectedId: string | null;
+  /** Toggle row selection; selecting the active id clears it. */
+  select: (attemptId: string | null) => void;
+  /** Full capture load state for the selected attempt. */
+  capture: DebugRequestCaptureState;
+  /** Retry the selected attempt's capture load. */
+  retryCapture: () => Promise<void>;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Attempts land continuously while a turn streams — match the subagents tick. */
+const POLL_INTERVAL_STREAMING_MS = 1_000;
+/** Idle sessions only accrue captures from background origins (titler, …). */
+const POLL_INTERVAL_IDLE_MS = 5_000;
+
+/** Distinct agent origins among captures ('main' when the scope is absent). */
+export function countRequestAgentOrigins(requests: readonly DebugRequestSummary[]): number {
+  const origins = new Set<string>();
+  for (const request of requests) {
+    origins.add(request.agentScope || request.agentName || 'main');
+  }
+  return origins.size;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Track the captured provider requests for one session and lazily load the
+ * full capture for the selected attempt.
+ *
+ * @param activeSessionId - Session whose captures should be listed.
+ * @param enabled - Whether list polling and capture loads are active.
+ * @param isStreaming - Whether a chat turn is live; paces the poll interval.
+ * @returns The capture list, selection, capture detail state, and refresh actions.
+ */
+export function useDebugRequests(
+  activeSessionId: string | null,
+  enabled = true,
+  isStreaming = false,
+): UseDebugRequestsReturn {
+  const [state, setState] = useState<DebugRequestsListState>({ status: 'loading' });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [capture, setCapture] = useState<DebugRequestCaptureState>({ status: 'idle' });
+  const sessionIdRef = useRef(activeSessionId);
+  sessionIdRef.current = activeSessionId;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const requestGenerationRef = useRef(0);
+  const captureGenerationRef = useRef(0);
+  // Prevent overlapping same-session polls (IPC > poll interval) from
+  // reordering lists. Session switches always proceed so they are never
+  // starved by a slow in-flight poll for the previous session.
+  const isPollingRef = useRef(false);
+  const pollingSessionRef = useRef<string | null>(null);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!enabled || !activeSessionId || !window.orchid?.debug?.sessionRequests) {
+      if (aliveRef.current) setState({ status: 'empty' });
+      return;
+    }
+    if (isPollingRef.current && pollingSessionRef.current === activeSessionId) return;
+    isPollingRef.current = true;
+    pollingSessionRef.current = activeSessionId;
+    const generation = ++requestGenerationRef.current;
+    const requestId = activeSessionId;
+    try {
+      const result = await window.orchid.debug.sessionRequests({ sessionId: requestId });
+      if (
+        !aliveRef.current
+        || !enabledRef.current
+        || requestGenerationRef.current !== generation
+        || sessionIdRef.current !== requestId
+      ) return;
+      setState(result.requests.length
+        ? { status: 'ready', requests: result.requests }
+        : { status: 'empty' });
+    } catch (err) {
+      if (
+        !aliveRef.current
+        || !enabledRef.current
+        || requestGenerationRef.current !== generation
+        || sessionIdRef.current !== requestId
+      ) return;
+      setState({ status: 'error', error: err instanceof Error ? err.message : String(err) });
+    } finally {
+      if (pollingSessionRef.current === requestId) {
+        pollingSessionRef.current = null;
+        isPollingRef.current = false;
+      }
+    }
+  }, [activeSessionId, enabled]);
+
+  // Initial load + session switch / re-enable: reset to loading, then fetch.
+  useEffect(() => {
+    if (!enabled || !activeSessionId) {
+      setState({ status: 'empty' });
+      return;
+    }
+    setState({ status: 'loading' });
+    void refresh();
+  }, [activeSessionId, enabled, refresh]);
+
+  // Selection is session-affine: switching sessions clears row + capture state.
+  useEffect(() => {
+    setSelectedId(null);
+  }, [activeSessionId]);
+
+  // Adaptive polling — immediate refresh on (re)arm so a turn that just ended
+  // lands its terminal captures without waiting out the idle interval.
+  useEffect(() => {
+    if (!enabled || !activeSessionId) return undefined;
+    void refresh();
+    const intervalMs = isStreaming ? POLL_INTERVAL_STREAMING_MS : POLL_INTERVAL_IDLE_MS;
+    const timer = setInterval(() => {
+      void refresh();
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [activeSessionId, enabled, isStreaming, refresh]);
+
+  const select = useCallback((attemptId: string | null) => {
+    setSelectedId((previous) => (previous === attemptId ? null : attemptId));
+  }, []);
+
+  const requests = state.status === 'ready' ? state.requests : [];
+  const selectedSummary = selectedId
+    ? requests.find((request) => request.attemptId === selectedId) ?? null
+    : null;
+
+  const loadCapture = useCallback(async (attemptId: string): Promise<void> => {
+    const generation = ++captureGenerationRef.current;
+    if (!window.orchid?.debug?.requestCapture) {
+      setCapture({ status: 'error', error: 'Request capture is unavailable' });
+      return;
+    }
+    setCapture({ status: 'loading' });
+    try {
+      const result = await window.orchid.debug.requestCapture({ attemptId });
+      if (generation !== captureGenerationRef.current) return;
+      setCapture(result.capture
+        ? { status: 'ready', capture: result.capture }
+        : { status: 'unavailable' });
+    } catch (err) {
+      if (generation !== captureGenerationRef.current) return;
+      setCapture({ status: 'error', error: err instanceof Error ? err.message : String(err) });
+    }
+  }, []);
+
+  // (Re)load the selected capture; a pending attempt reloads when its outcome
+  // or completion time changes so the response body appears once it settles.
+  useEffect(() => {
+    if (!selectedId || !selectedSummary) {
+      captureGenerationRef.current += 1;
+      setCapture({ status: 'idle' });
+      return;
+    }
+    void loadCapture(selectedId);
+  }, [
+    selectedId,
+    loadCapture,
+    selectedSummary?.outcome,
+    selectedSummary?.completedAt,
+  ]);
+
+  const retryCapture = useCallback(async () => {
+    if (!selectedId) return;
+    await loadCapture(selectedId);
+  }, [loadCapture, selectedId]);
+
+  return { state, requests, refresh, selectedId, select, capture, retryCapture };
+}

--- a/electron/src/renderer/hooks/useDebugRequests.ts
+++ b/electron/src/renderer/hooks/useDebugRequests.ts
@@ -19,7 +19,7 @@ import type {
 export type DebugRequestsListState =
   | { status: 'loading' }
   | { status: 'empty' }
-  | { status: 'ready'; requests: readonly DebugRequestSummary[] }
+  | { status: 'ready'; requests: readonly DebugRequestSummary[]; total: number }
   | { status: 'error'; error: string };
 
 export type DebugRequestCaptureState =
@@ -36,6 +36,8 @@ export interface UseDebugRequestsReturn {
   requests: readonly DebugRequestSummary[];
   /** Refresh the capture list for the active session. */
   refresh: () => Promise<void>;
+  /** Grow the window and re-fetch (Show more). */
+  showMore: () => Promise<void>;
   /** Currently selected attempt id (null when none). */
   selectedId: string | null;
   /** Toggle row selection; selecting the active id clears it. */
@@ -52,6 +54,10 @@ export interface UseDebugRequestsReturn {
 const POLL_INTERVAL_STREAMING_MS = 1_000;
 /** Idle sessions only accrue captures from background origins (titler, …). */
 const POLL_INTERVAL_IDLE_MS = 5_000;
+/** Initial list window — matches the main-process default. */
+const LIST_WINDOW_INITIAL = 200;
+/** Each Show more grows the window by this many rows. */
+const LIST_WINDOW_STEP = 200;
 
 /** Distinct agent origins among captures ('main' when the scope is absent). */
 export function countRequestAgentOrigins(requests: readonly DebugRequestSummary[]): number {
@@ -85,6 +91,8 @@ export function useDebugRequests(
   sessionIdRef.current = activeSessionId;
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
+  // Window size survives polls and refreshes; resets on session switch.
+  const windowRef = useRef(LIST_WINDOW_INITIAL);
   const requestGenerationRef = useRef(0);
   const captureGenerationRef = useRef(0);
   // Prevent overlapping same-session polls (IPC > poll interval) from
@@ -112,7 +120,10 @@ export function useDebugRequests(
     const generation = ++requestGenerationRef.current;
     const requestId = activeSessionId;
     try {
-      const result = await window.orchid.debug.sessionRequests({ sessionId: requestId });
+      const result = await window.orchid.debug.sessionRequests({
+        sessionId: requestId,
+        limit: windowRef.current,
+      });
       if (
         !aliveRef.current
         || !enabledRef.current
@@ -120,7 +131,7 @@ export function useDebugRequests(
         || sessionIdRef.current !== requestId
       ) return;
       setState(result.requests.length
-        ? { status: 'ready', requests: result.requests }
+        ? { status: 'ready', requests: result.requests, total: result.total }
         : { status: 'empty' });
     } catch (err) {
       if (
@@ -144,6 +155,7 @@ export function useDebugRequests(
       setState({ status: 'empty' });
       return;
     }
+    windowRef.current = LIST_WINDOW_INITIAL;
     setState({ status: 'loading' });
     void refresh();
   }, [activeSessionId, enabled, refresh]);
@@ -168,6 +180,11 @@ export function useDebugRequests(
   const select = useCallback((attemptId: string | null) => {
     setSelectedId((previous) => (previous === attemptId ? null : attemptId));
   }, []);
+
+  const showMore = useCallback(async () => {
+    windowRef.current += LIST_WINDOW_STEP;
+    await refresh();
+  }, [refresh]);
 
   const requests = state.status === 'ready' ? state.requests : [];
   const selectedSummary = selectedId
@@ -214,5 +231,5 @@ export function useDebugRequests(
     await loadCapture(selectedId);
   }, [loadCapture, selectedId]);
 
-  return { state, requests, refresh, selectedId, select, capture, retryCapture };
+  return { state, requests, refresh, showMore, selectedId, select, capture, retryCapture };
 }

--- a/electron/src/renderer/utils/navigate-shell.ts
+++ b/electron/src/renderer/utils/navigate-shell.ts
@@ -26,6 +26,7 @@ export const NAV_SECTION_MAP: Readonly<Record<string, string>> = {
   'index-status': 'inspector-index',
   context: 'inspector-context',
   usage: 'inspector-usage',
+  requests: 'inspector-requests',
 };
 
 export function resolveInspectorSectionId(focusSection: string): string {

--- a/electron/src/shared/types/debug.ts
+++ b/electron/src/shared/types/debug.ts
@@ -7,6 +7,7 @@
  * `debug_capture_requests` config gate is enabled; the attempt ledger rows
  * themselves are always written.
  */
+import { z } from 'zod';
 
 /** One captured request row in the session debug list. */
 export interface DebugRequestSummary {
@@ -63,3 +64,52 @@ export interface DebugRequestCapture {
 export interface DebugRequestCaptureResult {
   readonly capture: DebugRequestCapture | null;
 }
+
+// ── Preload boundary validation ───────────────────────────────────────────────
+
+/**
+ * Invoke-result schemas for the debug IPC channels. The request/response/
+ * rawChunks payloads are intentionally opaque (`z.unknown()`): captures exist
+ * to preserve exact provider payloads, so only the envelope is validated.
+ */
+export const debugRequestSummarySchema = z.object({
+  attemptId: z.string(),
+  sessionId: z.string(),
+  chainId: z.string().nullable(),
+  turnId: z.string().nullable(),
+  providerId: z.string(),
+  connectionName: z.string(),
+  modelId: z.string(),
+  protocol: z.string(),
+  agentScope: z.string().nullable(),
+  agentName: z.string().nullable(),
+  agentType: z.string().nullable(),
+  agentTier: z.string().nullable(),
+  outcome: z.enum(['pending', 'succeeded', 'failed', 'interrupted']),
+  startedAt: z.string(),
+  completedAt: z.string().nullable(),
+  firstTokenAt: z.string().nullable(),
+  inputTokens: z.number().nullable(),
+  outputTokens: z.number().nullable(),
+  requestBytes: z.number().nullable(),
+  responseBytes: z.number().nullable(),
+  truncated: z.boolean(),
+  rawAvailable: z.boolean(),
+  error: z.string().nullable(),
+});
+
+export const debugSessionRequestsResultSchema = z.object({
+  requests: z.array(debugRequestSummarySchema),
+});
+
+export const debugRequestCaptureSchema = z.object({
+  attemptId: z.string(),
+  summary: debugRequestSummarySchema,
+  request: z.unknown(),
+  response: z.unknown(),
+  rawChunks: z.array(z.unknown()),
+});
+
+export const debugRequestCaptureResultSchema = z.object({
+  capture: debugRequestCaptureSchema.nullable(),
+});

--- a/electron/src/shared/types/debug.ts
+++ b/electron/src/shared/types/debug.ts
@@ -39,7 +39,10 @@ export interface DebugRequestSummary {
 }
 
 export interface DebugSessionRequestsResult {
+  /** Newest-first summaries within the requested window. */
   readonly requests: readonly DebugRequestSummary[];
+  /** Unwindowed capture count for the session ("N of M" in the UI). */
+  readonly total: number;
 }
 
 /**

--- a/electron/src/shared/types/debug.ts
+++ b/electron/src/shared/types/debug.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-session request debug view types (issue 146).
+ *
+ * A capture is the raw, exact provider request and response for one durable
+ * provider attempt — from any agent origin (main, subagent, compactor, title,
+ * permission evaluator, web-fetch summarizer). Captures exist only when the
+ * `debug_capture_requests` config gate is enabled; the attempt ledger rows
+ * themselves are always written.
+ */
+
+/** One captured request row in the session debug list. */
+export interface DebugRequestSummary {
+  readonly attemptId: string;
+  readonly sessionId: string;
+  readonly chainId: string | null;
+  readonly turnId: string | null;
+  readonly providerId: string;
+  readonly connectionName: string;
+  readonly modelId: string;
+  readonly protocol: string;
+  readonly agentScope: string | null;
+  readonly agentName: string | null;
+  readonly agentType: string | null;
+  readonly agentTier: string | null;
+  readonly outcome: 'pending' | 'succeeded' | 'failed' | 'interrupted';
+  readonly startedAt: string;
+  readonly completedAt: string | null;
+  readonly firstTokenAt: string | null;
+  readonly inputTokens: number | null;
+  readonly outputTokens: number | null;
+  readonly requestBytes: number | null;
+  readonly responseBytes: number | null;
+  /** A capture field exceeded the per-field byte cap and was stored truncated. */
+  readonly truncated: boolean;
+  /** At least one raw provider chunk was captured (includeRawChunks honored). */
+  readonly rawAvailable: boolean;
+  readonly error: string | null;
+}
+
+export interface DebugSessionRequestsResult {
+  readonly requests: readonly DebugRequestSummary[];
+}
+
+/**
+ * Full capture for one attempt: the provider-neutral request that was
+ * serialized to the API and the response parts in arrival order.
+ */
+export interface DebugRequestCapture {
+  readonly attemptId: string;
+  readonly summary: DebugRequestSummary;
+  /** Serialized `LanguageModelV4CallOptions` (abort signal and like excluded). */
+  readonly request: unknown;
+  /**
+   * Stream attempts: `{ http, parts }` — response metadata plus normalized
+   * stream parts in arrival order. Generate attempts: the full generate
+   * result including request/response HTTP bodies.
+   */
+  readonly response: unknown;
+  /** Deserialized raw provider chunks, when the driver emitted them. */
+  readonly rawChunks: readonly unknown[];
+}
+
+export interface DebugRequestCaptureResult {
+  readonly capture: DebugRequestCapture | null;
+}

--- a/electron/src/shared/types/ipc-boundary.ts
+++ b/electron/src/shared/types/ipc-boundary.ts
@@ -231,6 +231,8 @@ export interface Config {
   mcp_servers: Record<string, Record<string, unknown>>;
   llm_stream_idle_timeout: number;
   llm_stream_retries: number;
+  /** Raw provider request/response debug capture gate (issue 146). */
+  debug_capture_requests: boolean;
   background_command_idle_timeout: number;
   /**
    * Max seconds after a turn starts before a still-default-named session is

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -510,6 +510,8 @@ export type ConfigPatch = {
   mcp_servers?: ConfigPatchMap<Record<string, unknown>>;
   llm_stream_idle_timeout?: number;
   llm_stream_retries?: number;
+  /** Raw provider request/response debug capture gate (issue 146). */
+  debug_capture_requests?: boolean;
   background_command_idle_timeout?: number;
   session_title_max_wait_seconds?: number;
   max_tool_steps?: number;
@@ -1614,6 +1616,13 @@ export interface OrchidAPI {
      contextSessionDetail: (params: { readonly sessionId: string; readonly timeRange?: import('./analytics').AnalyticsTimeRange }) => Promise<import('./analytics').ContextSessionDetailResult>;
       contextSessions: (params?: { readonly timeRange?: import('./analytics').AnalyticsTimeRange }) => Promise<import('./analytics').ContextSessionsResult>;
    };
+
+  debug: {
+    /** List captured provider requests for one session (any agent origin). */
+    sessionRequests: (params: { readonly sessionId: string }) => Promise<import('./debug').DebugSessionRequestsResult>;
+    /** Full raw request response capture for one provider attempt. */
+    requestCapture: (params: { readonly attemptId: string }) => Promise<import('./debug').DebugRequestCaptureResult>;
+  };
 }
 
 // ── IPC Channel names ────────────────────────────────────────────────────────
@@ -1806,6 +1815,10 @@ export const IPC_CHANNELS = {
   ANALYTICS_CONTEXT: 'analytics:context',
   ANALYTICS_CONTEXT_SESSION_DETAIL: 'analytics:context_session_detail',
   ANALYTICS_CONTEXT_SESSIONS: 'analytics:context_sessions',
+
+  // Debug — per-session raw request/response captures (issue 146)
+  DEBUG_SESSION_REQUESTS: 'debug:session_requests',
+  DEBUG_REQUEST_CAPTURE: 'debug:request_capture',
 } as const;
 
 export type IPCChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
@@ -1912,6 +1925,8 @@ export const ALLOWED_INVOKE_CHANNELS = [
   IPC_CHANNELS.ANALYTICS_CONTEXT,
   IPC_CHANNELS.ANALYTICS_CONTEXT_SESSION_DETAIL,
   IPC_CHANNELS.ANALYTICS_CONTEXT_SESSIONS,
+  IPC_CHANNELS.DEBUG_SESSION_REQUESTS,
+  IPC_CHANNELS.DEBUG_REQUEST_CAPTURE,
 ] as const satisfies readonly IPCChannel[];
 
 // ── Allowed event channels (preload security gate) ───────────────────────────

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -1619,7 +1619,7 @@ export interface OrchidAPI {
 
   debug: {
     /** List captured provider requests for one session (any agent origin). */
-    sessionRequests: (params: { readonly sessionId: string }) => Promise<import('./debug').DebugSessionRequestsResult>;
+    sessionRequests: (params: { readonly sessionId: string; readonly limit?: number }) => Promise<import('./debug').DebugSessionRequestsResult>;
     /** Full raw request response capture for one provider attempt. */
     requestCapture: (params: { readonly attemptId: string }) => Promise<import('./debug').DebugRequestCaptureResult>;
   };

--- a/electron/tests/integration/provider-attempt-capture.test.ts
+++ b/electron/tests/integration/provider-attempt-capture.test.ts
@@ -124,7 +124,7 @@ describe('provider attempt debug capture (issue 146)', () => {
     const attempts = h.ledger.listAttempts('session-off');
     expect(attempts).toHaveLength(1);
     expect(attempts[0].outcome).toBe('succeeded');
-    expect(h.capture.listForSession('session-off')).toEqual([]);
+    expect(h.capture.listForSession('session-off')).toEqual({ requests: [], total: 0 });
   });
 
   it('captures the request and the normalized stream parts in arrival order', async () => {
@@ -144,7 +144,7 @@ describe('provider attempt debug capture (issue 146)', () => {
     });
     await consume(result.stream);
 
-    const summaries = h.capture.listForSession('session-stream');
+    const summaries = h.capture.listForSession('session-stream').requests;
     expect(summaries).toHaveLength(1);
     expect(summaries[0]).toMatchObject({
       sessionId: 'session-stream', chainId: 'chain-1', turnId: 'turn-1',
@@ -199,7 +199,7 @@ describe('provider attempt debug capture (issue 146)', () => {
     });
     await consume(result.stream);
 
-    const [summary] = h.capture.listForSession('session-raw');
+    const [summary] = h.capture.listForSession('session-raw').requests;
     expect(summary.rawAvailable).toBe(true);
     const captured = h.capture.getCapture(summary.attemptId)!;
     // Raw parts never appear in the normalized response array…
@@ -237,7 +237,7 @@ describe('provider attempt debug capture (issue 146)', () => {
     await consume(result.stream);
 
     expect(h.ledger.listAttempts('session-err')[0].outcome).toBe('failed');
-    const [summary] = h.capture.listForSession('session-err');
+    const [summary] = h.capture.listForSession('session-err').requests;
     expect(summary.outcome).toBe('failed');
     expect(summary.responseBytes).not.toBeNull();
     const captured = h.capture.getCapture(summary.attemptId)!;
@@ -262,7 +262,7 @@ describe('provider attempt debug capture (issue 146)', () => {
       params, model: {},
     })).rejects.toThrow(/temporary network/i);
 
-    const summaries = h.capture.listForSession('session-throw');
+    const summaries = h.capture.listForSession('session-throw').requests;
     expect(summaries).toHaveLength(1);
     expect(summaries[0].outcome).toBe('failed');
     const captured = h.capture.getCapture(summaries[0].attemptId)!;
@@ -288,7 +288,7 @@ describe('provider attempt debug capture (issue 146)', () => {
       model: {},
     });
 
-    const summaries = h.capture.listForSession('session-generate');
+    const summaries = h.capture.listForSession('session-generate').requests;
     expect(summaries).toHaveLength(1);
     expect(summaries[0]).toMatchObject({ outcome: 'succeeded', rawAvailable: false });
     const captured = h.capture.getCapture(summaries[0].attemptId)!;
@@ -323,7 +323,7 @@ describe('provider attempt debug capture (issue 146)', () => {
       model: {},
     });
 
-    const [summary] = h.capture.listForSession('session-set-cookie');
+    const [summary] = h.capture.listForSession('session-set-cookie').requests;
     const captured = h.capture.getCapture(summary.attemptId)!;
     // What getCapture returns is exactly what the Requests inspector renders —
     // the credential must never survive into the persisted/read-back capture.
@@ -351,7 +351,7 @@ describe('provider attempt debug capture (issue 146)', () => {
     });
     await consume(result.stream);
 
-    const [summary] = h.capture.listForSession('session-headers');
+    const [summary] = h.capture.listForSession('session-headers').requests;
     const captured = h.capture.getCapture(summary.attemptId)!;
     const callOptions = (captured.request as { callOptions: Record<string, unknown> }).callOptions;
     expect(callOptions.headers).toEqual({
@@ -393,7 +393,7 @@ describe('provider attempt debug capture (issue 146)', () => {
       request: { callOptions: { prompt: 'x'.repeat(DEBUG_CAPTURE_MAX_FIELD_BYTES + 1024) } },
     });
 
-    const [summary] = capture.listForSession('session-big');
+    const [summary] = capture.listForSession('session-big').requests;
     expect(summary.truncated).toBe(true);
     const captured = capture.getCapture('cap-big')!;
     expect(captured.request).toEqual({
@@ -442,5 +442,38 @@ describe('provider attempt debug capture (issue 146)', () => {
     expect(book.listAttempts('session-broken')[0]).toMatchObject({
       outcome: 'succeeded', usage: { inputTokens: 1000, outputTokens: 100 },
     });
+  });
+
+  it('windows the session list newest-first with a total count', () => {
+    const { ledger: book, capture } = setup();
+    const COUNT = 30;
+    // Distinct started_at stamps so the DESC ordering is deterministic.
+    for (let i = 0; i < COUNT; i++) {
+      const attemptId = `win-${String(i).padStart(2, '0')}`;
+      book.insertPending({
+        attemptId, sessionId: 'session-window', chainId: 'chain-1', turnId: 'turn-1',
+        sdkCallId: attemptId, snapshot: snapshot(),
+      });
+      capture.insertRequest({
+        attemptId, sessionId: 'session-window',
+        request: { callOptions: { prompt: [] } },
+      });
+    }
+
+    const full = capture.listForSession('session-window');
+    expect(full.total).toBe(COUNT);
+    expect(full.requests).toHaveLength(COUNT);
+
+    const window = capture.listForSession('session-window', 10);
+    expect(window.total).toBe(COUNT);
+    expect(window.requests).toHaveLength(10);
+    // Newest first: the window covers the most recent attempts, and the
+    // ordering matches the full list's head.
+    const firstIds = window.requests.map((r) => r.attemptId);
+    expect(firstIds).toEqual(full.requests.slice(0, 10).map((r) => r.attemptId));
+    expect(firstIds[0]).toBe('win-29');
+
+    // The limit is clamped, never throws, and never returns zero rows.
+    expect(capture.listForSession('session-window', 0).requests).toHaveLength(1);
   });
 });

--- a/electron/tests/integration/provider-attempt-capture.test.ts
+++ b/electron/tests/integration/provider-attempt-capture.test.ts
@@ -305,6 +305,35 @@ describe('provider attempt debug capture (issue 146)', () => {
     expect(headers.authorization).toBe('[REDACTED]');
   });
 
+  it('redacts set-cookie response headers before persistence', async () => {
+    const h = harness({ sessionId: 'session-set-cookie', debugCapture: true });
+    await h.wrapGenerate({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'hi' }],
+        usage: { ...USAGE, raw: undefined },
+        response: {
+          headers: {
+            'Set-Cookie': 'session=secret-cookie-token; Path=/; HttpOnly',
+            'content-type': 'application/json',
+          },
+        },
+      }),
+      doStream: async () => { throw new Error('not used'); },
+      params: { prompt: [] },
+      model: {},
+    });
+
+    const [summary] = h.capture.listForSession('session-set-cookie');
+    const captured = h.capture.getCapture(summary.attemptId)!;
+    // What getCapture returns is exactly what the Requests inspector renders —
+    // the credential must never survive into the persisted/read-back capture.
+    const headers = ((captured.response as { response: { headers: Record<string, string> } })
+      .response).headers;
+    expect(headers['Set-Cookie']).toBe('[REDACTED]');
+    expect(headers['content-type']).toBe('application/json');
+    expect(JSON.stringify(captured)).not.toContain('secret-cookie-token');
+  });
+
   it('redacts credential headers from the captured call options', async () => {
     const h = harness({ sessionId: 'session-headers', debugCapture: true });
     const result = await h.wrapStream({

--- a/electron/tests/integration/provider-attempt-capture.test.ts
+++ b/electron/tests/integration/provider-attempt-capture.test.ts
@@ -1,0 +1,417 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { FrozenProviderRequestSnapshot } from '../../src/shared/types/accounting';
+import { createAttemptAccountingMiddleware } from '../../src/main/providers/accounting/middleware';
+import {
+  DEBUG_CAPTURE_MAX_FIELD_BYTES,
+  initializeProviderAttemptCaptureStore,
+  ProviderAttemptCaptureStore,
+  resetProviderAttemptCaptureStore,
+} from '../../src/main/providers/accounting/capture-store';
+import { ProviderAccountingStore } from '../../src/main/providers/accounting/store';
+
+let tempDir: string | undefined;
+let ledger: ProviderAccountingStore | undefined;
+
+afterEach(() => {
+  resetProviderAttemptCaptureStore();
+  ledger?.close();
+  ledger = undefined;
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+function snapshot(): FrozenProviderRequestSnapshot {
+  return {
+    providerId: 'anthropic', providerDisplayName: 'Anthropic',
+    connectionId: '11111111-1111-4111-8111-111111111111', connectionName: 'Work',
+    modelId: 'claude-test', protocol: 'anthropic-messages', modelSource: 'catalog',
+    catalogVersion: 1, catalogSource: 'bundled', catalogObservedAt: '2026-07-12T00:00:00.000Z',
+    fieldProvenance: {}, statusObservation: null,
+    pricing: {
+      currency: 'USD', effectiveAt: '2026-07-12T00:00:00.000Z',
+      rates: {
+        input: { amount: '5', per: 1_000_000, unit: 'tokens' },
+        output: { amount: '25', per: 1_000_000, unit: 'tokens' },
+      },
+      inclusion: { cacheRead: 'subset-of-input', cacheWrite: 'unknown', reasoning: 'unknown' },
+      provenance: {},
+    },
+  };
+}
+
+/**
+ * The middleware reaches the capture store through its runtime singleton
+ * (getProviderAttemptCaptureStore), so the tests point that singleton at the
+ * same accounting.db file as the ledger — listForSession/getCapture join
+ * provider_attempt_captures against provider_attempts.
+ */
+function setup(): { ledger: ProviderAccountingStore; capture: ProviderAttemptCaptureStore } {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-attempt-capture-'));
+  const dbPath = path.join(tempDir, 'accounting.db');
+  ledger = new ProviderAccountingStore({ dbPath });
+  return { ledger, capture: initializeProviderAttemptCaptureStore({ dbPath }) };
+}
+
+interface Harness {
+  readonly ledger: ProviderAccountingStore;
+  readonly capture: ProviderAttemptCaptureStore;
+  readonly wrapStream: (input: Record<string, unknown>) => Promise<{ stream: ReadableStream<unknown> }>;
+  readonly wrapGenerate: (input: Record<string, unknown>) => Promise<Record<string, unknown>>;
+}
+
+function harness(context: { sessionId: string; debugCapture?: boolean }): Harness {
+  const { ledger: book, capture } = setup();
+  const middleware = createAttemptAccountingMiddleware({
+    store: book, sessionId: context.sessionId, chainId: 'chain-1', turnId: 'turn-1',
+    snapshot: snapshot(), agentScope: 'subagent', agentName: 'explorer',
+    debugCapture: context.debugCapture,
+  });
+  return {
+    ledger: book,
+    capture,
+    wrapStream: middleware.wrapStream! as unknown as (
+      input: Record<string, unknown>,
+    ) => Promise<{ stream: ReadableStream<unknown> }>,
+    wrapGenerate: middleware.wrapGenerate! as unknown as (
+      input: Record<string, unknown>,
+    ) => Promise<Record<string, unknown>>,
+  };
+}
+
+const USAGE = {
+  inputTokens: { total: 1000, noCache: 1000, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 100, text: 100, reasoning: undefined },
+};
+
+/** Captured part types in arrival order, including the terminal part. */
+const partTypes = (captured: unknown): string[] =>
+  (captured as Array<{ type: string }>).map((part) => part.type);
+
+function streamOf(parts: unknown[]): ReadableStream<unknown> {
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
+async function consume(stream: ReadableStream<unknown>): Promise<void> {
+  const reader = stream.getReader();
+  while (!(await reader.read()).done) {
+    // drain
+  }
+  // The response capture is deferred off the settle path via queueMicrotask.
+  await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+}
+
+describe('provider attempt debug capture (issue 146)', () => {
+  it('writes the ledger row but no capture rows when the debug gate is off', async () => {
+    const h = harness({ sessionId: 'session-off' });
+    const result = await h.wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: streamOf([{ type: 'finish', finishReason: 'stop', usage: USAGE }]),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params: { prompt: [] }, model: {},
+    });
+    await consume(result.stream);
+
+    const attempts = h.ledger.listAttempts('session-off');
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0].outcome).toBe('succeeded');
+    expect(h.capture.listForSession('session-off')).toEqual([]);
+  });
+
+  it('captures the request and the normalized stream parts in arrival order', async () => {
+    const h = harness({ sessionId: 'session-stream', debugCapture: true });
+    const params = { prompt: [{ role: 'user', content: 'hello' }], temperature: 0.2 };
+    const result = await h.wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: streamOf([
+          { type: 'stream-start', warnings: [] },
+          { type: 'text-delta', id: '0', delta: 'hello' },
+          { type: 'finish', finishReason: 'stop', usage: USAGE },
+        ]),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params, model: {},
+    });
+    await consume(result.stream);
+
+    const summaries = h.capture.listForSession('session-stream');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      sessionId: 'session-stream', chainId: 'chain-1', turnId: 'turn-1',
+      providerId: 'anthropic', connectionName: 'Work', modelId: 'claude-test',
+      protocol: 'anthropic-messages', outcome: 'succeeded',
+      agentScope: 'subagent', agentName: 'explorer',
+      inputTokens: 1000, outputTokens: 100,
+      truncated: false, rawAvailable: false,
+    });
+
+    const captured = h.capture.getCapture(summaries[0].attemptId);
+    expect(captured).not.toBeNull();
+    expect(captured!.request).toEqual({
+      callOptions: params,
+      identity: {
+        providerId: 'anthropic',
+        connectionId: '11111111-1111-4111-8111-111111111111',
+        modelId: 'claude-test',
+        protocol: 'anthropic-messages',
+      },
+    });
+    // Arrival order, including the terminal finish part (usage/finishReason),
+    // alongside the stream's HTTP response metadata.
+    expect(captured!.response).toEqual({
+      http: { headers: {} },
+      parts: [
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-delta', id: '0', delta: 'hello' },
+        { type: 'finish', finishReason: 'stop', usage: USAGE },
+      ],
+    });
+    expect(partTypes((captured!.response as { parts: unknown[] }).parts))
+      .toEqual(['stream-start', 'text-delta', 'finish']);
+    expect(captured!.rawChunks).toEqual([]);
+  });
+
+  it('collects raw provider chunks separately from the normalized parts', async () => {
+    const h = harness({ sessionId: 'session-raw', debugCapture: true });
+    const result = await h.wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: streamOf([
+          { type: 'stream-start', warnings: [] },
+          { type: 'raw', rawValue: { chunk: 'a' } },
+          { type: 'text-delta', id: '0', delta: 'hi' },
+          { type: 'raw', rawValue: { chunk: 'b' } },
+          { type: 'finish', finishReason: 'stop', usage: USAGE },
+        ]),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params: {}, model: {},
+    });
+    await consume(result.stream);
+
+    const [summary] = h.capture.listForSession('session-raw');
+    expect(summary.rawAvailable).toBe(true);
+    const captured = h.capture.getCapture(summary.attemptId)!;
+    // Raw parts never appear in the normalized response array…
+    expect(captured.response).toEqual({
+      http: { headers: {} },
+      parts: [
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-delta', id: '0', delta: 'hi' },
+        { type: 'finish', finishReason: 'stop', usage: USAGE },
+      ],
+    });
+    expect(partTypes((captured.response as { parts: unknown[] }).parts))
+      .toEqual(['stream-start', 'text-delta', 'finish']);
+    // …they land in rawChunks, in arrival order.
+    expect(captured.rawChunks).toEqual([{ chunk: 'a' }, { chunk: 'b' }]);
+  });
+
+  it('captures the partial response when the stream errors mid-way', async () => {
+    const h = harness({ sessionId: 'session-err', debugCapture: true });
+    const result = await h.wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({ type: 'text-delta', id: '0', delta: 'partial' });
+            controller.enqueue({ type: 'error', error: new Error('boom') });
+            controller.close();
+          },
+        }),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params: {}, model: {},
+    });
+    await consume(result.stream);
+
+    expect(h.ledger.listAttempts('session-err')[0].outcome).toBe('failed');
+    const [summary] = h.capture.listForSession('session-err');
+    expect(summary.outcome).toBe('failed');
+    expect(summary.responseBytes).not.toBeNull();
+    const captured = h.capture.getCapture(summary.attemptId)!;
+    // Parts up to and including the error part — the exact provider failure
+    // is part of the debug record.
+    expect(captured.response).toEqual({
+      http: { headers: {} },
+      parts: [
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-delta', id: '0', delta: 'partial' },
+        { type: 'error', error: { name: 'Error', message: 'boom', stack: expect.any(String) } },
+      ],
+    });
+  });
+
+  it('leaves the response half empty when doStream throws before any part', async () => {
+    const h = harness({ sessionId: 'session-throw', debugCapture: true });
+    const params = { prompt: [{ role: 'user', content: 'hello' }] };
+    await expect(h.wrapStream({
+      doStream: async () => { throw new Error('temporary network failure'); },
+      doGenerate: async () => { throw new Error('not used'); },
+      params, model: {},
+    })).rejects.toThrow(/temporary network/i);
+
+    const summaries = h.capture.listForSession('session-throw');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].outcome).toBe('failed');
+    const captured = h.capture.getCapture(summaries[0].attemptId)!;
+    expect(captured.request).toMatchObject({ callOptions: params });
+    expect(captured.response).toBeNull();
+    expect(captured.rawChunks).toEqual([]);
+  });
+
+  it('captures generate-path request/response bodies with credential headers redacted', async () => {
+    const h = harness({ sessionId: 'session-generate', debugCapture: true });
+    await h.wrapGenerate({
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'hi there' }],
+        usage: { ...USAGE, raw: undefined },
+        request: { body: { model: 'claude-test', messages: [{ role: 'user', content: 'hello' }] } },
+        response: {
+          headers: { authorization: 'Bearer sk-secret-123', 'content-type': 'application/json' },
+          body: { id: 'msg_1', role: 'assistant' },
+        },
+      }),
+      doStream: async () => { throw new Error('not used'); },
+      params: { prompt: [{ role: 'user', content: 'hello' }] },
+      model: {},
+    });
+
+    const summaries = h.capture.listForSession('session-generate');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({ outcome: 'succeeded', rawAvailable: false });
+    const captured = h.capture.getCapture(summaries[0].attemptId)!;
+    expect(captured.response).toMatchObject({
+      content: [{ type: 'text', text: 'hi there' }],
+      request: { body: { model: 'claude-test', messages: [{ role: 'user', content: 'hello' }] } },
+      response: {
+        headers: { authorization: '[REDACTED]', 'content-type': 'application/json' },
+        body: { id: 'msg_1', role: 'assistant' },
+      },
+    });
+    const headers = (captured.response as { response: { headers: Record<string, string> } })
+      .response.headers;
+    expect(headers.authorization).toBe('[REDACTED]');
+  });
+
+  it('redacts credential headers from the captured call options', async () => {
+    const h = harness({ sessionId: 'session-headers', debugCapture: true });
+    const result = await h.wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: streamOf([{ type: 'finish', finishReason: 'stop', usage: USAGE }]),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params: {
+        prompt: [{ role: 'user', content: 'hello' }],
+        headers: { authorization: 'Bearer x', 'x-api-key': 'k', 'content-type': 'application/json' },
+        abortSignal: new AbortController().signal,
+      },
+      model: {},
+    });
+    await consume(result.stream);
+
+    const [summary] = h.capture.listForSession('session-headers');
+    const captured = h.capture.getCapture(summary.attemptId)!;
+    const callOptions = (captured.request as { callOptions: Record<string, unknown> }).callOptions;
+    expect(callOptions.headers).toEqual({
+      authorization: '[REDACTED]',
+      'x-api-key': '[REDACTED]',
+      'content-type': 'application/json',
+    });
+    // Abort signals are runtime handles — never persisted.
+    expect(callOptions).not.toHaveProperty('abortSignal');
+  });
+
+  it('keeps the first finalized response when finalizeResponse runs twice', () => {
+    const { ledger: book, capture } = setup();
+    book.insertPending({
+      attemptId: 'cap-1', sessionId: 'session-idem', chainId: 'chain-1', turnId: 'turn-1',
+      sdkCallId: 'cap-1', snapshot: snapshot(),
+    });
+    capture.insertRequest({
+      attemptId: 'cap-1', sessionId: 'session-idem', request: { callOptions: { prompt: [] } },
+    });
+    capture.finalizeResponse('cap-1', { response: { first: true }, rawChunks: [] });
+    // A replayed settle callback must not overwrite the first response.
+    capture.finalizeResponse('cap-1', { response: { second: true }, rawChunks: [{ chunk: 'late' }] });
+
+    const captured = capture.getCapture('cap-1')!;
+    expect(captured.response).toEqual({ first: true });
+    expect(captured.rawChunks).toEqual([]);
+    expect(captured.summary.rawAvailable).toBe(false);
+  });
+
+  it('replaces over-cap fields with a truncation marker', () => {
+    const { ledger: book, capture } = setup();
+    book.insertPending({
+      attemptId: 'cap-big', sessionId: 'session-big', chainId: 'chain-1', turnId: 'turn-1',
+      sdkCallId: 'cap-big', snapshot: snapshot(),
+    });
+    capture.insertRequest({
+      attemptId: 'cap-big', sessionId: 'session-big',
+      request: { callOptions: { prompt: 'x'.repeat(DEBUG_CAPTURE_MAX_FIELD_BYTES + 1024) } },
+    });
+
+    const [summary] = capture.listForSession('session-big');
+    expect(summary.truncated).toBe(true);
+    const captured = capture.getCapture('cap-big')!;
+    expect(captured.request).toEqual({
+      __truncated: true,
+      originalBytes: expect.any(Number),
+      capBytes: DEBUG_CAPTURE_MAX_FIELD_BYTES,
+    });
+    const marker = captured.request as { originalBytes: number };
+    expect(marker.originalBytes).toBeGreaterThan(DEBUG_CAPTURE_MAX_FIELD_BYTES);
+  });
+
+  it('never breaks the provider stream when the capture store is unavailable', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-attempt-capture-'));
+    // A regular file where the capture DB's parent directory should be: every
+    // capture write throws, exercising the middleware's best-effort try/catch.
+    const blocker = path.join(tempDir, 'blocker');
+    fs.writeFileSync(blocker, 'not a directory');
+    const book = new ProviderAccountingStore({ dbPath: path.join(tempDir, 'accounting.db') });
+    ledger = book;
+    initializeProviderAttemptCaptureStore({ dbPath: path.join(blocker, 'accounting.db') });
+    const middleware = createAttemptAccountingMiddleware({
+      store: book, sessionId: 'session-broken', chainId: 'chain-1', turnId: 'turn-1',
+      snapshot: snapshot(), debugCapture: true,
+    });
+    const wrapStream = middleware.wrapStream! as unknown as (
+      input: Record<string, unknown>,
+    ) => Promise<{ stream: ReadableStream<unknown> }>;
+    const result = await wrapStream({
+      doStream: async () => ({
+        response: { headers: {} },
+        stream: streamOf([
+          { type: 'text-delta', id: '0', delta: 'still streaming' },
+          { type: 'finish', finishReason: 'stop', usage: USAGE },
+        ]),
+      }),
+      doGenerate: async () => { throw new Error('not used'); },
+      params: { prompt: [] }, model: {},
+    });
+    const parts: unknown[] = [];
+    const reader = result.stream.getReader();
+    for (let read = await reader.read(); !read.done; read = await reader.read()) {
+      parts.push(read.value);
+    }
+    expect(parts).toHaveLength(2);
+
+    expect(book.listAttempts('session-broken')[0]).toMatchObject({
+      outcome: 'succeeded', usage: { inputTokens: 1000, outputTokens: 100 },
+    });
+  });
+});

--- a/electron/tests/parity/config.test.ts
+++ b/electron/tests/parity/config.test.ts
@@ -416,11 +416,11 @@ describe('Config Parity', () => {
       expect(cfg.subagents).toHaveProperty('prompt_task_max_chars');
     });
 
-    it('top-level field count matches expected (48 top-level + 12 rag + 7 agents_md + 11 subagents nested fields)', () => {
+    it('top-level field count matches expected (49 top-level + 12 rag + 7 agents_md + 11 subagents nested fields)', () => {
       const cfg = defaults();
       // Top-level keys count
       const topLevelKeys = Object.keys(cfg);
-      expect(topLevelKeys).toHaveLength(48); // 48 top-level fields (rag, agents_md, subagents, compaction are nested)
+      expect(topLevelKeys).toHaveLength(49); // 49 top-level fields (rag, agents_md, subagents, compaction are nested)
 
       // RAG nested keys count
       const ragKeys = Object.keys(cfg.rag);


### PR DESCRIPTION
## Summary

Every LLM request in a session — from any agent origin — can now be inspected after the fact with the exact request sent and the exact response received. Previously, diagnosing a misbehaving compactor or evaluator meant cross-referencing `accounting.db` ledger rows against `sessions.db` with no visibility into what was actually on the wire (the exact blind spot documented in the stacked-summary-heads learning).

A new **Requests** inspector section lists every captured request for the active session with agent origin, model, outcome, tokens, and timing. Selecting a row opens a Request / Response / Raw-chunks JSON viewer with copy buttons. Capture is **off by default** and gated by `debug_capture_requests` (Settings → General → Streaming, or per-project in the Project Config editor where it rides the trust surface).

| Origin | Captured | Notes |
|---|---|---|
| Main agent turns | ✓ | all steps + retries, raw provider chunks |
| Subagent runs | ✓ | attributed to scope + agent |
| Compactors (simple + selective) | ✓ | every correction attempt |
| Session title namer | ✓ | |
| Permission evaluator (`decide-for-me`) | ✓ | **now also visible in analytics** — previously wrote no ledger rows at all |
| Web-fetch summarizer | ✓ | same analytics fix |

## Design decisions

- **Tap, don't scatter.** The capture lives in the attempt-accounting middleware — the single choke point every provider call already flows through — rather than at each call site. One gate, one redaction pass, one failure boundary.
- **Never break the stream.** All capture writes are best-effort; the response half is deferred off the settle path via `queueMicrotask` (mirroring the TTFT write). A test drives the capture store into a hard failure and asserts the stream completes normally.
- **Redaction is capture-specific.** The ledger sanitizer would destroy the payload (it redacts `body`-shaped keys); captures strip only credential headers (`authorization`, `api-key`, `x-api-key`, `x-goog-api-key`, cookie, `proxy-authorization`) and runtime handles. Prompts keep full fidelity — that's the point.
- **Bounded by design.** 4 MiB cap per serialized field with `{__truncated, originalBytes}` markers; the gate defaults off because every step resends the full conversation.
- **Raw ≠ byte stream.** `include.rawChunks` yields deserialized SSE events (every field the API sent, including ones the SDK discards); the generate path captures the true HTTP `request.body`/`response.body` from result telemetry.

## Data & analytics

Storage is `~/.orchid/accounting.db` (schema v7: `provider_attempt_captures` table, joined to `provider_attempts` by id — summary queries borrow ledger metadata instead of duplicating it). Migration is plain `CREATE TABLE IF NOT EXISTS`.

Heads-up: session token/cost totals now include evaluator and web-fetch summarizer attempts. This is deliberate attribution parity — those calls were always real spend — but existing sessions' analytics numbers will shift slightly.

## Test plan

- `tests/integration/provider-attempt-capture.test.ts` (10 tests): gate-off, stream shape, raw-chunk separation, mid-stream failure, immediate-throw, generate bodies, redaction both sides, finalize idempotence, truncation, store-outage isolation
- Full suite 4639/4639, lint + both typechecks clean

Closes #146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to capture provider requests and responses for debugging.
  * Added a Requests inspector showing request details, outcomes, token usage, and captured payloads.
  * Added command-palette navigation to the Requests inspector.
  * Captures redact credentials, support truncation indicators, and preserve partial results when errors occur.
* **Bug Fixes**
  * Provider operations continue normally when debug capture is unavailable or encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->