### PR TITLE
fix(tools): keep distinct string payload in error projections

### DIFF
--- a/electron/src/main/tools/result.ts
+++ b/electron/src/main/tools/result.ts
@@ -554,9 +554,14 @@ export const genericAgentProjector: AgentProjector = (canonical, toolName) => {
     : undefined;
   // String-valued error outcomes default error.message to the value itself
   // (genericBuiltInToolOutcome), so rendering both <data> and <error> would
-  // emit the text twice. Emit <error> only.
+  // emit the text twice. Emit <error> only; keep <data> when it differs from
+  // error.message so distinct payload text is not lost.
+  const stringValue = generic.success && typeof generic.data.value === 'string'
+    ? generic.data.value
+    : undefined;
   const includeBodyOnError = canonical.status !== 'error'
-    || typeof (generic.success ? generic.data.value : undefined) !== 'string';
+    || stringValue === undefined
+    || stringValue !== canonical.error.message;
   return projectionWithCanonicalCompleteness(
     canonical,
     renderXmlToolResult(

--- a/electron/tests/unit/tool-result-projection.test.ts
+++ b/electron/tests/unit/tool-result-projection.test.ts
@@ -49,6 +49,19 @@ describe('genericAgentProjector token trims', () => {
     expect(projection.content).toContain('<error code="tool_error">');
   });
 
+  it('keeps the body when a string error value differs from error.message', () => {
+    const canonical = {
+      ...errorCanonical('Command exited with code 1.'),
+      data: {
+        value: 'stderr: ENOENT no such file',
+        origin: { kind: 'built-in', name: 'execute_command' },
+      },
+    } as CanonicalToolResult;
+    const projection = genericAgentProjector(canonical, 'execute_command');
+    expect(projection.content).toContain('<error code="tool_error">Command exited with code 1.</error>');
+    expect(projection.content).toContain('<data>stderr: ENOENT no such file</data>');
+  });
+
   it('renders string values as data for non-error statuses', () => {
     const projection = genericAgentProjector(
       completeCanonical('plain output', 'skill'),


### PR DESCRIPTION
genericAgentProjector dropped <data> for any string-valued error outcome, losing payload text when it differed from error.message. Only omit the body when it equals error.message (the dedup case from genericBuiltInToolOutcome) so distinct values render both.