### PR TITLE
fix(context): correct live token attribution in context panel (#187)

### DIFF
--- a/electron/src/main/llm/stream/sdk-event-adapter.ts
+++ b/electron/src/main/llm/stream/sdk-event-adapter.ts
@@ -118,6 +118,8 @@ export class SdkEventAdapter {
   private currentStepMessages: readonly ModelMessage[];
   private stepIndex = 0;
   private stepChars: ReasoningChars = emptyReasoningChars();
+  /** Tool-call ids whose input chars already landed in `stepChars.tool`. */
+  private readonly countedToolInput = new Set<string>();
   private readonly reasoningParts = new Map<string, PendingReasoningSequence>();
 
   constructor(private readonly options: SdkEventAdapterOptions) {
@@ -136,6 +138,7 @@ export class SdkEventAdapter {
           : this.options.coreMessages;
         this.reasoningParts.clear();
         this.stepChars = emptyReasoningChars();
+        this.countedToolInput.clear();
         break;
       }
 
@@ -192,6 +195,7 @@ export class SdkEventAdapter {
         const argsDelta = stringField(part.inputTextDelta) ?? stringField(part.delta) ?? '';
         if (toolCallId && argsDelta) {
           this.stepChars.tool += argsDelta.length;
+          this.countedToolInput.add(toolCallId);
           this.options.eagerBridge.inputDelta(toolCallId, argsDelta);
           this.options.attempt.markDeliveredOutput();
           yield { type: 'tool_call_delta', toolCallId, argsDelta };
@@ -210,11 +214,19 @@ export class SdkEventAdapter {
         const toolCallId = streamToolCallId(part);
         const toolName = this.options.resolveToolName(stringField(part.toolName) ?? 'unknown');
         const rawInput = part.input ?? part.args;
+        // Whole-delivered tool calls (no input-delta parts) still generated
+        // tokens — count their input as tool-use chars once, deduped against
+        // streamed deltas for the same call (issue 187).
+        const args = stringifyToolInput(rawInput);
+        if (toolCallId && !this.countedToolInput.has(toolCallId) && args) {
+          this.stepChars.tool += args.length;
+          this.countedToolInput.add(toolCallId);
+        }
         if (toolCallId) {
           const event = this.options.eagerBridge.sdkToolCall({
             toolCallId,
             toolName,
-            args: stringifyToolInput(rawInput),
+            args,
             rawInput,
             providerExecuted: part.providerExecuted === true,
             invalid: part.invalid === true,

--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -1402,7 +1402,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
             usage={chat.usage}
             maxContext={maxContext}
             messages={chat.messages}
-            streamingThinkingChars={Math.floor(chat.streamingThinking.length / 500) * 500 || undefined}
+            streamingThinkingChars={Math.floor(chat.streamingUnaccountedThinkingChars / 500) * 500 || undefined}
             model={providerPickerValue}
             modelLabels={providerModelLabels}
             modelDetails={providerModelDetails}
@@ -1470,7 +1470,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
           cumulativeUsage={chat.cumulativeUsage}
           maxContext={maxContext}
           messages={chat.messages}
-          streamingThinkingChars={Math.floor(chat.streamingThinking.length / 500) * 500 || undefined}
+          streamingThinkingChars={Math.floor(chat.streamingUnaccountedThinkingChars / 500) * 500 || undefined}
           focusSection={inspectorFocusSection}
           onFocusSectionConsumed={handleFocusSectionConsumed}
         />

--- a/electron/src/renderer/components/ContextGrid.tsx
+++ b/electron/src/renderer/components/ContextGrid.tsx
@@ -9,7 +9,7 @@
 import { useMemo } from 'react';
 import type { Message, Usage } from '../../shared/types/message';
 import { MessageRole, MessageType } from '../../shared/types/message';
-import { contextUsedTokens } from '../../shared/usage';
+import { contextUsedTokens, usageCountersEqual } from '../../shared/usage';
 
 const COLOR_FREE = 'var(--context-free)';
 const COLOR_SYSTEM = 'var(--context-system)';
@@ -179,13 +179,18 @@ function estimateSummaryTokensFromChars(
   return Math.round((chars.summary / totalChars) * inputTokens);
 }
 
-function isPersistedUsageRef(
+/**
+ * True when the usage record is already attached to one of the visible
+ * messages. Reference equality is useless here: the done-event usage and the
+ * message-attached usage cross IPC as separate structured clones (issue 187).
+ */
+function isPersistedUsage(
   messages: readonly Message[],
   usage: Usage | null,
 ): boolean {
   if (!usage) return false;
   for (const message of messages) {
-    if (message.usage === usage) return true;
+    if (usageCountersEqual(message.usage, usage)) return true;
   }
   return false;
 }
@@ -201,21 +206,21 @@ function computeBreakdown(
   if (usage?.context) {
     const context = usage.context;
     const persistedReasoning = sumPersistedReasoning(messages);
-    const isPersisted = isPersistedUsageRef(messages, usage);
     const normalizeNonNegative = (value: number | undefined): number | undefined =>
       typeof value === 'number' && value >= 0 ? value : undefined;
     const usageReasoning = normalizeNonNegative(usage.reasoning_tokens);
     const contextReasoning = normalizeNonNegative(usage.context?.reasoning_tokens);
-    const providerDelta = isPersisted ? 0 : (usageReasoning ?? contextReasoning ?? 0);
+    const providerDelta = isPersistedUsage(messages, usage) ? 0 : (usageReasoning ?? contextReasoning ?? 0);
     const streamingTokens =
       streamingThinkingChars && streamingThinkingChars > 0
         ? Math.round(streamingThinkingChars / 4)
         : 0;
-    // A positive provider count is authoritative; the thinking-char estimate is
-    // only a fallback for providers that never report reasoning tokens. Taking
-    // the max would let the estimate inflate a turn the provider already counted.
-    const liveOrStreaming = providerDelta > 0 ? providerDelta : streamingTokens;
-    const streamingDelta = Math.max(0, streamingTokens - providerDelta);
+    // Provider-reported reasoning (finished steps) and the thinking-char
+    // estimate (in-flight step) cover DISJOINT parts of the turn — they are
+    // summed, never exchanged. The caller passes only thinking chars not yet
+    // covered by a usage event, so no finished step is estimated twice.
+    const liveOrStreaming = providerDelta + streamingTokens;
+    const streamingDelta = streamingTokens;
     const effectiveAssistantTokens = context.assistant_tokens + streamingDelta;
     const effectiveUsedTokens = context.used_tokens + streamingDelta;
     // Summary tokens: provider-reported when present, otherwise estimated from
@@ -235,27 +240,25 @@ function computeBreakdown(
     const reserve = (value: number): number => Math.round(Math.max(0, value) * summaryReserve);
     const scaledAssistantTokens = reserve(effectiveAssistantTokens);
     const windowReasoning = persistedReasoning + liveOrStreaming;
+    const chars = countMessageChars(messages);
+    if (streamingThinkingChars && streamingThinkingChars > 0) {
+      chars.reasoning += streamingThinkingChars;
+    }
     let assistant: { response: number; reasoning: number };
-    if (windowReasoning > 0) {
-      const reasoning = Math.min(
-        Math.max(0, scaledAssistantTokens),
-        Math.max(0, windowReasoning),
-      );
+    if (windowReasoning > 0 && windowReasoning <= Math.max(0, scaledAssistantTokens)) {
+      // Reported reasoning fits inside the assistant bucket — authoritative.
       assistant = {
-        response: Math.max(0, scaledAssistantTokens - reasoning),
-        reasoning,
+        response: Math.max(0, scaledAssistantTokens - windowReasoning),
+        reasoning: windowReasoning,
       };
     } else {
-      // No positive provider count. A provider-reported zero is not treated as
-      // authoritative here: models that stream visible thinking but report
-      // reasoning_tokens = 0 would otherwise show no reasoning once the chain
-      // finishes (the live view counts the same thinking via streaming chars).
-      // Fall back to the character-ratio estimate, which yields zero on its own
-      // when there is no visible reasoning text.
-      const chars = countMessageChars(messages);
-      if (streamingThinkingChars && streamingThinkingChars > 0) {
-        chars.reasoning += streamingThinkingChars;
-      }
+      // Either nothing was reported, or the reported reasoning exceeds what
+      // the final snapshot's assistant bucket holds — generated-token totals
+      // (per-message usage) outgrow the last step's window position on every
+      // multi-step reasoning-heavy turn, and clamping there redirected the
+      // whole bucket into Reasoning, collapsing an explicit response to zero
+      // (issue 187). Fall back to the visible character ratio, which yields
+      // zero on its own when there is no visible reasoning text.
       assistant = splitAssistantTokens(scaledAssistantTokens, chars);
     }
     return {
@@ -344,7 +347,7 @@ function buildLegendSections(b: TokenBreakdown): LegendSection[] {
     {
       entries: [
         entry('tool-definition', COLOR_TOOLS, 'Tool (Definition)', b.tools),
-        entry('tool-use', COLOR_TOOL_USE, 'Tool use (Output)', b.toolUse),
+        entry('tool-use', COLOR_TOOL_USE, 'Tool use', b.toolUse),
       ],
     },
     { entries: [entry('user', COLOR_USER, 'User', b.user)] },

--- a/electron/src/renderer/hooks/useChat.ts
+++ b/electron/src/renderer/hooks/useChat.ts
@@ -109,6 +109,11 @@ export interface ChatState {
   streamingContent: string;
   /** Thinking content being streamed. */
   streamingThinking: string;
+  /**
+   * Thinking chars not yet covered by a usage event — the only part the
+   * context panel may estimate as in-flight reasoning (issue 187).
+   */
+  streamingUnaccountedThinkingChars: number;
   /** Tool calls generated or run during the current turn. */
   toolBlocks: ToolBlock[];
   /**
@@ -466,6 +471,14 @@ export function useChat(
   const status: ChatStatus = projection?.status ?? 'idle';
   const streamingContent = projection?.response ?? '';
   const streamingThinking = projection?.thinking ?? '';
+  /**
+   * Thinking chars not yet covered by a usage event — the only part the
+   * context panel may estimate as in-flight reasoning (issue 187). Counted
+   * thinking is already attributed through the provider-reported tokens.
+   */
+  const streamingUnaccountedThinkingChars = projection
+    ? Math.max(0, projection.thinking.length - projection.usageThinkingChars)
+    : 0;
   const toolBlocks = useMemo(() => projection?.toolCalls.map(chatToolSnapshotToBlock) ?? [], [projection?.toolCalls]);
   const streamSegments = projection?.streamSegments ?? [];
   const usage = projection?.usage ?? persistedUsage;
@@ -945,6 +958,7 @@ export function useChat(
     status,
     streamingContent,
     streamingThinking,
+    streamingUnaccountedThinkingChars,
     toolBlocks,
     streamSegments,
     streamRevision: projectionState.revision,

--- a/electron/src/shared/chat/turn-projection.ts
+++ b/electron/src/shared/chat/turn-projection.ts
@@ -94,6 +94,13 @@ export interface ChatTurnProjection {
   streamSegments: ChatStreamSegmentSnapshot[];
   toolCalls: ChatTurnToolSnapshot[];
   usage: Usage | null;
+  /**
+   * Thinking character count already covered by the latest usage event.
+   * The difference to `thinking.length` is in-flight thinking the provider
+   * has not accounted for yet — the renderer estimates those tokens instead
+   * of re-estimating the whole turn (issue 187).
+   */
+  usageThinkingChars: number;
   error: string | null;
   interruptState: ChatSnapshot['interruptState'];
   cwd: string | null;
@@ -160,6 +167,7 @@ export function beginChatTurnProjection(sessionId: string, startedAt: number | n
     streamSegments: [],
     toolCalls: [],
     usage: null,
+    usageThinkingChars: 0,
     error: null,
     interruptState: 'idle',
     cwd: null,
@@ -253,6 +261,9 @@ export function seedChatTurnProjection(snapshot: ChatSnapshot): ChatTurnProjecti
     streamSegments: snapshot.streamSegments.map(copySegment),
     toolCalls: snapshot.toolCalls.map((tool) => ({ ...tool })),
     usage: snapshot.usage,
+    // A non-null snapshot usage means the last finish-step already accounted
+    // every thinking char emitted before the snapshot was taken.
+    usageThinkingChars: snapshot.usage ? snapshot.thinking.length : 0,
     error: snapshot.error,
     interruptState: snapshot.interruptState,
     cwd: snapshot.cwd,
@@ -312,7 +323,7 @@ export function applyChatTurnEvent(
         streamSegments: appendSegment(next.streamSegments, 'thinking', action.segmentId, action.data, action.occurredAt),
       };
     case 'usage':
-      return { ...next, usage: action.usage };
+      return { ...next, usage: action.usage, usageThinkingChars: next.thinking.length };
     case 'tool_call_start':
       return updateTool(next, action.toolCallId, action.toolName, action.occurredAt, () => ({}));
     case 'tool_call_delta':

--- a/electron/src/shared/usage.ts
+++ b/electron/src/shared/usage.ts
@@ -157,7 +157,13 @@ export const EMPTY_SUBAGENT_USAGE_SUMMARY: SubagentUsageSummary = {
   total: null,
 };
 
-function usageCountersEqual(a: Usage | null | undefined, b: Usage | null | undefined): boolean {
+/**
+ * Compare the token counters of two usage records (context snapshots
+ * excluded). IPC structured clones break reference identity between the
+ * done-event usage and its message-attached copy, so persisted-usage checks
+ * must compare by value (issue 187).
+ */
+export function usageCountersEqual(a: Usage | null | undefined, b: Usage | null | undefined): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
   return (

--- a/electron/tests/unit/chat-turn-projection.test.ts
+++ b/electron/tests/unit/chat-turn-projection.test.ts
@@ -103,7 +103,10 @@ describe('ChatTurnProjection', () => {
       interrupted: true,
     });
 
-    const { terminal, status, compactionProgress, ...projection } = seedChatTurnProjection(snapshot);
+    const { terminal, status, compactionProgress, usageThinkingChars, ...projection } = seedChatTurnProjection(snapshot);
+    // The snapshot carried a usage event, so its thinking length is fully
+    // accounted (issue 187).
+    expect(usageThinkingChars).toBe(snapshot.thinking.length);
 
     expect({ ...projection, state: status }).toEqual(snapshot);
     expect(terminal).toBeNull();

--- a/electron/tests/unit/context-grid.test.ts
+++ b/electron/tests/unit/context-grid.test.ts
@@ -278,10 +278,11 @@ describe('context grid breakdown', () => {
     expect(categories.reasoning + categories.response).toBe(4_069);
   });
 
-  it('does not inflate a positive provider reasoning count with the streaming estimate', () => {
-    // While a turn is active the provider-reported count (here 500) is
-    // authoritative. The thinking-char estimate (8000 chars -> 2000 tokens)
-    // must not override it, or the live reasoning figure is overstated.
+  it('sums the provider reasoning count with the in-flight streaming estimate', () => {
+    // While a turn is active the provider-reported count (here 500) covers
+    // finished steps; the thinking-char estimate (8000 chars -> 2000 tokens)
+    // covers the in-flight step. They are disjoint and must be summed —
+    // picking one made live thinking inflate "Response" (issue 187).
     const usage = {
       prompt_tokens: 1_000,
       completion_tokens: 600,
@@ -314,7 +315,7 @@ describe('context grid breakdown', () => {
     const reasoningTokens = html.match(
       /context-panel-label">Reasoning<\/span>.*?context-panel-tokens">([^<]+)</s,
     )?.[1];
-    expect(reasoningTokens).toBe('500');
+    expect(reasoningTokens).toBe('2.5k');
   });
 
   it('excludes hidden messages from every character bucket', () => {
@@ -368,7 +369,8 @@ describe('context grid breakdown', () => {
     );
 
     expect(html).toContain('Tool (Definition)');
-    expect(html).toContain('Tool use (Output)');
+    expect(html).toContain('Tool use');
+    expect(html).not.toContain('Tool use (Output)');
     expect(html).toContain('Response');
     expect(html).toContain('Reasoning');
     expect(html).not.toContain('>Tools<');

--- a/electron/tests/unit/context-live-attribution.test.ts
+++ b/electron/tests/unit/context-live-attribution.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Issue #187 regressions — live/done token attribution in the Context panel.
+ *
+ * Three defects:
+ * 1. In-flight thinking chars are bucketed into "Response" (not "Reasoning")
+ *    because provider-reported reasoning (finished steps) and the streaming
+ *    thinking estimate (in-flight step) were treated as mutually exclusive —
+ *    they cover disjoint steps and must be summed.
+ * 2. "Response" collapses to 0 when the turn ends: the renderer receives the
+ *    done-event usage and the message-attached usage as separate structured
+ *    clones across IPC, so reference equality cannot detect that the usage is
+ *    already persisted on a message — its reasoning tokens double-count and
+ *    clamp the whole assistant bucket into "Reasoning".
+ * 3. The turn projection must expose how much thinking text is still
+ *    unaccounted for by the latest usage event, so the renderer does not
+ *    re-estimate thinking that the provider already reported.
+ */
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  applyChatTurnEvents,
+  beginChatTurnProjection,
+} from '../../src/shared/chat/turn-projection';
+import {
+  computeContextCategories,
+  ContextLegend,
+} from '../../src/renderer/components/ContextGrid';import type { Message, Usage } from '../../src/shared/types/message';
+import { MessageRole, MessageType } from '../../src/shared/types/message';
+
+function usageWith(reasoning: number, assistantTokens: number): Usage {
+  return {
+    prompt_tokens: 12_000,
+    completion_tokens: 3_500,
+    total_tokens: 15_500,
+    cached_tokens: 0,
+    reasoning_tokens: reasoning,
+    context: {
+      input_tokens: 12_000,
+      output_tokens: 3_500,
+      used_tokens: 15_500,
+      system_tokens: 500,
+      tools_tokens: 500,
+      tool_use_tokens: 1_000,
+      user_tokens: 4_000,
+      assistant_tokens: assistantTokens,
+      reasoning_tokens: reasoning,
+    },
+  };
+}
+
+function textMessage(content: string, usage?: Usage): Message {
+  return {
+    id: `text-${content.length}`,
+    role: MessageRole.ASSISTANT,
+    content,
+    type: MessageType.TEXT,
+    thinking: null,
+    hidden: false,
+    ...(usage ? { usage } : {}),
+  } as unknown as Message;
+}
+
+function thinkingMessage(content: string): Message {
+  return {
+    id: `thinking-${content.length}`,
+    role: MessageRole.ASSISTANT,
+    content,
+    type: MessageType.THINKING,
+    thinking: content,
+    hidden: false,
+  } as unknown as Message;
+}
+
+function panelTokens(
+  html: string,
+  label: string,
+): number {
+  const match = html.match(
+    new RegExp(`context-panel-label">${label}</span>.*?context-panel-tokens">([\\d.,kM]+)<`, 's'),
+  )?.[1];
+  if (!match) throw new Error(`panel row not found: ${label}`);
+  if (match.endsWith('k')) return Math.round(parseFloat(match) * 1_000);
+  if (match.endsWith('M')) return Math.round(parseFloat(match) * 1_000_000);
+  return parseInt(match.replace(/,/g, ''), 10);
+}
+
+function renderPanel(
+  messages: readonly Message[],
+  usage: Usage | null,
+  streamingThinkingChars?: number,
+): { response: number; reasoning: number; toolUse: number } {
+  const html = renderToStaticMarkup(createElement(ContextLegend, {
+    messages: [...messages],
+    usage: usage ?? undefined,
+    maxContext: 200_000,
+    ...(streamingThinkingChars ? { streamingThinkingChars } : {}),
+    variant: 'panel',
+  }));
+  return {
+    response: panelTokens(html, 'Response'),
+    reasoning: panelTokens(html, 'Reasoning'),
+    toolUse: panelTokens(html, 'Tool use'),
+  };
+}
+
+describe('issue 187: live reasoning attribution', () => {
+  it('attributes in-flight thinking to Reasoning, not Response', () => {
+    // Turn so far: finished step reported 1200 reasoning tokens; 2000 chars of
+    // the NEXT step's thinking are streaming with no usage event yet.
+    const usage = usageWith(1_200, 1_400);
+    const messages = [textMessage('prior answer'), textMessage('x'.repeat(200))];
+
+    const before = renderPanel(messages, usage);
+    const during = renderPanel(messages, usage, 2_000);
+
+    expect(during.reasoning).toBeGreaterThan(before.reasoning);
+    // The whole point of #187: Response must not move while only thinking
+    // streams in.
+    expect(during.response).toBe(before.response);
+  });
+
+  it('sums provider reasoning with the streaming estimate instead of picking one', () => {
+    const usage = usageWith(500, 3_000);
+    const panel = renderPanel([textMessage('answer')], usage, 8_000);
+
+    // 500 provider-reported + ~2000 estimated in-flight (8000 chars / 4).
+    expect(panel.reasoning).toBeGreaterThanOrEqual(2_400);
+  });
+
+  it('keeps a positive Response after the turn ends with a cloned done-event usage', () => {
+    // The done event and the merged terminal messages cross IPC separately —
+    // the usage object on the message is a structural clone, never the same
+    // reference the projection holds.
+    const turnUsage = usageWith(1_200, 1_400);
+    const messages = [
+      textMessage('question context'.repeat(5)),
+      textMessage('Here is the fix for the auth bug. '.repeat(20), structuredClone(turnUsage)),
+    ];
+
+    const categories = computeContextCategories(messages, structuredClone(turnUsage), 200_000);
+
+    expect(categories.response).toBeGreaterThan(0);
+    expect(categories.reasoning).toBe(1_200);
+  });
+
+  it('keeps an explicit response visible when turn reasoning exceeds the final snapshot bucket', () => {
+    // Multi-step reasoning-heavy turn: per-message usage reports 2300 reasoning
+    // tokens, but the final step's context snapshot only holds 900 assistant
+    // tokens (earlier steps' reasoning never re-enters the final window).
+    // Clamping with the session total redirected the whole bucket into
+    // Reasoning and collapsed the explicit response to zero.
+    const turnUsage = usageWith(2_300, 900);
+    const messages = [
+      textMessage('question context'.repeat(5)),
+      thinkingMessage('x'.repeat(9_000)),
+      textMessage('Here is the fix for the auth bug. '.repeat(20), structuredClone(turnUsage)),
+    ];
+
+    const panel = renderPanel(messages, structuredClone(turnUsage));
+
+    expect(panel.response).toBeGreaterThan(0);
+    expect(panel.reasoning).toBeGreaterThan(0);
+  });
+
+  it('labels the tool-use row without the stale "(Output)" suffix', () => {
+    const html = renderToStaticMarkup(createElement(ContextLegend, {
+      messages: [],
+      usage: usageWith(0, 0),
+      maxContext: 1_000,
+      variant: 'panel',
+    }));
+    expect(html).toContain('Tool use');
+    expect(html).not.toContain('Tool use (Output)');
+  });
+});
+
+describe('issue 187: unaccounted thinking tracking', () => {
+  const identity = (sequence: number) => ({ sessionId: 's1', turnId: 't1', sequence });
+  const at = (sequence: number) => ({ ...identity(sequence), occurredAt: '2026-01-01T00:00:00Z' });
+
+  it('captures the thinking length already covered by each usage event', () => {
+    const projected = applyChatTurnEvents(beginChatTurnProjection('s1', 0), [
+      { ...at(1), type: 'thinking', data: 'a'.repeat(900), segmentId: 'think-1' },
+      { ...at(2), type: 'usage', usage: usageWith(200, 300) },
+      { ...at(3), type: 'thinking', data: 'b'.repeat(300), segmentId: 'think-2' },
+    ]);
+
+    expect(projected?.thinking.length).toBe(1_200);
+    expect(projected?.usageThinkingChars).toBe(900);
+  });
+
+  it('treats all thinking as unaccounted before any usage event', () => {
+    const projected = applyChatTurnEvents(beginChatTurnProjection('s1', 0), [
+      { ...at(1), type: 'thinking', data: 'a'.repeat(400), segmentId: 'think-1' },
+    ]);
+
+    expect(projected?.usageThinkingChars).toBe(0);
+    expect(projected?.thinking.length).toBe(400);
+  });
+});

--- a/electron/tests/unit/sdk-event-adapter.test.ts
+++ b/electron/tests/unit/sdk-event-adapter.test.ts
@@ -210,6 +210,44 @@ describe('SdkEventAdapter', () => {
     expect(bridge.sdkToolCall).toHaveBeenCalledTimes(2);
   });
 
+  it('counts whole-delivered tool input as tool-use chars, deduped against streamed deltas', () => {
+    const { adapter, buildUsage } = createAdapter();
+    adapt(adapter, { type: 'start-step' });
+
+    // Whole delivery: no tool-input-delta parts preceded this call.
+    adapt(adapter, { type: 'tool-call', toolCallId: 'whole', toolName: 'read', input: { path: '/a/b/c'.repeat(20) } });
+    // Streamed delivery: chars arrive via deltas, the final part must not
+    // double-count them.
+    adapt(adapter, { type: 'tool-input-start', toolCallId: 'streamed', toolName: 'grep' });
+    adapt(adapter, { type: 'tool-input-delta', toolCallId: 'streamed', inputTextDelta: '{"pattern":"x' });
+    adapt(adapter, { type: 'tool-input-delta', toolCallId: 'streamed', inputTextDelta: '"}' });
+    adapt(adapter, { type: 'tool-input-available', toolCallId: 'streamed', toolName: 'grep', input: { pattern: 'x' } });
+    adapt(adapter, {
+      type: 'finish-step',
+      usage: { inputTokens: 10, outputTokens: 40 },
+    });
+
+    const chars = buildUsage.mock.calls[0]?.[2];
+    expect(chars?.tool).toBe(JSON.stringify({ path: '/a/b/c'.repeat(20) }).length + '{"pattern":"x"}'.length);
+  });
+
+  it('resets per-step tool-input dedupe state at the next start-step', () => {
+    const { adapter, buildUsage } = createAdapter();
+    adapt(adapter, { type: 'start-step' });
+    adapt(adapter, { type: 'tool-call', toolCallId: 'whole', toolName: 'read', input: { path: '/a' } });
+    adapt(adapter, { type: 'finish-step', usage: { inputTokens: 10, outputTokens: 40 } });
+    // Next step re-delivers the same call id — it must count again (fresh
+    // dedupe state), not be suppressed by the previous step's set.
+    adapt(adapter, { type: 'start-step' });
+    adapt(adapter, { type: 'tool-call', toolCallId: 'whole', toolName: 'read', input: { path: '/a' } });
+    adapt(adapter, { type: 'finish-step', usage: { inputTokens: 12, outputTokens: 40 } });
+
+    const stepOne = buildUsage.mock.calls[0]?.[2];
+    const stepTwo = buildUsage.mock.calls[1]?.[2];
+    expect(stepOne?.tool).toBe(JSON.stringify({ path: '/a' }).length);
+    expect(stepTwo?.tool).toBe(JSON.stringify({ path: '/a' }).length);
+  });
+
   it('emits finalized eager starts before a new streamed start without draining completions', () => {
     const { adapter, bridge } = createAdapter();
     vi.mocked(bridge.drainEagerStarts).mockImplementation(function* () {


### PR DESCRIPTION
## Summary

During agent turns the Context panel's "Response" figure climbed while the model was only thinking or emitting tool calls, and the instant a turn finished it collapsed to 0 — even when the assistant had just written a full answer (fixes #187). Live thinking now feeds "Reasoning" while it streams, tool-call input is counted as tool use regardless of how the provider delivers it, and a finished turn keeps its explicit response visible.

Before/after on a simulated 3-step turn (thinking → tool, thinking → tool, final answer) driven through the real snapshot/usage/panel functions:

| Phase | Before | After |
|---|---|---|
| step-2 thinking streaming | Response 93 → 518 ↗ | Response 93 (flat), Reasoning 1200 → 1600 ↗ |
| turn done, explicit response | Response **0** | Response **192**, Reasoning 708 |
| whole-delivered tool call | 0 chars counted | input counted in Tool use |

Three stacked defects, each verified against production code before fixing:

1. **In-flight thinking → "Response"** — `ContextGrid` treated provider-reported reasoning (finished steps) and the streaming thinking estimate (in-flight step) as mutually exclusive; they cover disjoint steps and are now summed. The renderer now also passes only thinking chars *not yet covered by a usage event* (`usageThinkingChars` on the turn projection), so finished steps are never estimated twice.
2. **Response → 0 at chain end** — the persisted-usage guard used reference equality, but the done-event usage and the message-attached usage cross IPC as separate structured clones, so it always failed and reasoning double-counted; comparison is now by value (`usageCountersEqual`). The clamp additionally compared session-total reasoning against the final step's window bucket, redirecting the whole assistant bucket into Reasoning on every multi-step reasoning-heavy turn — it now falls back to the visible character ratio when the reported count cannot fit the bucket.
3. **Whole-delivered tool calls → "Response"** — `SdkEventAdapter` only counted `tool-input-delta` chars; calls arriving whole (custom OpenAI-compatible endpoints) now count their input once per step, deduped against streamed deltas. The legend label "Tool use (Output)" is now just "Tool use" since the bucket includes input.

## Test plan

- New `tests/unit/context-live-attribution.test.ts` (7 cases): live thinking grows Reasoning without moving Response, provider reasoning + streaming estimate are summed, a structurally-cloned done usage keeps Response > 0, reasoning-exceeds-bucket keeps an explicit response visible, projection `usageThinkingChars` capture, label check.
- New adapter tests: whole-delivered input counted and deduped, per-step dedupe reset.
- Updated 3 existing tests that encoded the old semantics (mutually-exclusive reasoning, ref-equality seeding, stale label).
- Full suite: 301 files / 4673 tests pass; typecheck and eslint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live context usage tracking for streaming and completed responses.
  * Reasoning usage now combines reported and in-progress estimates more accurately.
  * Fixed usage tracking when data is copied between application processes.
  * Prevented duplicate counting of streamed tool input.
* **UI Improvements**
  * The context panel now shows unaccounted thinking characters in 500-character increments.
  * Renamed “Tool use (Output)” to “Tool use” for clearer labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->