### PR TITLE
perf(tools): trim redundant tokens from tool result projections

### DIFF
--- a/electron/src/main/tools/ast/get-function.ts
+++ b/electron/src/main/tools/ast/get-function.ts
@@ -87,23 +87,24 @@ export const getFunctionHandler: ToolHandler = async (input: unknown, ctx) => {
     try {
       stat = await fs.promises.stat(file_path);
     } catch {
-      return genericBuiltInToolOutcome('get_function', `<ast_error tool="get_function" file="${xmlAttr(file_path)}">` +
-          `File not found: ${file_path}</ast_error>`, 'error');
+      return genericBuiltInToolOutcome('get_function', `File not found: ${file_path}`, 'error');
     }
 
     const names = [function_name.trim()].filter(Boolean);
     if (names.length === 0) {
-      return genericBuiltInToolOutcome('get_function', '<ast_error tool="get_function">No valid function names provided.</ast_error>', 'error');
+      return genericBuiltInToolOutcome('get_function', 'No valid function names provided.', 'error');
     }
 
     const maxFileSize = getToolConfig(ctx).ast_max_file_size;
     if (!stat.isFile()) {
-      return genericBuiltInToolOutcome('get_function', `<ast_error tool="get_function" file="${xmlAttr(file_path)}">` +
-          `Path is not a regular file: ${file_path}</ast_error>`, 'error');
+      return genericBuiltInToolOutcome('get_function', `Path is not a regular file: ${file_path}`, 'error');
     }
     if (stat.size > maxFileSize) {
-      return genericBuiltInToolOutcome('get_function', `<ast_error tool="get_function" file="${xmlAttr(file_path)}">` +
-          `File exceeds AST size limit (${stat.size} bytes; maximum ${maxFileSize} bytes).</ast_error>`, 'error');
+      return genericBuiltInToolOutcome(
+        'get_function',
+        `File exceeds AST size limit (${stat.size} bytes; maximum ${maxFileSize} bytes).`,
+        'error',
+      );
     }
 
     const extraction = await runGetFunctionInWorker({
@@ -118,8 +119,7 @@ export const getFunctionHandler: ToolHandler = async (input: unknown, ctx) => {
       const matches = extraction.functions.filter((item) => item.name === targetName);
       if (matches.length === 0) {
         foundFunctions.push(
-          `<function name="${xmlAttr(targetName)}" ` +
-          `file="${xmlAttr(file_path)}" status="not_found">\n` +
+          `<function name="${xmlAttr(targetName)}" status="not_found">\n` +
           `Function '${targetName}' not found.\n</function>`,
         );
         continue;
@@ -132,7 +132,6 @@ export const getFunctionHandler: ToolHandler = async (input: unknown, ctx) => {
         if (lastHash === currentHash) {
           foundFunctions.push(
             `<function name="${xmlAttr(targetName)}" ` +
-            `file="${xmlAttr(file_path)}" ` +
             `start_line="${match.startLine}" end_line="${match.endLine}">\n` +
             'No changes have been made since last retrieval.\n</function>',
           );
@@ -140,7 +139,6 @@ export const getFunctionHandler: ToolHandler = async (input: unknown, ctx) => {
           const parts: string[] = [];
           parts.push(
             `<function name="${xmlAttr(targetName)}" ` +
-            `file="${xmlAttr(file_path)}" ` +
             `start_line="${match.startLine}" end_line="${match.endLine}">`,
           );
           if (extraction.importsText) {
@@ -169,16 +167,14 @@ export const getFunctionHandler: ToolHandler = async (input: unknown, ctx) => {
     return genericBuiltInToolOutcome('get_function', contentXml, 'complete');
   } catch (err) {
     if (err instanceof GetFunctionCapacityError) {
-      return genericBuiltInToolOutcome('get_function', '<ast_error tool="get_function">' +
-        'AST extraction is at capacity; retry shortly.</ast_error>', 'error');
+      return genericBuiltInToolOutcome('get_function',
+        'AST extraction is at capacity; retry shortly.', 'error');
     }
     if (err instanceof Error && err.message.includes('Unsupported file extension')) {
-      return genericBuiltInToolOutcome('get_function', `<ast_error tool="get_function" file="${xmlAttr(file_path)}">` +
-          `${err.message}</ast_error>`, 'error');
+      return genericBuiltInToolOutcome('get_function', err.message, 'error');
     }
     const msg = err instanceof Error ? err.message : String(err);
-    return genericBuiltInToolOutcome('get_function', `<ast_error tool="get_function" file="${xmlAttr(file_path)}">` +
-        `${msg}</ast_error>`, 'error');
+    return genericBuiltInToolOutcome('get_function', msg, 'error');
   }
 };
 

--- a/electron/src/main/tools/filesystem/apply-patch.ts
+++ b/electron/src/main/tools/filesystem/apply-patch.ts
@@ -55,16 +55,8 @@ const applyPatchAgentProjector: AgentProjector = (canonical, toolName = 'apply_p
   const parsed = applyPatchResultDataSchema.parse(canonical.data);
   const { files, added, modified, deleted, failed } = parsed;
 
-  const summaryParts: string[] = [];
-  if (added > 0) summaryParts.push(`${added} added`);
-  if (modified > 0) summaryParts.push(`${modified} modified`);
-  if (deleted > 0) summaryParts.push(`${deleted} deleted`);
-  if (failed > 0) summaryParts.push(`${failed} failed`);
-  // F11: count unique file paths so multi-operation patches on the same file
-  // don't inflate the file count in the summary.
-  const uniquePaths = new Set(files.map((f) => f.path));
-  const summary = `${uniquePaths.size} file${uniquePaths.size === 1 ? '' : 's'}: ${summaryParts.join(', ')}`;
-
+  // No summary line: the envelope attributes (files/added/modified/deleted/
+  // failed) already carry the counts; a prose summary would restate them.
   const fileSections = files.map((file) => {
     const attrs: Record<string, string | number | undefined> = {
       path: file.path,
@@ -85,7 +77,7 @@ const applyPatchAgentProjector: AgentProjector = (canonical, toolName = 'apply_p
     return `<file${attrString} />`;
   });
 
-  const body = [summary, ...fileSections].join('\n');
+  const body = fileSections.join('\n');
 
   return projectionWithCanonicalCompleteness(
     canonical,

--- a/electron/src/main/tools/result.ts
+++ b/electron/src/main/tools/result.ts
@@ -329,6 +329,35 @@ function renderListMcpResourcesPayload(record: Record<string, JsonValue>): strin
     '\n</resources>';
 }
 
+function renderAskQuestionPayload(record: Record<string, JsonValue>): string {
+  // The questions are intentionally omitted: the agent authored them in the
+  // tool-call args one message earlier. Only the answers are new information.
+  if (record.cancelled === true) return '';
+  const answers = Array.isArray(record.answers)
+    ? record.answers.filter((entry): entry is Record<string, JsonValue> =>
+        entry !== null && typeof entry === 'object' && !Array.isArray(entry))
+    : [];
+  if (answers.length === 0) return '<answers count="0" />';
+  return '<answers count="' + answers.length + '">\n' +
+    answers.map((answer) => {
+      if (answer.skipped === true) return '<answer skipped="true" />';
+      const selected = Array.isArray(answer.selected)
+        ? answer.selected
+            .filter((label): label is string => typeof label === 'string')
+            .join(', ')
+        : '';
+      const attrs = selected.length > 0
+        ? ' selected="' + escapeXmlAttribute(selected) + '"'
+        : '';
+      const text = typeof answer.text === 'string' && answer.text.length > 0
+        ? xmlText(answer.text)
+        : '';
+      if (attrs.length === 0 && text.length === 0) return '<answer />';
+      return '<answer' + attrs + '>' + text + '</answer>';
+    }).join('\n') +
+    '\n</answers>';
+}
+
 function renderFindSymbolReferencesPayload(record: Record<string, JsonValue>): string {
   if (typeof record.error === 'string') return '';
   const references = Array.isArray(record.references)
@@ -424,9 +453,6 @@ function renderReplaceSymbolPayload(record: Record<string, JsonValue>): string {
     'path="' + escapeXmlAttribute(record.file) + '"',
     'success="' + escapeXmlAttribute(record.success ?? true) + '"',
     'replacements="' + escapeXmlAttribute(record.replacements ?? 0) + '"',
-    'replace_all="false"',
-    'added="0"',
-    'removed="0"',
   ];
   if (typeof record.error === 'string') {
     attrs.push('error="' + escapeXmlAttribute(record.error) + '"');
@@ -479,6 +505,7 @@ export const payloadRenderers: ReadonlyMap<string, PayloadRenderer> = new Map([
   ['web_fetch', renderWebFetchPayload],
   ['delegate_to_subagent', renderDelegateToSubagentPayload],
   ['replace_symbol', renderReplaceSymbolPayload],
+  ['ask_question', renderAskQuestionPayload],
 ]);
 
 function renderGenericPayload(
@@ -525,6 +552,11 @@ export const genericAgentProjector: AgentProjector = (canonical, toolName) => {
     typeof value.uri === 'string'
     ? value.uri
     : undefined;
+  // String-valued error outcomes default error.message to the value itself
+  // (genericBuiltInToolOutcome), so rendering both <data> and <error> would
+  // emit the text twice. Emit <error> only.
+  const includeBodyOnError = canonical.status !== 'error'
+    || typeof (generic.success ? generic.data.value : undefined) !== 'string';
   return projectionWithCanonicalCompleteness(
     canonical,
     renderXmlToolResult(
@@ -536,7 +568,7 @@ export const genericAgentProjector: AgentProjector = (canonical, toolName) => {
         ...(resourceUri !== undefined ? { uri: resourceUri } : {}),
       },
       undefined,
-      true,
+      includeBodyOnError,
     ),
   );
 };

--- a/electron/tests/unit/apply-patch.test.ts
+++ b/electron/tests/unit/apply-patch.test.ts
@@ -765,8 +765,8 @@ describe('apply_patch agentProjector', () => {
     expect(result.content).toContain('<file path="src/app.ts" operation="update" status="complete"');
     expect(result.content).toContain('<file path="bad.ts" operation="update" status="error"');
     expect(result.content).toContain('<error code="match_failed"');
-    expect(result.content).toContain('3 files');
-    expect(result.content).toContain('1 failed');
+    expect(result.content).toContain('files="3"');
+    expect(result.content).toContain('failed="1"');
   });
 
   it('renders move_path attribute', () => {
@@ -897,8 +897,10 @@ describe('apply_patch agentProjector', () => {
     expect(result.content).not.toContain('<new_string>');
   });
 
-  it('F11: counts unique file paths in summary (not operations)', () => {
-    // Two operations on the same file — the summary should say "1 file", not "2 files".
+  it('omits the prose summary; envelope attributes carry the counts', () => {
+    // Two operations on the same file. The projection no longer renders a
+    // summary line (it duplicated the envelope's files/added/… attributes);
+    // the counts live only in the attributes.
     const data: ApplyPatchResultData = {
       files: [
         {
@@ -948,7 +950,8 @@ describe('apply_patch agentProjector', () => {
 
     const result = projector(canonical(data));
 
-    expect(result.content).toContain('1 file:');
-    expect(result.content).not.toContain('2 files');
+    expect(result.content).toContain('files="2"');
+    expect(result.content).toContain('modified="2"');
+    expect(result.content).not.toMatch(/\d+ files?:/);
   });
 });

--- a/electron/tests/unit/tool-result-projection.test.ts
+++ b/electron/tests/unit/tool-result-projection.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { genericAgentProjector } from '../../src/main/tools/result';
+import type { CanonicalToolResult } from '../../src/shared/types/tool-result';
+
+function errorCanonical(message: string): CanonicalToolResult {
+  return {
+    schemaVersion: 1,
+    family: 'generic',
+    status: 'error',
+    completeness: 'complete',
+    data: {
+      value: message,
+      origin: { kind: 'built-in', name: 'skill' },
+    },
+    error: { code: 'tool_error', message },
+  } as CanonicalToolResult;
+}
+
+function completeCanonical(value: unknown, name: string): CanonicalToolResult {
+  return {
+    schemaVersion: 1,
+    family: 'generic',
+    status: 'complete',
+    completeness: 'complete',
+    data: { value, origin: { kind: 'built-in', name } },
+  } as CanonicalToolResult;
+}
+
+describe('genericAgentProjector token trims', () => {
+  it('renders string-valued error outcomes once (error element only)', () => {
+    const message = "Error: skill 'x' does not exist.";
+    const projection = genericAgentProjector(errorCanonical(message), 'skill');
+    expect(projection.content).toContain('<error code="tool_error">');
+    expect(projection.content).toContain(message);
+    expect(projection.content).not.toContain('<data>');
+    expect(projection.content.match(new RegExp(message.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')))
+      .toHaveLength(1);
+  });
+
+  it('keeps the body for object-valued error outcomes', () => {
+    const canonical = {
+      ...errorCanonical('Tool execution failed.'),
+      data: {
+        value: { error: 'detail' },
+        origin: { kind: 'built-in', name: 'find_symbol_references' },
+      },
+    } as CanonicalToolResult;
+    const projection = genericAgentProjector(canonical, 'find_symbol_references');
+    expect(projection.content).toContain('<error code="tool_error">');
+  });
+
+  it('renders string values as data for non-error statuses', () => {
+    const projection = genericAgentProjector(
+      completeCanonical('plain output', 'skill'),
+      'skill',
+    );
+    expect(projection.content).toContain('<data>plain output</data>');
+  });
+
+  it('renders ask_question answers without echoing the questions', () => {
+    const projection = genericAgentProjector(
+      completeCanonical(
+        {
+          questions: [{
+            type: 'single',
+            title: 'Which database?',
+            options: [{ label: 'PostgreSQL' }, { label: 'SQLite' }],
+          }],
+          answers: [
+            { selected: ['PostgreSQL'], text: 'hosted please', skipped: false },
+            { selected: [], text: null, skipped: true },
+          ],
+        },
+        'ask_question',
+      ),
+      'ask_question',
+    );
+    expect(projection.content).toContain('<answers count="2">');
+    expect(projection.content).toContain('<answer selected="PostgreSQL">hosted please</answer>');
+    expect(projection.content).toContain('<answer skipped="true" />');
+    expect(projection.content).not.toContain('Which database?');
+    expect(projection.content).not.toContain('SQLite');
+  });
+
+  it('renders ask_question cancellation without the questions payload', () => {
+    const canonical = {
+      ...completeCanonical({ questions: [{ type: 'single', title: 'Q?' }], answers: [], cancelled: true }, 'ask_question'),
+      status: 'cancelled' as const,
+    };
+    const projection = genericAgentProjector(canonical, 'ask_question');
+    expect(projection.content).toContain('status="cancelled"');
+    expect(projection.content).not.toContain('Q?');
+    expect(projection.content).not.toContain('<data>');
+  });
+});


### PR DESCRIPTION
## Summary

Tool results were spending tokens on information the model already had. A per-tool audit of all 33 tool projection surfaces found five clear-cut redundancies, now removed:

- **Error results rendered their text twice.** `genericBuiltInToolOutcome` defaults `error.message` to the string value, and the projector rendered both `<data>` and `<error>` — so every string-valued error from `skill`, `execute_command`, `get_function`, the subagent tools, etc. sent its message twice. The projector now emits `<error>` only for string-valued error outcomes; object-valued errors keep both body and error.
- **`ask_question` echoed the questions back.** The agent authored them in the tool-call args one message earlier; only the answers are new. The agent projection now renders answers only. The canonical value is untouched, so the renderer history widget still shows question titles.
- **`apply_patch` rendered a prose summary** (`3 files: 1 added, 1 modified, 1 failed`) that restated the envelope's `files/added/modified/deleted/failed` attributes.
- **`replace_symbol`** shipped three constant attributes (`replace_all="false" added="0" removed="0"`) identical on every call.
- **`get_function`** wrapped errors in `<ast_error tool="get_function" file="…">` that duplicated the envelope `name=` and its own `file` attribute, and repeated `file=` on every inner `<function>` element under the single-file `<functions file=…>` wrapper.

Estimated ~40–70 tokens saved per affected call; a heavy session with typical error rates saves ~5–15k tokens before cache-read discounts.

Stacked on #191 — merge that first. Tier 2 (arg echoes like grep's `<query directory=…>`) was deferred; several have weak-but-real justifications documented in the audit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified tool error messages for clearer, more consistent output.
  * Removed redundant file details from function result entries while preserving overall file context.
  * Improved handling of generic errors without duplicating error text.

* **Improvements**
  * Streamlined patch results to show per-file details while keeping totals available in summary metadata.
  * Added structured output for questions, including answers, skipped responses, and cancellations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->