### PR TITLE
fix(llm): recover tool names for replayed tool results

### DIFF
--- a/electron/src/main/llm/model-messages.ts
+++ b/electron/src/main/llm/model-messages.ts
@@ -39,6 +39,10 @@ export function toModelMessages(
   options: { readonly responsesReplay?: boolean } = {},
 ): ModelMessage[] {
   const modelMessages: ModelMessage[] = [];
+  // tool_call_id → tool name recovered from the paired assistant tool_calls.
+  // Persisted results carry no name; providers like Google serialize this
+  // name on the wire, so 'unknown' must remain a fallback only.
+  const toolNamesByCallId = new Map<string, string>();
 
   for (const message of historyMessages) {
     if (message.role === MessageRole.SYSTEM) {
@@ -87,6 +91,11 @@ export function toModelMessages(
           },
         ];
       }) ?? [];
+      // Record names even when the arguments fail to parse: the id→name
+      // association is a persisted fact, independent of part replayability.
+      for (const toolCall of message.tool_calls ?? []) {
+        toolNamesByCallId.set(toolCall.id, toolCall.function.name);
+      }
 
       const content: AssistantContent = toolCallContent.length > 0
         ? [
@@ -120,8 +129,7 @@ export function toModelMessages(
           {
             type: 'tool-result' as const,
             toolCallId: message.tool_call_id,
-            // The persisted result has no name; AI SDK pairs by toolCallId.
-            toolName: 'unknown',
+            toolName: toolNamesByCallId.get(message.tool_call_id) ?? 'unknown',
             output: { type: 'text', value: textContent },
           },
         ],

--- a/electron/tests/unit/model-messages.test.ts
+++ b/electron/tests/unit/model-messages.test.ts
@@ -101,6 +101,89 @@ describe('toModelMessages', () => {
     ]);
   });
 
+  it('recovers the tool name from the paired assistant tool call', () => {
+    expect(toModelMessages([
+      assistant({
+        content: null,
+        tool_calls: [
+          {
+            id: 'call-read',
+            type: 'function',
+            function: { name: 'read', arguments: '{"path":"README.md"}' },
+          },
+          {
+            id: 'call-grep',
+            type: 'function',
+            function: { name: 'grep', arguments: '{"pattern":"foo"}' },
+          },
+        ],
+      }),
+      { role: 'tool', content: 'result-a', tool_call_id: 'call-read' },
+      { role: 'tool', content: 'result-b', tool_call_id: 'call-grep' },
+    ])).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-read',
+            toolName: 'read',
+            input: { path: 'README.md' },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-grep',
+            toolName: 'grep',
+            input: { pattern: 'foo' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'call-read',
+          toolName: 'read',
+          output: { type: 'text', value: 'result-a' },
+        }],
+      },
+      {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'call-grep',
+          toolName: 'grep',
+          output: { type: 'text', value: 'result-b' },
+        }],
+      },
+    ]);
+  });
+
+  it('recovers the tool name even when the call arguments do not parse', () => {
+    expect(toModelMessages([
+      assistant({
+        content: null,
+        tool_calls: [{
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'read', arguments: '{not json}' },
+        }],
+      }),
+      { role: 'tool', content: 'result', tool_call_id: 'call-1' },
+    ])).toEqual([
+      { role: 'assistant', content: '' },
+      {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'read',
+          output: { type: 'text', value: 'result' },
+        }],
+      },
+    ]);
+  });
+
   it('skips persisted tool results without a tool call ID', () => {
     expect(toModelMessages([
       { role: 'tool', content: 'orphaned result' },


### PR DESCRIPTION
## Summary

Every replayed tool result was sent to providers with `toolName: 'unknown'`, because the persisted result record carries no tool name. Providers that pair results purely by call id (OpenAI, Anthropic) tolerated it, but the Google adapter serializes the name on the wire (`functionResponse.name`), so Gemini sessions sent `name: "unknown"` for every replayed result on every subsequent turn of a session — and the results that outlive compaction had no name anywhere except the XML envelope text.

The name was never actually lost: the paired assistant `tool_calls` message in the same replayed history holds both the id and the name. `toModelMessages` now records that association while walking the history and emits the recovered name on each `tool-result` part. `toApiMessages` already guarantees a result only replays after its paired call, so the lookup hits in practice; `'unknown'` remains only as the orphaned fallback. Names are recorded even when a call's `arguments` fail to parse, since the id→name association is a persisted fact independent of part replayability.

## Test plan

- New regression tests: parallel-call name recovery, and unparseable-arguments recovery (`tests/unit/model-messages.test.ts`).
- Existing orphan-result test still asserts the `'unknown'` fallback.
- Full unit suite: 4,087 passing; the 25 failures in `project-config-view.test.tsx` reproduce on the clean base branch (pre-existing).

Stacked on #190 — merge that first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool results now display the correct tool name when linked to an assistant tool call.
  * Tool names are preserved even when tool-call arguments contain invalid JSON.
  * Unknown tool names continue to use a safe fallback when no matching call is available.

* **Tests**
  * Added coverage for multiple tool results, invalid arguments, and parsed tool output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->