### PR TITLE
fix(ui): wheel-scroll and auto-reveal active tab in Tabs strip

### DIFF
--- a/electron/src/renderer/components/ui/Tabs.tsx
+++ b/electron/src/renderer/components/ui/Tabs.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, type ReactNode } from 'react';
+import { useEffect, useRef, type HTMLAttributes, type ReactNode } from 'react';
 
 export type TabsVariant = 'boxed' | 'bordered' | 'lift' | 'pill';
 
@@ -37,8 +37,31 @@ export function Tabs({
   activeItemClassName = '',
   ...props
 }: TabsProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const onWheel = (e: WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) return;
+      if (e.deltaY === 0 || root.scrollWidth <= root.clientWidth) return;
+      e.preventDefault();
+      root.scrollLeft += e.deltaX || e.deltaY;
+    };
+    root.addEventListener('wheel', onWheel, { passive: false });
+    return () => root.removeEventListener('wheel', onWheel);
+  }, []);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const active = root.querySelector<HTMLElement>('[aria-selected="true"]');
+    active?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [value]);
+
   return (
     <div
+      ref={rootRef}
       role="tablist"
       className={`tabs ${VARIANT_CLASS[variant]} ${className}`.trim().replace(/\s+/g, ' ')}
       {...props}


### PR DESCRIPTION
The Configuration tab strip holds 14 tabs but only responded to shift+wheel or horizontal trackpad swipes — a plain mouse wheel did nothing, leaving off-screen tabs unreachable. This was the same bug the session tab bar had (fixed in `35a49c00` for that component only); the shared `Tabs` primitive never received the treatment.

The `Tabs` primitive now translates vertical wheel motion into horizontal scroll (skipped while ctrl/meta is held for zoom, or when the strip fits its container) and scrolls the active tab into view whenever the selection changes. Since ConfigView, ProjectConfigView, AnalyticsView, and the sidebar inspector all render through this primitive, every tab strip is fixed in one place.

Fixes #178
