### PR TITLE
test: fix jsdom scrollIntoView failures and RAG abort-race flake

### DIFF
--- a/electron/tests/unit/project-config-view.test.tsx
+++ b/electron/tests/unit/project-config-view.test.tsx
@@ -236,6 +236,10 @@ function renderStatic(): string {
 }
 
 beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
   mockOrchid();
 });
 

--- a/electron/tests/unit/rag-pipeline.test.ts
+++ b/electron/tests/unit/rag-pipeline.test.ts
@@ -1169,7 +1169,7 @@ describe('Model Download', () => {
 
     const pending = downloadModel('test/stalled-model', undefined, {
       inactivityTimeoutMs: 20,
-      totalTimeoutMs: 100,
+      totalTimeoutMs: 5000,
     });
 
     await expect(pending).rejects.toThrow(/timed out/i);


### PR DESCRIPTION
## Summary

`npm test` was red on `perf/tool-result-token-trims` (26 failures across 2 files); the suite is green again with no production changes.

25 `project-config-view` failures came from the Tabs auto-reveal added in 3e02de6b — `scrollIntoView` is not implemented in jsdom. The component behavior is correct; the test file just lacked the `HTMLElement.prototype.scrollIntoView` stub its sibling suites already use.

The remaining `rag-pipeline` failure was a load-dependent race, not a real bug: with `inactivityTimeoutMs: 20` / `totalTimeoutMs: 100`, CPU preemption between the two inactivity-timer re-arms could let the total-limit abort fire first, changing the error message the test asserts on. Widening `totalTimeoutMs` to 5000 lets the inactivity watchdog always win; the test still aborts at ~20ms.

Stacked on `perf/tool-result-token-trims` (#192) — merge after it.
