### PR TITLE
fix(ui): align thought elapsed counter placement with tool widgets

### DIFF
--- a/electron/src/renderer/components/MessageWidget.tsx
+++ b/electron/src/renderer/components/MessageWidget.tsx
@@ -165,13 +165,18 @@ function ThinkingMessage({
           ) : (
             <Icon name="alertCircle" size={12} />
           )}
-          {`${isStreaming ? 'Thinking…' : 'Thought'}${durationLabel ? ` ${durationLabel}` : ''}`}
+          {isStreaming ? 'Thinking…' : 'Thought'}
         </span>
-        <Icon
-          name="chevronDown"
-          size={12}
-          className={`orchid-disclosure-chevron ${expanded ? 'is-open' : ''}`}
-        />
+        <span className="inline-flex shrink-0 items-center gap-1.5">
+          {durationLabel ? (
+            <span className="orchid-tool-elapsed" aria-hidden="true">{durationLabel}</span>
+          ) : null}
+          <Icon
+            name="chevronDown"
+            size={12}
+            className={`orchid-disclosure-chevron ${expanded ? 'is-open' : ''}`}
+          />
+        </span>
       </button>
       <CollapsibleRegion open={expanded} id={panelId}>
         <div


### PR DESCRIPTION
## Summary

Thought headers rendered their duration inline on the left (`Thought 1.2s`) while tool blocks render elapsed on the right next to the status badge, so the two live timers sat at different alignments and read as inconsistent. The thought header now mirrors the tool-block layout: icon + label on the left, duration + chevron in a `shrink-0` right span. It reuses the tool blocks' `orchid-tool-elapsed` class, so both timers share the same mono/tabular-nums styling and `936ms` → `4.2s` → `1m 05s` scale, matching the original design mock (screen 005: `Thought` left, `936ms` right).

Stacked on #177 (base `fix/issue-139-140-elapsed-timers`) — merge that first.

Refs #139, #140.
