### PR TITLE
feat(prompts): shared all-agents and subagents-only prompt slots (#156)

### DIFF
--- a/electron/scripts/copy-defaults.js
+++ b/electron/scripts/copy-defaults.js
@@ -11,6 +11,7 @@ const pairs = [
   ['src/main/agents/defaults', 'dist/main/agents/defaults'],
   ['src/main/skills/defaults', 'dist/main/skills/defaults'],
   ['src/main/personality/defaults', 'dist/main/personality/defaults'],
+  ['src/main/prompts/defaults', 'dist/main/prompts/defaults'],
   // AST tree-sitter queries (.scm) — required by parser.loadQueryFile()
   ['src/main/ast/queries', 'dist/main/ast/queries'],
 ];

--- a/electron/src/main/agents/subagent-runner.ts
+++ b/electron/src/main/agents/subagent-runner.ts
@@ -40,6 +40,7 @@ import {
   type ProjectRuntime,
 } from '../project/runtime';
 import { appendRootAgentsMd, seedSubagentRootAgentsMd } from '../project/agents-md';
+import { appendSharedRules, appendSubagentRules } from '../project/shared-prompts';
 import type {
   SubagentCompactionPauseController,
   SubagentHistoryBox,
@@ -275,15 +276,16 @@ export function createSubagentStreamRunner(): SubagentStreamRunner {
         .map((tool) => tool.definition.name)
         .filter((name) => !SUBAGENT_FORBIDDEN_TOOLS.has(name));
       const agentForRun: Agent = { ...params.agent, allowed_tools: allowedTools };
-      // Root AGENTS.md injection is non-fatal: an fs/config failure falls back
-      // to the un-augmented prompt rather than failing the delegation (the
-      // adjacent tracker seeding is already non-fatal).
+      // Shared-prompt + root AGENTS.md injection is non-fatal: an fs/config
+      // failure falls back to the un-augmented prompt rather than failing the
+      // delegation (the adjacent tracker seeding is already non-fatal).
       const basePrompt = params.agent.system_prompt || 'You are a helpful assistant.';
       let fullPrompt = basePrompt;
       try {
-        fullPrompt = appendRootAgentsMd(basePrompt, runtime);
+        fullPrompt = appendSubagentRules(appendSharedRules(basePrompt, runtime), runtime);
+        fullPrompt = appendRootAgentsMd(fullPrompt, runtime);
       } catch (err) {
-        console.debug('root AGENTS.md injection failed (non-fatal):', err);
+        console.debug('shared prompt / root AGENTS.md injection failed (non-fatal):', err);
       }
       // U5: the run's history is a mutable handoff. Every stream segment reads
       // the box's CURRENT contents, so a compaction apply that swaps it between

--- a/electron/src/main/config/loader.ts
+++ b/electron/src/main/config/loader.ts
@@ -24,6 +24,7 @@ export const HOME_CONFIG_PATH = path.join(HOME_CONFIG_DIR, 'config.json');
 export const HOME_AGENTS_DIR = path.join(HOME_CONFIG_DIR, 'agents');
 export const HOME_SKILLS_DIR = path.join(HOME_CONFIG_DIR, 'skills');
 export const HOME_PERSONALITIES_DIR = path.join(HOME_CONFIG_DIR, 'personalities');
+export const HOME_PROMPTS_DIR = path.join(HOME_CONFIG_DIR, 'prompts');
 export const PROJECT_CONFIG_NAME = '.orchid.json';
 
 // ---------------------------------------------------------------------------
@@ -201,6 +202,7 @@ export function ensureHomeConfig(): void {
   fs.mkdirSync(HOME_AGENTS_DIR, { recursive: true });
   fs.mkdirSync(HOME_SKILLS_DIR, { recursive: true });
   fs.mkdirSync(HOME_PERSONALITIES_DIR, { recursive: true });
+  fs.mkdirSync(HOME_PROMPTS_DIR, { recursive: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/electron/src/main/defs/manage.ts
+++ b/electron/src/main/defs/manage.ts
@@ -22,12 +22,19 @@ import type {
   DefinitionScope,
   ManagedAgent,
   ManagedPersonality,
+  ManagedSharedPrompt,
   ManagedSkill,
   AgentSaveMessage,
   PersonalitySaveMessage,
+  SharedPromptSaveMessage,
   SkillSaveMessage,
 } from '../../shared/types/definitions';
 import type { Skill } from '../../shared/types/skill';
+import { sharedPromptFileName } from '../prompts/registry';
+import {
+  SHARED_PROMPT_SLOTS,
+  type SharedPromptSlot,
+} from '../../shared/types/definitions';
 import {
   parseFrontmatter,
   serializeFrontmatter,
@@ -52,6 +59,7 @@ import {
   removeFileInScope,
   renameDefinitionDir,
   resolveScopeRoot,
+  sharedPromptMdPath,
   skillMdPath,
   validateDefinitionName,
 } from './paths';
@@ -434,6 +442,104 @@ export function listManagedPersonalities(
     collectProjectNames: collectPersonalityProjectNames,
     listInDir: listPersonalityEntriesInDir,
   });
+}
+
+// ── Shared prompts ───────────────────────────────────────────────────────────
+
+/**
+ * List both shared prompt slots across scopes (up to 2 slots × 2 scopes).
+ * A non-empty file is required — an empty slot file is equivalent to absent.
+ */
+export function listManagedSharedPrompts(
+  projectDir: string | null,
+): ManagedSharedPrompt[] {
+  const out: ManagedSharedPrompt[] = [];
+  const scopes: readonly DefinitionScope[] =
+    projectDir != null ? ['global', 'project'] : ['global'];
+  for (const scope of scopes) {
+    const root = resolveScopeRoot('prompts', scope, projectDir);
+    for (const slot of SHARED_PROMPT_SLOTS) {
+      const filePath = path.join(root, sharedPromptFileName(slot));
+      const content = readSlotFileContent(filePath);
+      if (content == null) continue;
+      const overriddenByProject =
+        scope === 'global' &&
+        projectDir != null &&
+        readSlotFileContent(path.join(
+          projectDir,
+          '.orchid',
+          'prompts',
+          sharedPromptFileName(slot),
+        )) != null;
+      out.push({
+        slot,
+        content,
+        scope,
+        path: filePath,
+        overriddenByProject,
+      });
+    }
+  }
+  return out;
+}
+
+/** Trimmed slot file content, or null when missing/empty/unreadable. */
+function readSlotFileContent(file: string): string | null {
+  try {
+    const raw = fs.readFileSync(file, 'utf-8').trim();
+    return raw ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write one shared prompt slot file. Empty/whitespace content disables the
+ * slot by deleting its file — the reader treats missing files as absent, and
+ * deleting (rather than writing an empty file) keeps the trust fingerprint
+ * free of invisible residue.
+ */
+export function saveSharedPrompt(
+  msg: SharedPromptSaveMessage,
+  projectDir: string | null,
+): ManagedSharedPrompt {
+  const slot: SharedPromptSlot = msg.slot;
+  if (!SHARED_PROMPT_SLOTS.includes(slot)) {
+    throw new Error(`Invalid shared prompt slot: ${msg.slot}`);
+  }
+
+  const scopeRoot = resolveScopeRoot('prompts', msg.scope, projectDir);
+  const filePath = sharedPromptMdPath(msg.scope, slot, projectDir);
+  const content = msg.content.trim();
+  if (content) {
+    atomicWriteText(filePath, `${content}\n`, scopeRoot);
+  } else if (fs.existsSync(filePath)) {
+    removeFileInScope(filePath, scopeRoot);
+  }
+
+  return {
+    slot,
+    content,
+    scope: msg.scope,
+    path: filePath,
+    overriddenByProject: false,
+  };
+}
+
+export function deleteSharedPrompt(
+  scope: DefinitionScope,
+  slot: string,
+  projectDir: string | null,
+): void {
+  if (!SHARED_PROMPT_SLOTS.includes(slot as SharedPromptSlot)) {
+    throw new Error(`Invalid shared prompt slot: ${slot}`);
+  }
+  const root = resolveScopeRoot('prompts', scope, projectDir);
+  const filePath = sharedPromptMdPath(scope, slot as SharedPromptSlot, projectDir);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Shared prompt "${slot}" not found in ${scope} scope`);
+  }
+  removeFileInScope(filePath, root);
 }
 
 // ── Save ─────────────────────────────────────────────────────────────────────

--- a/electron/src/main/defs/paths.ts
+++ b/electron/src/main/defs/paths.ts
@@ -13,14 +13,17 @@ import { safeFsync } from '../utils/safe-fsync';
 import {
   HOME_AGENTS_DIR,
   HOME_PERSONALITIES_DIR,
+  HOME_PROMPTS_DIR,
   HOME_SKILLS_DIR,
 } from '../config/loader';
 import {
   DEFINITION_NAME_PATTERN,
   type DefinitionScope,
+  type SharedPromptSlot,
 } from '../../shared/types/definitions';
+import { sharedPromptFileName } from '../prompts/registry';
 
-export type DefinitionKind = 'skills' | 'agents' | 'personalities';
+export type DefinitionKind = 'skills' | 'agents' | 'personalities' | 'prompts';
 
 /** Built-in internal agents that must never be project-overlaid or IPC-deleted. */
 export const RESERVED_INTERNAL_AGENT_NAMES = new Set([
@@ -53,6 +56,8 @@ export function resolveScopeRoot(
         return HOME_AGENTS_DIR;
       case 'personalities':
         return HOME_PERSONALITIES_DIR;
+      case 'prompts':
+        return HOME_PROMPTS_DIR;
     }
   }
 
@@ -99,6 +104,18 @@ export function personalityMdPath(
 ): string {
   const safe = validateDefinitionName(name);
   return path.join(resolveScopeRoot('personalities', scope, projectDir), `${safe}.md`);
+}
+
+/** Absolute path of one shared prompt slot file. */
+export function sharedPromptMdPath(
+  scope: DefinitionScope,
+  slot: SharedPromptSlot,
+  projectDir: string | null,
+): string {
+  return path.join(
+    resolveScopeRoot('prompts', scope, projectDir),
+    sharedPromptFileName(slot),
+  );
 }
 
 // ── Path containment ─────────────────────────────────────────────────────────
@@ -273,6 +290,7 @@ export function assertPathUnderOrchidRoots(
     path.resolve(HOME_SKILLS_DIR),
     path.resolve(HOME_AGENTS_DIR),
     path.resolve(HOME_PERSONALITIES_DIR),
+    path.resolve(HOME_PROMPTS_DIR),
   ];
   if (projectDir) {
     rootsLogical.push(path.resolve(path.join(projectDir, '.orchid')));

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -22,10 +22,12 @@ import {
   HOME_AGENTS_DIR,
   HOME_SKILLS_DIR,
   HOME_PERSONALITIES_DIR,
+  HOME_PROMPTS_DIR,
 } from './config/loader';
 import { loadAgents, seedAgentsDir } from './agents/registry';
 import { loadSkills, seedSkillsDir } from './skills/registry';
 import { loadPersonalities, seedPersonalitiesDir } from './personality/registry';
+import { seedSharedPromptsDir } from './prompts/registry';
 import { shutdownProjectMCPManagers } from './mcp/project-registry';
 import { initUpdater, destroyUpdater, checkForUpdates } from './updater';
 import { initFileLogging, closeFileLogging } from './logging';
@@ -317,6 +319,7 @@ app.whenReady().then(async () => {
         seedAgentsDir(HOME_AGENTS_DIR);
         seedSkillsDir(HOME_SKILLS_DIR);
         seedPersonalitiesDir(HOME_PERSONALITIES_DIR);
+        seedSharedPromptsDir(HOME_PROMPTS_DIR);
         loadPersonalities();
 
         // Do not select a project layer as a process-wide default.

--- a/electron/src/main/ipc/chat/send.ts
+++ b/electron/src/main/ipc/chat/send.ts
@@ -19,6 +19,7 @@ import { agentMachine, type AgentContext } from '../../agents/xstate/agent-machi
 import { interruptMachine } from '../../agents/xstate/interrupt-machine';
 import { appendRootAgentsMd, findRootAgentsMdEntry } from '../../project/agents-md';
 import { appendProjectPersonality } from '../../project/personality';
+import { appendSharedRules } from '../../project/shared-prompts';
 import { getProviderRuntime } from '../../providers';
 import { getProviderAccountingStore } from '../../providers/accounting/store';
 import type { ProviderAttemptAccountingContext } from '../../providers/accounting/middleware';
@@ -320,7 +321,8 @@ export async function startChatTurn(
     const turnRegistry = getBuiltinToolRegistryForRuntime(runtime, {
       agents: new Map(runtime.agents), skills: new Map(runtime.skills), mcpManager,
     });
-    const personalityPrompt = appendProjectPersonality(baseSystemPrompt, runtime);
+    const sharedRulesPrompt = appendSharedRules(baseSystemPrompt, runtime);
+    const personalityPrompt = appendProjectPersonality(sharedRulesPrompt, runtime);
     let fullSystemPrompt = personalityPrompt;
     try {
       fullSystemPrompt = appendRootAgentsMd(personalityPrompt, runtime);

--- a/electron/src/main/ipc/definitions.ts
+++ b/electron/src/main/ipc/definitions.ts
@@ -12,12 +12,15 @@ import { AgentTier, AgentType } from '../../shared/types/agent';
 import {
   deleteAgent,
   deletePersonality,
+  deleteSharedPrompt,
   deleteSkill,
   listManagedAgents,
   listManagedPersonalities,
+  listManagedSharedPrompts,
   listManagedSkills,
   saveAgent,
   savePersonality,
+  saveSharedPrompt,
   saveSkill,
 } from '../defs/manage';
 import { assertPathUnderOrchidRoots } from '../defs/paths';
@@ -64,6 +67,17 @@ const personalitySaveSchema = z.object({
   name: nameSchema,
   content: z.string().min(1),
   previousName: z.string().optional(),
+});
+
+const sharedPromptSaveSchema = z.object({
+  scope: scopeSchema,
+  slot: z.enum(['all-agents', 'subagents']),
+  content: z.string(),
+});
+
+const sharedPromptDeleteSchema = z.object({
+  scope: scopeSchema,
+  slot: z.enum(['all-agents', 'subagents']),
 });
 
 const deleteSchema = z.object({
@@ -150,6 +164,7 @@ export function registerDefinitionsIPC(): void {
       skills,
       agents: listManagedAgents(listProjectDir),
       personalities: listManagedPersonalities(listProjectDir),
+      sharedPrompts: listManagedSharedPrompts(listProjectDir),
       availableTools,
       availableSkills: Array.from(skillNames).sort((a, b) => a.localeCompare(b)),
     };
@@ -206,6 +221,27 @@ export function registerDefinitionsIPC(): void {
     ),
   );
 
+  ipcMain.handle(
+    IPC_CHANNELS.SHARED_PROMPT_SAVE,
+    withDefinitionMutation(
+      sharedPromptSaveSchema,
+      'shared-prompt:save',
+      (data, projectDir) => saveSharedPrompt(data, projectDir),
+    ),
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.SHARED_PROMPT_DELETE,
+    withDefinitionMutation(
+      sharedPromptDeleteSchema,
+      'shared-prompt:delete',
+      (data, projectDir) => {
+        deleteSharedPrompt(data.scope, data.slot, projectDir);
+        return { status: 'deleted' as const };
+      },
+    ),
+  );
+
   ipcMain.handle(IPC_CHANNELS.DEFINITION_REVEAL, async (event, payload: unknown) => {
     const parsed = revealSchema.safeParse(payload);
     if (!parsed.success) {
@@ -226,5 +262,7 @@ export function unregisterDefinitionsIPC(): void {
   ipcMain.removeHandler(IPC_CHANNELS.AGENT_DELETE);
   ipcMain.removeHandler(IPC_CHANNELS.PERSONALITY_SAVE);
   ipcMain.removeHandler(IPC_CHANNELS.PERSONALITY_DELETE);
+  ipcMain.removeHandler(IPC_CHANNELS.SHARED_PROMPT_SAVE);
+  ipcMain.removeHandler(IPC_CHANNELS.SHARED_PROMPT_DELETE);
   ipcMain.removeHandler(IPC_CHANNELS.DEFINITION_REVEAL);
 }

--- a/electron/src/main/project/runtime.ts
+++ b/electron/src/main/project/runtime.ts
@@ -12,6 +12,7 @@ import { readAgents } from '../agents/registry';
 import { loadConfig } from '../config/loader';
 import type { Config } from '../config/schema';
 import { readPersonalities } from '../personality/registry';
+import { readSharedPrompts, type SharedPrompts } from '../prompts/registry';
 import { readSkills } from '../skills/registry';
 import { canonicalizeProjectDirectory } from './path';
 
@@ -26,6 +27,8 @@ export interface ProjectRuntime {
   readonly skills: ReadonlyMap<string, Skill>;
   /** Home personalities overlaid by this project's personalities. */
   readonly personalities: ReadonlyMap<string, string>;
+  /** Shared prompt slots (home replaced per-slot by this project's files). */
+  readonly sharedPrompts: SharedPrompts;
 }
 
 export interface ProjectRuntimeRegistryOptions {
@@ -37,6 +40,8 @@ export interface ProjectRuntimeRegistryOptions {
   readonly homeSkillsDir?: string;
   /** Override the home personalities directory. */
   readonly homePersonalitiesDir?: string;
+  /** Override the home shared prompts directory. */
+  readonly homePromptsDir?: string;
 }
 
 function requireCanonicalProjectDirectory(projectDir: string): string {
@@ -93,6 +98,10 @@ export class ProjectRuntimeRegistry {
       }),
       personalities: readPersonalities({
         homeDir: this.options.homePersonalitiesDir,
+        projectDir: canonicalProjectDir,
+      }),
+      sharedPrompts: readSharedPrompts({
+        homeDir: this.options.homePromptsDir,
         projectDir: canonicalProjectDir,
       }),
     });

--- a/electron/src/main/project/shared-prompts.ts
+++ b/electron/src/main/project/shared-prompts.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared prompt injection into the static system instructions.
+ *
+ * Siblings to `appendProjectPersonality` / `appendRootAgentsMd`: append the
+ * resolved shared prompt slots (from the project runtime snapshot) under
+ * clear headings without mutating the base prompt. Pure — reads only the
+ * frozen runtime, never touches disk or the AGENTS.md tracker.
+ */
+import type { ProjectRuntime } from './runtime';
+
+/**
+ * Append the all-agents shared rules. Injected for the main agent and every
+ * subagent — internal agents (session-namer, web-fetch) opt out at their
+ * call sites to keep their prompts minimal.
+ */
+export function appendSharedRules(
+  agentSystemPrompt: string,
+  runtime: ProjectRuntime,
+): string {
+  const rules = runtime.sharedPrompts['all-agents'];
+  return rules
+    ? `${agentSystemPrompt}\n\n## Shared rules\n\n${rules}\n`
+    : agentSystemPrompt;
+}
+
+/**
+ * Append the subagents-only shared rules (parallel-work awareness, mutation
+ * limits, …). Injected after the all-agents slot so subagent-specific
+ * guidance reads as a refinement of the shared baseline.
+ */
+export function appendSubagentRules(
+  agentSystemPrompt: string,
+  runtime: ProjectRuntime,
+): string {
+  const rules = runtime.sharedPrompts.subagents;
+  return rules
+    ? `${agentSystemPrompt}\n\n## Subagent rules\n\n${rules}\n`
+    : agentSystemPrompt;
+}

--- a/electron/src/main/project/trust.ts
+++ b/electron/src/main/project/trust.ts
@@ -3,7 +3,7 @@
  *
  * Trust is keyed by canonical absolute path and fingerprinted against the
  * project's security surface: the raw `.orchid.json` bytes, the files under
- * `.orchid/{agents,skills,personalities}`, and root instruction-file aliases.
+ * `.orchid/{agents,skills,personalities,prompts}`, and root instruction-file aliases.
  * Bare projects carry no surface and resolve `trusted` without a store entry;
  * a drifted fingerprint turns an existing grant into `changed`.
  */
@@ -28,6 +28,7 @@ import {
   HOME_AGENTS_DIR,
   HOME_CONFIG_DIR,
   HOME_PERSONALITIES_DIR,
+  HOME_PROMPTS_DIR,
   HOME_SKILLS_DIR,
   PROJECT_CONFIG_NAME,
 } from '../config/loader';
@@ -40,6 +41,7 @@ import {
   type Config,
 } from '../config/schema';
 import { readPersonalities } from '../personality/registry';
+import { readSharedPrompts } from '../prompts/registry';
 import { readSkills } from '../skills/registry';
 import { canonicalizeProjectDirectory } from './path';
 
@@ -85,7 +87,7 @@ const OVERSIZE_CONFIG_NOTE =
   `.orchid.json exceeds ${TRUST_REPORT_MAX_CONFIG_BYTES} bytes; ` +
   'its content is omitted from this report.';
 
-const DEFINITION_DIRS = ['agents', 'skills', 'personalities'] as const;
+const DEFINITION_DIRS = ['agents', 'skills', 'personalities', 'prompts'] as const;
 
 /** Top-level project-config keys with dedicated report sections. */
 const SECTION_KEYS = new Set([
@@ -119,6 +121,8 @@ export interface ProjectTrustStoreOptions {
   readonly homeSkillsDir?: string;
   /** Override the home personalities directory. */
   readonly homePersonalitiesDir?: string;
+  /** Override the home shared prompts directory. */
+  readonly homePromptsDir?: string;
 }
 
 interface SurfaceFile {
@@ -207,7 +211,7 @@ function readTrustStoreFile(storePath: string): Map<string, TrustStoreRecord> {
 }
 
 /**
- * Files under `.orchid/{agents,skills,personalities}` sorted by relative
+ * Files under `.orchid/{agents,skills,personalities,prompts}` sorted by relative
  * path, capped at TRUST_FINGERPRINT_MAX_FILES. The walk exits early once
  * MAX_FILES + 1 files are collected; the first overflowing file is returned
  * separately so the fingerprint can name it. Residual: files deeper past the
@@ -763,6 +767,9 @@ export class ProjectTrustStore {
     const homePersonalities = readPersonalities({
       homeDir: this.options.homePersonalitiesDir ?? HOME_PERSONALITIES_DIR,
     });
+    const homePrompts = readSharedPrompts({
+      homeDir: this.options.homePromptsDir ?? HOME_PROMPTS_DIR,
+    });
     const projectAgents = readAgents({
       homeDir: null,
       projectDir: path.join(canonical, '.orchid', 'agents'),
@@ -791,6 +798,18 @@ export class ProjectTrustStore {
         kind: 'personality',
         name,
         overridesHome: homePersonalities.has(name),
+      });
+    }
+    const projectPrompts = readSharedPrompts({
+      homeDir: null,
+      projectDir: canonical,
+    });
+    for (const [slot, content] of Object.entries(projectPrompts)) {
+      if (content == null) continue;
+      definitions.push({
+        kind: 'prompt',
+        name: `prompts/${slot}.md`,
+        overridesHome: homePrompts[slot as keyof typeof homePrompts] != null,
       });
     }
     return definitions.slice(0, TRUST_REPORT_MAX_DEFINITIONS);

--- a/electron/src/main/prompts/defaults/subagents.md
+++ b/electron/src/main/prompts/defaults/subagents.md
@@ -1,0 +1,5 @@
+You are operating as a subagent.
+
+- Other agents may be running in parallel and editing files in this workspace. Do not revert, delete, or overwrite work you did not create unless your task explicitly requires it.
+- Do not use mutating git commands (commit, push, branch, merge, rebase, reset, checkout, stash, cherry-pick, revert) unless your task explicitly allows it.
+- Keep your output scoped to your assigned task. Report findings and completed work concisely; do not expand scope on your own.

--- a/electron/src/main/prompts/registry.ts
+++ b/electron/src/main/prompts/registry.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared prompt registry — reads fixed-slot prompt files injected into every
+ * agent's system prompt.
+ *
+ * Layout mirrors personalities:
+ *   home:    ~/.orchid/prompts/{all-agents,subagents}.md
+ *   project: <workspace>/.orchid/prompts/{all-agents,subagents}.md
+ *
+ * Each slot is a singleton: a non-empty project file replaces the home file
+ * for that slot (never merged). Empty or missing files mean "no rules".
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { HOME_PROMPTS_DIR } from '../config/loader';
+import {
+  SHARED_PROMPT_SLOTS,
+  type SharedPromptSlot,
+} from '../../shared/types/definitions';
+
+/** Effective (project-overridden) content per slot; null = no prompt. */
+export type SharedPrompts = Readonly<Record<SharedPromptSlot, string | null>>;
+
+export const EMPTY_SHARED_PROMPTS: SharedPrompts = {
+  'all-agents': null,
+  subagents: null,
+};
+
+export function sharedPromptFileName(slot: SharedPromptSlot): string {
+  return `${slot}.md`;
+}
+
+/**
+ * Read one slot's prompt from a directory. Empty/whitespace-only or missing
+ * files return null (an empty file cannot inject rules).
+ */
+function readSlotFromDir(dir: string, slot: SharedPromptSlot): string | null {
+  const file = path.join(dir, sharedPromptFileName(slot));
+  try {
+    const content = fs.readFileSync(file, 'utf-8').trim();
+    return content ? content : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface ReadSharedPromptsOptions {
+  /**
+   * Override home prompts directory.
+   * `null` skips the home load entirely (project-only reads).
+   */
+  homeDir?: string | null;
+  /** Project root whose `.orchid/prompts/` directory is overlaid. */
+  projectDir?: string;
+}
+
+/**
+ * Read both shared prompt slots and resolve their effective content.
+ * A non-empty project file replaces the home file per slot (no merge).
+ */
+export function readSharedPrompts(
+  options?: ReadSharedPromptsOptions,
+): SharedPrompts {
+  const homeDir = options?.homeDir ?? HOME_PROMPTS_DIR;
+  const projectDir = options?.projectDir
+    ? path.join(options.projectDir, '.orchid', 'prompts')
+    : null;
+
+  const result: Record<SharedPromptSlot, string | null> = {
+    'all-agents': null,
+    subagents: null,
+  };
+  for (const slot of SHARED_PROMPT_SLOTS) {
+    const home =
+      options?.homeDir === null
+        ? null
+        : readSlotFromDir(homeDir, slot);
+    const project = projectDir ? readSlotFromDir(projectDir, slot) : null;
+    result[slot] = project ?? home;
+  }
+  return result;
+}
+
+/**
+ * Seed default shared prompt files into the given home directory.
+ * Bundled defaults are copied only when the target file does not exist —
+ * user edits always win (same policy as personality seeding).
+ */
+export function seedSharedPromptsDir(
+  homeDir: string = HOME_PROMPTS_DIR,
+): void {
+  const defaultsDir = path.join(__dirname, 'defaults');
+  if (!fs.existsSync(defaultsDir) || !fs.statSync(defaultsDir).isDirectory()) {
+    return;
+  }
+  fs.mkdirSync(homeDir, { recursive: true });
+  for (const entry of fs.readdirSync(defaultsDir).sort()) {
+    if (!SHARED_PROMPT_SLOTS.some((slot) => sharedPromptFileName(slot) === entry)) continue;
+    const source = path.join(defaultsDir, entry);
+    if (!fs.statSync(source).isFile()) continue;
+    const target = path.join(homeDir, entry);
+    if (!fs.existsSync(target)) {
+      fs.copyFileSync(source, target);
+    }
+  }
+}

--- a/electron/src/main/tools/tool-worker.ts
+++ b/electron/src/main/tools/tool-worker.ts
@@ -1,5 +1,6 @@
 import { parentPort } from 'node:worker_threads';
 import { ConfigManager } from '../config/loader';
+import { EMPTY_SHARED_PROMPTS } from '../prompts/registry';
 import { createToolWorkerRegistry } from './worker-registry';
 import type {
   ToolExecutionContext,
@@ -53,6 +54,7 @@ async function handleExecute(message: ToolWorkerExecuteMessage): Promise<void> {
       agents: new Map(),
       skills: new Map(),
       personalities: new Map(),
+      sharedPrompts: EMPTY_SHARED_PROMPTS,
     };
     const toolCtx: ToolExecutionContext = { cwd: context.cwd, projectRuntime };
     const result = await registered.handler(validation.data, toolCtx);

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -76,6 +76,8 @@ import type {
   DefinitionDeleteMessage,
   DefinitionRevealMessage,
   PersonalitySaveMessage,
+  SharedPromptDeleteMessage,
+  SharedPromptSaveMessage,
   SkillSaveMessage,
   RAGIndexMessage,
   RAGIndexProgress,
@@ -629,6 +631,14 @@ const orchidAPI: OrchidAPI = {
 
     delete: (message: DefinitionDeleteMessage) =>
       invoke(IPC_CHANNELS.PERSONALITY_DELETE, message),
+  },
+
+  sharedPrompt: {
+    save: (message: SharedPromptSaveMessage) =>
+      invoke(IPC_CHANNELS.SHARED_PROMPT_SAVE, message),
+
+    delete: (message: SharedPromptDeleteMessage) =>
+      invoke(IPC_CHANNELS.SHARED_PROMPT_DELETE, message),
   },
 
   mcp: {

--- a/electron/src/renderer/AppReady.tsx
+++ b/electron/src/renderer/AppReady.tsx
@@ -18,7 +18,7 @@ import type { Notify, NotifySeverity } from './utils/notify';
 import { useSessionActivity } from './hooks/useSessionActivity';
 import type { Config } from '../shared/types/ipc-boundary';
 
-type SettingsTab = 'general' | 'providers' | 'mcp' | 'tier-models' | 'rag' | 'skills' | 'agents' | 'personalities';
+type SettingsTab = 'general' | 'providers' | 'mcp' | 'tier-models' | 'rag' | 'skills' | 'agents' | 'personalities' | 'shared-prompts';
 
 const ConfigView = lazy(() => import('./components/ConfigView').then((module) => ({
   default: module.ConfigView,

--- a/electron/src/renderer/components/ConfigView.tsx
+++ b/electron/src/renderer/components/ConfigView.tsx
@@ -83,6 +83,9 @@ const ProvidersTab = lazyWithPreload(() => import('./Preferences/ProvidersTab').
 const RAGTab = lazyWithPreload(() => import('./Preferences/RAGTab').then((module) => ({
   default: module.RAGTab,
 })));
+const SharedPromptsTab = lazyWithPreload(() => import('./Preferences/SharedPromptsTab').then((module) => ({
+  default: module.SharedPromptsTab,
+})));
 const SkillsTab = lazyWithPreload(() => import('./Preferences/SkillsTab').then((module) => ({
   default: module.SkillsTab,
 })));
@@ -115,7 +118,8 @@ type TabId =
   | 'compaction'
   | 'skills'
   | 'agents'
-  | 'personalities';
+  | 'personalities'
+  | 'shared-prompts';
 
 const TAB_COMPONENTS = {
   general: GeneralTab,
@@ -131,6 +135,7 @@ const TAB_COMPONENTS = {
   skills: SkillsTab,
   agents: AgentsTab,
   personalities: PersonalitiesTab,
+  'shared-prompts': SharedPromptsTab,
 } satisfies Record<TabId, { preload: () => Promise<unknown> }>;
 
 interface TabDef {
@@ -152,6 +157,7 @@ const TABS: TabDef[] = [
   { id: 'skills', label: 'Skills' },
   { id: 'agents', label: 'Agents' },
   { id: 'personalities', label: 'Personalities' },
+  { id: 'shared-prompts', label: 'Shared Prompts' },
 ];
 
 interface ConfigViewProps {
@@ -283,7 +289,12 @@ export function ConfigView({ onClose, initialTab = 'general', onNotify, onOpenAn
         if (!providers.overview) await providers.refresh();
       } else if (tab === 'tier-models' || tab === 'rag') {
         await providers.ensureModelList();
-      } else if (tab === 'skills' || tab === 'agents' || tab === 'personalities') {
+      } else if (
+        tab === 'skills'
+        || tab === 'agents'
+        || tab === 'personalities'
+        || tab === 'shared-prompts'
+      ) {
         if (!definitions) await loadDefinitions({ silent: true });
       }
     };
@@ -1002,5 +1013,10 @@ function renderTab(
         return <StateMessage kind="warning" title="Personalities could not be loaded." />;
       }
       return <PersonalitiesTab data={definitions} onReload={reloadDefinitions} lockedScope="global" />;
+    case 'shared-prompts':
+      if (!definitions) {
+        return <StateMessage kind="warning" title="Shared prompts could not be loaded." />;
+      }
+      return <SharedPromptsTab data={definitions} onReload={reloadDefinitions} lockedScope="global" />;
   }
 }

--- a/electron/src/renderer/components/Preferences/SharedPromptsTab.tsx
+++ b/electron/src/renderer/components/Preferences/SharedPromptsTab.tsx
@@ -1,0 +1,332 @@
+/**
+ * SharedPromptsTab — edit the fixed shared prompt slots.
+ *
+ * Two singleton slots (All agents / Subagents), each with a global file and an
+ * optional project override (replace semantics — a non-empty project file
+ * replaces the global one for that slot). Unlike named definitions there is
+ * no add/rename: the files themselves are the identity.
+ *
+ * Receives preloaded definitions data from ConfigView to avoid tab-switch flicker.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import type {
+  DefinitionScope,
+  DefinitionsListResult,
+  ManagedSharedPrompt,
+  SharedPromptSlot,
+} from '../../../shared/types/definitions';
+import { onOrchidEvent } from '../../utils/events';
+import { Alert } from '../ui/Alert';
+import { Button } from '../ui/Button';
+import { ConfigCard } from '../ui/ConfigCard';
+import { Panel } from '../ui/Panel';
+import { SectionHeader } from '../ui/SectionHeader';
+import { StatusBadge } from '../ui/StatusBadge';
+import { ScopeToggle } from './ScopeToggle';
+
+export interface SharedPromptsTabProps {
+  data: DefinitionsListResult;
+  onReload: () => Promise<void>;
+  lockedScope?: 'global' | 'project';
+}
+
+const SLOT_META: Record<SharedPromptSlot, { title: string; description: string }> = {
+  'all-agents': {
+    title: 'All agents',
+    description:
+      'Injected into the main agent and every subagent. Use for rules that must be respected by all agents.',
+  },
+  subagents: {
+    title: 'Subagents',
+    description:
+      'Injected into subagents only, after the all-agents rules. Use for subagent-specific guidance such as parallel-work awareness and mutation limits.',
+  },
+};
+
+interface SlotEditorState {
+  scope: DefinitionScope;
+  content: string;
+  dirty: boolean;
+}
+
+export function SharedPromptsTab({ data, onReload, lockedScope }: SharedPromptsTabProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [savingSlot, setSavingSlot] = useState<SharedPromptSlot | null>(null);
+  const [editors, setEditors] = useState<
+    Record<SharedPromptSlot, SlotEditorState>
+  >({
+    'all-agents': { scope: lockedScope ?? 'global', content: '', dirty: false },
+    subagents: { scope: lockedScope ?? 'global', content: '', dirty: false },
+  });
+
+  useEffect(() => {
+    return onOrchidEvent('orchid:definitions-workspace-changed', () => {
+      setError(null);
+    });
+  }, []);
+
+  const projectDir = data.projectDir;
+  const projectAvailable = projectDir != null;
+
+  // Reset non-dirty editors to the on-disk state whenever the definitions
+  // snapshot changes. Dirty slots keep their drafts — the two editors are
+  // independently always-mounted, so saving one slot must not wipe the
+  // other's unsaved edits.
+  useEffect(() => {
+    setEditors((prev) => {
+      const initial: Record<SharedPromptSlot, SlotEditorState> = {
+        'all-agents': { scope: lockedScope ?? 'global', content: '', dirty: false },
+        subagents: { scope: lockedScope ?? 'global', content: '', dirty: false },
+      };
+      if (lockedScope) {
+        for (const slot of ['all-agents', 'subagents'] as const) {
+          const entry = data.sharedPrompts.find(
+            (p) => p.slot === slot && p.scope === lockedScope,
+          );
+          initial[slot] = {
+            scope: lockedScope,
+            content: entry?.content ?? '',
+            dirty: false,
+          };
+        }
+      } else {
+        // Prefer the most specific available scope for editing: a project
+        // override when present, otherwise the global entry.
+        for (const prompt of data.sharedPrompts) {
+          if (initial[prompt.slot].scope === 'project') continue;
+          initial[prompt.slot] = {
+            scope: prompt.scope,
+            content: prompt.content,
+            dirty: false,
+          };
+        }
+      }
+      return {
+        'all-agents': prev['all-agents'].dirty ? prev['all-agents'] : initial['all-agents'],
+        subagents: prev.subagents.dirty ? prev.subagents : initial.subagents,
+      };
+    });
+  }, [data, lockedScope]);
+
+  const findEntry = useCallback(
+    (slot: SharedPromptSlot, scope: DefinitionScope): ManagedSharedPrompt | undefined =>
+      data.sharedPrompts.find((p) => p.slot === slot && p.scope === scope),
+    [data.sharedPrompts],
+  );
+
+  const handleScopeChange = useCallback(
+    (slot: SharedPromptSlot, scope: DefinitionScope) => {
+      if (lockedScope) return;
+      setEditors((prev) => {
+        if (prev[slot].dirty) {
+          const ok = window.confirm(
+            `Discard unsaved changes to the ${slot} prompt before switching scope?`,
+          );
+          if (!ok) return prev;
+        }
+        return {
+          ...prev,
+          [slot]: {
+            scope,
+            content: findEntry(slot, scope)?.content ?? '',
+            dirty: false,
+          },
+        };
+      });
+    },
+    [lockedScope, findEntry],
+  );
+
+  const handleContentChange = useCallback(
+    (slot: SharedPromptSlot, content: string) => {
+      setEditors((prev) => ({
+        ...prev,
+        [slot]: { ...prev[slot], content, dirty: true },
+      }));
+    },
+    [],
+  );
+
+  const handleSave = useCallback(
+    async (slot: SharedPromptSlot) => {
+      if (!window.orchid?.sharedPrompt?.save) return;
+      const editor = editors[slot];
+      setSavingSlot(slot);
+      setError(null);
+      try {
+        await window.orchid.sharedPrompt.save({
+          scope: editor.scope,
+          slot,
+          content: editor.content,
+        });
+        // Clear the dirty flag so the post-reload reset re-syncs this slot
+        // from disk without wiping the other slot's still-dirty draft.
+        setEditors((prev) => ({ ...prev, [slot]: { ...prev[slot], dirty: false } }));
+        await onReload();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : `Failed to save ${slot} prompt`);
+      } finally {
+        setSavingSlot(null);
+      }
+    },
+    [editors, onReload],
+  );
+
+  const handleDelete = useCallback(
+    async (slot: SharedPromptSlot) => {
+      if (!window.orchid?.sharedPrompt?.delete) return;
+      const editor = editors[slot];
+      const ok = window.confirm(
+        `Delete the ${editor.scope} "${slot}" prompt file? The slot falls back to ` +
+          (editor.scope === 'project' ? 'the global prompt' : 'no prompt') +
+          '.',
+      );
+      if (!ok) return;
+      setError(null);
+      try {
+        await window.orchid.sharedPrompt.delete({ scope: editor.scope, slot });
+        await onReload();
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('not found')) {
+          await onReload();
+          return;
+        }
+        setError(err instanceof Error ? err.message : `Failed to delete ${slot} prompt`);
+      }
+    },
+    [editors, onReload],
+  );
+
+  const handleReveal = useCallback(async (prompt: ManagedSharedPrompt) => {
+    try {
+      await window.orchid?.definitions?.reveal({ path: prompt.path });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reveal path');
+    }
+  }, []);
+
+  const renderSlot = (slot: SharedPromptSlot) => {
+    const meta = SLOT_META[slot];
+    const editor = editors[slot];
+    const entry = findEntry(slot, editor.scope);
+    const projectEntry = findEntry(slot, 'project');
+    const effective =
+      projectEntry ?? findEntry(slot, 'global') ?? undefined;
+
+    return (
+      <ConfigCard key={slot} className="flex flex-col gap-3 p-4">
+        <SectionHeader
+          title={meta.title}
+          actions={
+            entry ? (
+              <Button
+                variant="ghost"
+                size="xs"
+                type="button"
+                onClick={() => void handleReveal(entry)}
+              >
+                Reveal
+              </Button>
+            ) : undefined
+          }
+        />
+        <p className="config-card-desc text-sm text-base-content/70">{meta.description}</p>
+
+        {!lockedScope && (
+          <div className="config-scope-bar">
+            <ScopeToggle
+              value={editor.scope}
+              onChange={(value) => handleScopeChange(slot, value as DefinitionScope)}
+              projectAvailable={projectAvailable}
+              projectDir={projectDir}
+              includeAll={false}
+              ariaLabel={`${meta.title} prompt scope`}
+            />
+          </div>
+        )}
+
+        {projectEntry && editor.scope === 'global' && (
+          <div className="flex items-center gap-2">
+            <StatusBadge tone="warning" size="xs" outline>
+              overridden by project
+            </StatusBadge>
+            <span className="text-xs text-base-content/60">
+              Editing the global file has no effect until the project override is removed.
+            </span>
+          </div>
+        )}
+
+        <textarea
+          className="textarea textarea-bordered w-full font-mono text-xs"
+          rows={10}
+          value={editor.content}
+          placeholder={
+            entry
+              ? undefined
+              : 'No prompt in this scope yet — type rules and save to create the file.'
+          }
+          onChange={(e) => handleContentChange(slot, e.target.value)}
+          aria-label={`${meta.title} prompt (markdown)`}
+        />
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs text-base-content/60">
+            File: {editor.scope === 'global' ? '~/.orchid/prompts' : '.orchid/prompts'}/{slot}.md
+            {effective && editor.scope !== effective.scope
+              ? ` · effective: ${effective.scope}`
+              : ''}
+          </span>
+          <div className="flex justify-end gap-2">
+            {entry && (
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                onClick={() => void handleDelete(slot)}
+              >
+                Delete
+              </Button>
+            )}
+            <Button
+              variant="primary"
+              size="sm"
+              type="button"
+              onClick={() => void handleSave(slot)}
+              loading={savingSlot === slot}
+              disabled={!editor.dirty}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </ConfigCard>
+    );
+  };
+
+  return (
+    <div className="config-form flex flex-col gap-4">
+      <Panel as="section" className="config-fieldset flex flex-col gap-3">
+        <SectionHeader title="Shared Prompts" />
+
+        {error && (
+          <Alert tone="error" className="py-2 text-sm mb-3" action={
+            <Button variant="ghost" size="xs" type="button" onClick={() => setError(null)}>
+              Dismiss
+            </Button>
+          }>
+            {error}
+          </Alert>
+        )}
+
+        {(['all-agents', 'subagents'] as const).map(renderSlot)}
+
+        <div className="config-note text-xs text-base-content/60 mt-2">
+          Shared prompts are injected into the system prompt of every turn. A
+          non-empty project file replaces the global file for that slot (no
+          merge). Internal agents (session naming, web fetch) do not receive
+          shared prompts. Changes apply from the next turn.
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/electron/src/renderer/components/ProjectConfigView.tsx
+++ b/electron/src/renderer/components/ProjectConfigView.tsx
@@ -18,6 +18,7 @@ import { AgentsTab } from './Preferences/AgentsTab';
 import { MCPServersTab } from './Preferences/MCPServersTab';
 import { PermissionsTab } from './Preferences/PermissionsTab';
 import { PersonalitiesTab } from './Preferences/PersonalitiesTab';
+import { SharedPromptsTab } from './Preferences/SharedPromptsTab';
 import {
   ProjectTierModelsTab,
   readTierOverrides,
@@ -56,6 +57,7 @@ type ProjectTab =
   | 'skills'
   | 'agents'
   | 'personalities'
+  | 'shared-prompts'
   | 'compaction';
 
 interface ProjectTabDef {
@@ -74,6 +76,7 @@ const PROJECT_TABS: ProjectTabDef[] = [
   { id: 'skills', label: 'Skills' },
   { id: 'agents', label: 'Agents' },
   { id: 'personalities', label: 'Personalities' },
+  { id: 'shared-prompts', label: 'Shared Prompts' },
 ];
 
 type ProjectFieldKind =
@@ -832,6 +835,17 @@ export function ProjectConfigView({ projectDir, onNewChat, onClose }: ProjectCon
         }
         return (
           <PersonalitiesTab data={definitions} onReload={loadDefinitions} lockedScope="project" />
+        );
+      case 'shared-prompts':
+        if (!definitions) {
+          return defsLoading ? (
+            <StateMessage kind="loading" title="Loading shared prompts…" />
+          ) : (
+            <StateMessage kind="warning" title="Shared prompts could not be loaded." />
+          );
+        }
+        return (
+          <SharedPromptsTab data={definitions} onReload={loadDefinitions} lockedScope="project" />
         );
     }
   };

--- a/electron/src/shared/types/definitions.ts
+++ b/electron/src/shared/types/definitions.ts
@@ -48,6 +48,26 @@ export interface ManagedPersonality {
   readonly overriddenByProject: boolean;
 }
 
+/**
+ * Shared prompt slots — fixed singleton prompt files injected into the
+ * system prompt alongside each agent's own instructions.
+ *
+ * - `all-agents`: injected for the main agent and every subagent
+ * - `subagents`: injected for subagents only (parallel-work awareness, …)
+ */
+export type SharedPromptSlot = 'all-agents' | 'subagents';
+
+export const SHARED_PROMPT_SLOTS: readonly SharedPromptSlot[] = ['all-agents', 'subagents'];
+
+export interface ManagedSharedPrompt {
+  readonly slot: SharedPromptSlot;
+  readonly content: string;
+  readonly scope: DefinitionScope;
+  /** Absolute path to `<slot>.md` */
+  readonly path: string;
+  readonly overriddenByProject: boolean;
+}
+
 export interface SkillSaveMessage {
   /** Write scope. Project requires a bound workspace. */
   scope: DefinitionScope;
@@ -82,6 +102,18 @@ export interface PersonalitySaveMessage {
   previousName?: string;
 }
 
+export interface SharedPromptSaveMessage {
+  /** Write scope. Project requires a bound workspace. */
+  scope: DefinitionScope;
+  slot: SharedPromptSlot;
+  content: string;
+}
+
+export interface SharedPromptDeleteMessage {
+  scope: DefinitionScope;
+  slot: SharedPromptSlot;
+}
+
 export interface DefinitionDeleteMessage {
   scope: DefinitionScope;
   name: string;
@@ -98,6 +130,7 @@ export interface DefinitionsListResult {
   skills: ManagedSkill[];
   agents: ManagedAgent[];
   personalities: ManagedPersonality[];
+  sharedPrompts: ManagedSharedPrompt[];
   /**
    * Registered tool names available for agent `allowed_tools` selection.
    * Includes built-ins and currently registered MCP tools.

--- a/electron/src/shared/types/ipc.ts
+++ b/electron/src/shared/types/ipc.ts
@@ -37,8 +37,11 @@ import type {
   DefinitionsListResult,
   ManagedAgent,
   ManagedPersonality,
+  ManagedSharedPrompt,
   ManagedSkill,
   PersonalitySaveMessage,
+  SharedPromptDeleteMessage,
+  SharedPromptSaveMessage,
   SkillSaveMessage,
 } from './definitions';
 import type {
@@ -70,8 +73,12 @@ export type {
   DefinitionsListResult,
   ManagedAgent,
   ManagedPersonality,
+  ManagedSharedPrompt,
   ManagedSkill,
   PersonalitySaveMessage,
+  SharedPromptDeleteMessage,
+  SharedPromptSaveMessage,
+  SharedPromptSlot,
   SkillSaveMessage,
   DefinitionScope,
 } from './definitions';
@@ -1099,9 +1106,9 @@ export interface TrustReportModelOverride {
   modelId: string;
 }
 
-/** One project-local definition (agent / skill / personality). */
+/** One project-local definition (agent / skill / personality / shared prompt). */
 export interface TrustReportDefinition {
-  kind: 'agent' | 'skill' | 'personality';
+  kind: 'agent' | 'skill' | 'personality' | 'prompt';
   name: string;
   /** True when it shadows a home definition of the same name. */
   overridesHome: boolean;
@@ -1549,6 +1556,11 @@ export interface OrchidAPI {
     delete: (message: DefinitionDeleteMessage) => Promise<{ status: string }>;
   };
 
+  sharedPrompt: {
+    save: (message: SharedPromptSaveMessage) => Promise<ManagedSharedPrompt>;
+    delete: (message: SharedPromptDeleteMessage) => Promise<{ status: string }>;
+  };
+
   mcp: {
     status: () => Promise<MCPServerStatus[]>;
   };
@@ -1755,6 +1767,8 @@ export const IPC_CHANNELS = {
   SKILL_DELETE: 'skill:delete',
   PERSONALITY_SAVE: 'personality:save',
   PERSONALITY_DELETE: 'personality:delete',
+  SHARED_PROMPT_SAVE: 'shared_prompt:save',
+  SHARED_PROMPT_DELETE: 'shared_prompt:delete',
 
   // MCP
   MCP_STATUS: 'mcp:status',
@@ -1894,6 +1908,8 @@ export const ALLOWED_INVOKE_CHANNELS = [
   IPC_CHANNELS.SKILL_DELETE,
   IPC_CHANNELS.PERSONALITY_SAVE,
   IPC_CHANNELS.PERSONALITY_DELETE,
+  IPC_CHANNELS.SHARED_PROMPT_SAVE,
+  IPC_CHANNELS.SHARED_PROMPT_DELETE,
   IPC_CHANNELS.MCP_STATUS,
   IPC_CHANNELS.RAG_STATUS,
   IPC_CHANNELS.RAG_INDEX,

--- a/electron/tests/integration/renderer-style-contract.test.ts
+++ b/electron/tests/integration/renderer-style-contract.test.ts
@@ -598,6 +598,7 @@ const BASELINE_COMPONENT_ROOT_HITS: ReadonlySet<string> = new Set([
   'components/Preferences/ScopeToggle.tsx::join',
   'components/Preferences/SkillsTab.tsx::label',
   'components/Preferences/SkillsTab.tsx::textarea',
+  'components/Preferences/SharedPromptsTab.tsx::textarea',
   'components/Providers/ConnectionModelsDialog.tsx::label',
   'components/Providers/ConnectionModelsDialog.tsx::list',
   'components/Providers/ConnectionWizard.tsx::label',
@@ -609,7 +610,7 @@ const BASELINE_COMPONENT_ROOT_HITS: ReadonlySet<string> = new Set([
 ]);
 
 /** Total component-root token occurrences captured at baseline time (count guard). */
-const BASELINE_COMPONENT_ROOT_TOTAL_TOKENS = 67;
+const BASELINE_COMPONENT_ROOT_TOTAL_TOKENS = 68;
 
 const BASELINE_NON_TOKEN_COLORS: ReadonlyMap<string, number> = new Map([
 ]);

--- a/electron/tests/unit/agents-md-root-injection.test.ts
+++ b/electron/tests/unit/agents-md-root-injection.test.ts
@@ -23,6 +23,7 @@ import {
   findRootAgentsMdEntry,
 } from '../../src/main/project/agents-md';
 import type { ProjectRuntime } from '../../src/main/project/runtime';
+import { EMPTY_SHARED_PROMPTS } from '../../src/main/prompts/registry';
 
 const BASE_PROMPT = 'You are a helpful assistant.';
 
@@ -39,6 +40,7 @@ function makeRuntime(projectDir: string, config: Config): ProjectRuntime {
     agents: new Map(),
     skills: new Map(),
     personalities: new Map(),
+    sharedPrompts: EMPTY_SHARED_PROMPTS,
   };
 }
 

--- a/electron/tests/unit/chat-ipc.test.ts
+++ b/electron/tests/unit/chat-ipc.test.ts
@@ -101,6 +101,7 @@ const mocks = vi.hoisted(() => {
     agents: Map<string, Agent>;
     skills: Map<string, unknown>;
     personalities: Map<string, string>;
+    sharedPrompts: Record<'all-agents' | 'subagents', string | null>;
   }>();
   const runtimeRegistry = {
     get: vi.fn((cwd: string) => {
@@ -122,6 +123,7 @@ const mocks = vi.hoisted(() => {
         ]),
         skills: new Map(),
         personalities: new Map(),
+        sharedPrompts: { 'all-agents': null, subagents: null },
       };
     }),
     _set: (cwd: string, runtime: {
@@ -129,6 +131,7 @@ const mocks = vi.hoisted(() => {
       agents?: Map<string, Agent>;
       skills?: Map<string, unknown>;
       personalities?: Map<string, string>;
+      sharedPrompts?: Record<'all-agents' | 'subagents', string | null>;
     }) => {
       runtimeByCwd.set(cwd, {
         config: runtime.config ?? {
@@ -145,6 +148,7 @@ const mocks = vi.hoisted(() => {
         ]),
         skills: runtime.skills ?? new Map(),
         personalities: runtime.personalities ?? new Map(),
+        sharedPrompts: runtime.sharedPrompts ?? { 'all-agents': null, subagents: null },
       });
     },
     _reset: () => {

--- a/electron/tests/unit/definition-reload.test.ts
+++ b/electron/tests/unit/definition-reload.test.ts
@@ -87,12 +87,15 @@ vi.mock('../../src/main/defs/manage', () => ({
   listManagedSkills: mocks.listManagedSkills,
   listManagedAgents: mocks.listManagedAgents,
   listManagedPersonalities: mocks.listManagedPersonalities,
+  listManagedSharedPrompts: vi.fn(() => []),
   saveSkill: vi.fn(),
   saveAgent: vi.fn(),
   savePersonality: vi.fn(),
+  saveSharedPrompt: vi.fn(),
   deleteSkill: vi.fn(),
   deleteAgent: vi.fn(),
   deletePersonality: vi.fn(),
+  deleteSharedPrompt: vi.fn(),
 }));
 
 import { reloadDefinitionRegistries } from '../../src/main/defs/reload';

--- a/electron/tests/unit/definitions-ipc.test.ts
+++ b/electron/tests/unit/definitions-ipc.test.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => {
     listManagedSkills: vi.fn(() => []),
     listManagedAgents: vi.fn(() => []),
     listManagedPersonalities: vi.fn(() => []),
+    listManagedSharedPrompts: vi.fn(() => []),
   };
 });
 
@@ -53,12 +54,15 @@ vi.mock('../../src/main/defs/manage', () => ({
   listManagedSkills: mocks.listManagedSkills,
   listManagedAgents: mocks.listManagedAgents,
   listManagedPersonalities: mocks.listManagedPersonalities,
+  listManagedSharedPrompts: mocks.listManagedSharedPrompts,
   saveSkill: vi.fn(),
   deleteSkill: vi.fn(),
   saveAgent: vi.fn(),
   deleteAgent: vi.fn(),
   savePersonality: vi.fn(),
   deletePersonality: vi.fn(),
+  saveSharedPrompt: vi.fn(),
+  deleteSharedPrompt: vi.fn(),
 }));
 
 vi.mock('../../src/main/defs/paths', () => ({

--- a/electron/tests/unit/project-trust-report.test.ts
+++ b/electron/tests/unit/project-trust-report.test.ts
@@ -83,6 +83,7 @@ beforeEach(() => {
     homeAgentsDir: path.join(homeDir, 'agents'),
     homeSkillsDir: path.join(homeDir, 'skills'),
     homePersonalitiesDir: path.join(homeDir, 'personalities'),
+    homePromptsDir: path.join(homeDir, 'prompts'),
   });
 });
 
@@ -209,6 +210,34 @@ describe('ProjectTrustStore.buildReport', () => {
     expect(byKey.get('agent:shared-agent')?.overridesHome).toBe(true);
     expect(byKey.get('agent:project-only')?.overridesHome).toBe(false);
     expect(byKey.get('skill:brand-new-skill')?.overridesHome).toBe(false);
+  });
+
+  it('reports project shared prompts and flags home overrides', () => {
+    fs.mkdirSync(path.join(homeDir, 'prompts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(homeDir, 'prompts', 'all-agents.md'),
+      'Home rules',
+      'utf-8',
+    );
+    fs.mkdirSync(path.join(project, '.orchid', 'prompts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(project, '.orchid', 'prompts', 'all-agents.md'),
+      'Project rules',
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(project, '.orchid', 'prompts', 'subagents.md'),
+      'Project subagent rules',
+      'utf-8',
+    );
+
+    const report = store.buildReport(project);
+    const byKey = new Map(
+      report.definitions.map((d) => [`${d.kind}:${d.name}`, d]),
+    );
+
+    expect(byKey.get('prompt:prompts/all-agents.md')?.overridesHome).toBe(true);
+    expect(byKey.get('prompt:prompts/subagents.md')?.overridesHome).toBe(false);
   });
 
   it('splits model overrides from other top-level config overrides', () => {

--- a/electron/tests/unit/shared-prompts.test.ts
+++ b/electron/tests/unit/shared-prompts.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Shared prompts — registry read/seed, runtime overlay, injection helpers,
+ * and defs CRUD for the fixed prompt slots.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const mocks = vi.hoisted(() => ({ homeDir: '' }));
+
+// Mock home paths to a temp dir so we don't touch ~/.orchid
+vi.mock('../../src/main/config/loader', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/main/config/loader')>();
+  const home = path.join(os.tmpdir(), `orchid-prompts-home-${process.pid}`);
+  mocks.homeDir = home;
+  return {
+    ...actual,
+    HOME_CONFIG_DIR: home,
+    HOME_SKILLS_DIR: path.join(home, 'skills'),
+    HOME_AGENTS_DIR: path.join(home, 'agents'),
+    HOME_PERSONALITIES_DIR: path.join(home, 'personalities'),
+    HOME_PROMPTS_DIR: path.join(home, 'prompts'),
+    HOME_CONFIG_PATH: path.join(home, 'config.json'),
+  };
+});
+
+import {
+  readSharedPrompts,
+  seedSharedPromptsDir,
+} from '../../src/main/prompts/registry';
+import {
+  appendSharedRules,
+  appendSubagentRules,
+} from '../../src/main/project/shared-prompts';
+import { appendProjectPersonality } from '../../src/main/project/personality';
+import {
+  deleteSharedPrompt,
+  listManagedSharedPrompts,
+  saveSharedPrompt,
+} from '../../src/main/defs/manage';
+import { HOME_PROMPTS_DIR } from '../../src/main/config/loader';
+import type { ProjectRuntime } from '../../src/main/project/runtime';
+
+let projectDir: string;
+
+function makeRuntime(
+  sharedPrompts: Partial<Record<'all-agents' | 'subagents', string | null>>,
+): ProjectRuntime {
+  return {
+    projectDir,
+    config: {} as ProjectRuntime['config'],
+    agents: new Map(),
+    skills: new Map(),
+    personalities: new Map(),
+    sharedPrompts: {
+      'all-agents': sharedPrompts['all-agents'] ?? null,
+      subagents: sharedPrompts.subagents ?? null,
+    },
+  };
+}
+
+beforeEach(() => {
+  fs.rmSync(HOME_PROMPTS_DIR, { recursive: true, force: true });
+  fs.mkdirSync(HOME_PROMPTS_DIR, { recursive: true });
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-prompts-proj-'));
+});
+
+afterEach(() => {
+  fs.rmSync(projectDir, { recursive: true, force: true });
+  fs.rmSync(HOME_PROMPTS_DIR, { recursive: true, force: true });
+});
+
+function writeHomeSlot(slot: string, content: string): void {
+  fs.writeFileSync(path.join(HOME_PROMPTS_DIR, `${slot}.md`), content, 'utf-8');
+}
+
+function writeProjectSlot(slot: string, content: string): void {
+  const dir = path.join(projectDir, '.orchid', 'prompts');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${slot}.md`), content, 'utf-8');
+}
+
+describe('readSharedPrompts', () => {
+  it('returns null for both slots when nothing exists', () => {
+    expect(readSharedPrompts()).toEqual({ 'all-agents': null, subagents: null });
+  });
+
+  it('reads home slots', () => {
+    writeHomeSlot('all-agents', 'Be terse.');
+    expect(readSharedPrompts()).toEqual({
+      'all-agents': 'Be terse.',
+      subagents: null,
+    });
+  });
+
+  it('treats an empty home file as absent', () => {
+    writeHomeSlot('all-agents', '   \n');
+    expect(readSharedPrompts()['all-agents']).toBeNull();
+  });
+
+  it('replaces the home slot with a non-empty project file', () => {
+    writeHomeSlot('all-agents', 'Home rules');
+    writeHomeSlot('subagents', 'Home subagent rules');
+    writeProjectSlot('all-agents', 'Project rules');
+
+    const result = readSharedPrompts({ projectDir });
+    expect(result['all-agents']).toBe('Project rules');
+    expect(result.subagents).toBe('Home subagent rules');
+  });
+
+  it('falls back to home when the project file is empty', () => {
+    writeHomeSlot('all-agents', 'Home rules');
+    writeProjectSlot('all-agents', '');
+
+    const result = readSharedPrompts({ projectDir });
+    expect(result['all-agents']).toBe('Home rules');
+  });
+
+  it('skips the home load entirely with homeDir: null', () => {
+    writeHomeSlot('all-agents', 'Home rules');
+    writeProjectSlot('subagents', 'Project subagent rules');
+
+    const result = readSharedPrompts({ homeDir: null, projectDir });
+    expect(result['all-agents']).toBeNull();
+    expect(result.subagents).toBe('Project subagent rules');
+  });
+});
+
+describe('seedSharedPromptsDir', () => {
+  it('seeds a default subagents prompt once and never overwrites edits', () => {
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-prompts-seed-'));
+    try {
+      seedSharedPromptsDir(target);
+      const seeded = path.join(target, 'subagents.md');
+      expect(fs.existsSync(seeded)).toBe(true);
+      expect(fs.readFileSync(seeded, 'utf-8')).toContain('subagent');
+
+      fs.writeFileSync(seeded, 'Custom rules', 'utf-8');
+      seedSharedPromptsDir(target);
+      expect(fs.readFileSync(seeded, 'utf-8')).toBe('Custom rules');
+    } finally {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('append helpers', () => {
+  it('appendSharedRules appends under a Shared rules heading', () => {
+    const out = appendSharedRules('Base prompt.', makeRuntime({ 'all-agents': 'Rule A' }));
+    expect(out).toBe('Base prompt.\n\n## Shared rules\n\nRule A\n');
+  });
+
+  it('appendSubagentRules appends under a Subagent rules heading', () => {
+    const out = appendSubagentRules('Base prompt.', makeRuntime({ subagents: 'Rule S' }));
+    expect(out).toBe('Base prompt.\n\n## Subagent rules\n\nRule S\n');
+  });
+
+  it('both return the prompt unchanged when the slot is null', () => {
+    const runtime = makeRuntime({});
+    expect(appendSharedRules('Base.', runtime)).toBe('Base.');
+    expect(appendSubagentRules('Base.', runtime)).toBe('Base.');
+  });
+
+  it('subagent composition reads shared → subagent → root order', () => {
+    const runtime = makeRuntime({ 'all-agents': 'Shared', subagents: 'Sub' });
+    const out = appendSubagentRules(appendSharedRules('Base.', runtime), runtime);
+    expect(out.indexOf('## Shared rules')).toBeLessThan(out.indexOf('## Subagent rules'));
+    expect(out.startsWith('Base.')).toBe(true);
+  });
+
+  it('main composition reads base → shared → personality order', () => {
+    const runtime: ProjectRuntime = {
+      ...makeRuntime({ 'all-agents': 'Shared' }),
+      personalities: new Map([['p', 'Persona text']]),
+      config: { personality: 'p' } as ProjectRuntime['config'],
+    };
+    const withShared = appendSharedRules('Base.', runtime);
+    const withPersonality = appendProjectPersonality(withShared, runtime);
+    expect(withPersonality.startsWith('Base.')).toBe(true);
+    expect(withPersonality.indexOf('## Shared rules')).toBeLessThan(
+      withPersonality.indexOf('## Personality'),
+    );
+    expect(withPersonality).toContain('Persona text');
+  });
+});
+
+describe('shared prompt CRUD', () => {
+  it('saves and lists a global slot', () => {
+    const saved = saveSharedPrompt(
+      { scope: 'global', slot: 'all-agents', content: 'Global rules' },
+      null,
+    );
+    expect(saved.path).toBe(path.join(HOME_PROMPTS_DIR, 'all-agents.md'));
+
+    const listed = listManagedSharedPrompts(null);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      slot: 'all-agents',
+      content: 'Global rules',
+      scope: 'global',
+      overriddenByProject: false,
+    });
+  });
+
+  it('saving empty content deletes the slot file (disables it) and leaves no residue', () => {
+    saveSharedPrompt({ scope: 'global', slot: 'all-agents', content: 'Rules' }, null);
+    saveSharedPrompt({ scope: 'global', slot: 'all-agents', content: '  ' }, null);
+    expect(fs.existsSync(path.join(HOME_PROMPTS_DIR, 'all-agents.md'))).toBe(false);
+    expect(listManagedSharedPrompts(null)).toHaveLength(0);
+    expect(readSharedPrompts()['all-agents']).toBeNull();
+  });
+
+  it('marks the global entry overridden by a project override', () => {
+    saveSharedPrompt({ scope: 'global', slot: 'subagents', content: 'Home' }, null);
+    saveSharedPrompt(
+      { scope: 'project', slot: 'subagents', content: 'Project' },
+      projectDir,
+    );
+
+    const listed = listManagedSharedPrompts(projectDir);
+    expect(listed).toHaveLength(2);
+    const globalEntry = listed.find((p) => p.scope === 'global');
+    const projectEntry = listed.find((p) => p.scope === 'project');
+    expect(globalEntry?.overriddenByProject).toBe(true);
+    expect(projectEntry?.overriddenByProject).toBe(false);
+    expect(projectEntry?.path).toContain(path.join('.orchid', 'prompts'));
+  });
+
+  it('delete removes the slot file in the given scope', () => {
+    saveSharedPrompt({ scope: 'project', slot: 'subagents', content: 'X' }, projectDir);
+    deleteSharedPrompt('project', 'subagents', projectDir);
+    expect(fs.existsSync(path.join(projectDir, '.orchid', 'prompts', 'subagents.md'))).toBe(false);
+    expect(() => deleteSharedPrompt('project', 'subagents', projectDir)).toThrow(/not found/);
+  });
+
+  it('rejects unknown slot names', () => {
+    expect(() =>
+      saveSharedPrompt({ scope: 'global', slot: 'bogus' as 'all-agents', content: 'x' }, null),
+    ).toThrow(/Invalid shared prompt slot/);
+    expect(() => deleteSharedPrompt('global', 'bogus', null)).toThrow(/Invalid shared prompt slot/);
+  });
+});
+
+describe('project runtime overlay', () => {
+  it('includes resolved shared prompts in the runtime snapshot', async () => {
+    const { ProjectRuntimeRegistry } = await import('../../src/main/project/runtime');
+    writeHomeSlot('all-agents', 'Home rules');
+    writeProjectSlot('all-agents', 'Project rules');
+
+    const registry = new ProjectRuntimeRegistry({ homePromptsDir: HOME_PROMPTS_DIR });
+    const runtime = registry.get(projectDir);
+    expect(runtime.sharedPrompts['all-agents']).toBe('Project rules');
+    expect(runtime.sharedPrompts.subagents).toBeNull();
+    registry.invalidate(projectDir);
+  });
+});


### PR DESCRIPTION
## Summary

Agents now share a common layer of system-prompt rules that every agent must respect, plus a second layer scoped to subagents only — both editable in the UI and overridable per project (closes #156).

Two fixed singleton slots replace what previously had to be copy-pasted into every AGENT.md:

| Slot | Injected into | Purpose |
|---|---|---|
| `all-agents` | Main agent + every subagent | Rules that must be respected by all agents |
| `subagents` | Subagents only, after the shared layer | Parallel-work awareness: don't revert others' work, re-read before editing, no mutating git commands unless explicitly allowed |

A default `subagents.md` ships with exactly that guidance, so new installs get the parallel-work safety net without configuration.

## Design decisions

- **Singleton slots, not a named-definition registry.** The issue asks for two well-known layers, so two well-known files (`prompts/all-agents.md`, `prompts/subagents.md`) — same layout and editing surface as personalities, one file per concern.
- **Project override replaces, never merges.** A non-empty `<workspace>/.orchid/prompts/<slot>.md` replaces the global file for that slot, matching the overlay semantics of every other definition type. Empty or missing files mean "no rules" — saving empty content deletes the file so no invisible residue drifts the trust fingerprint.
- **Injection order is deliberate.** Main: base prompt → `## Shared rules` → Personality → AGENTS.md. Subagents: base → Shared rules → `## Subagent rules` → AGENTS.md, so subagent guidance reads as a refinement of the shared baseline. Internal agents (session-namer, web-fetch) are excluded — their jobs don't involve workspace editing and the rules would only burn tokens.
- **Prompt-only enforcement.** The git/no-clobber rules are advisory. Hard enforcement hooks exist later via the permission detection packs; explicitly out of scope here.
- **Trust surface covers the new files.** Project prompt files feed the trust fingerprint and appear in the surface-diff report (`kind: 'prompt'` with an overrides-home marker), so a project slipping in hostile rules triggers the same changed-trust gate as agents/skills/personalities. Untrusted projects never inject.

Edits apply from the next turn — `sharedPrompts` rides the frozen `ProjectRuntime` snapshot, same as agents/skills/personalities today.

## Test plan

- `tests/unit/shared-prompts.test.ts` (18 tests): slot read/resolve (project replace, empty-as-absent, `homeDir: null` probe), seeding never overwrites edits, injection helpers + composition order, CRUD including delete-on-empty and unknown-slot rejection, runtime overlay.
- Trust report emits `kind: 'prompt'` entries with correct `overridesHome` (project-trust-report suite).
- Full suite green: 4692 tests, lint, both typechecks, runtime cycle check, `build:main` copies the seeded default.

> Based on `fix/issue-187-token-attribution` (open PR #188); GitHub will retarget to `main` when it merges.
