### PR TITLE
feat(ui): context ring with breakdown per subagent

### DIFF
--- a/electron/src/renderer/components/ChatView.tsx
+++ b/electron/src/renderer/components/ChatView.tsx
@@ -1453,7 +1453,7 @@ export function ChatView({ isVisible = true, bootstrapConfig = null, onNotify, a
               )}
             >
             <DeferredSurface isVisible={isVisible}>
-              <SubagentView subagents={subagents} openRequest={subagentOpenRequest} onBackToChat={() => setContentMode('chat')} />
+              <SubagentView subagents={subagents} openRequest={subagentOpenRequest} modelDetails={providerModelDetails} onBackToChat={() => setContentMode('chat')} />
             </DeferredSurface>
             </Suspense>
           </div>

--- a/electron/src/renderer/components/ContextRadialButton.tsx
+++ b/electron/src/renderer/components/ContextRadialButton.tsx
@@ -1,0 +1,247 @@
+/**
+ * Context radial button — the ring + dropup breakdown shared by the chat
+ * footer and the subagent view detail header (issue 168).
+ *
+ * The panel is fixed-positioned from the trigger rect and rendered through a
+ * portal to document.body: ancestors like the subagent view's container-type
+ * containment (or view-enter transform animations) would otherwise become the
+ * containing block for fixed descendants and skew the coordinates off-screen.
+ */
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+import { createPortal } from 'react-dom';
+import type { Message, Usage } from '../../shared/types/message';
+import { contextUsedTokens } from '../../shared/usage';
+import { ContextBreakdownView, contextPercent } from './ContextGrid';
+import { Icon } from './Icon';
+import { Button } from './ui/Button';
+import { StatusBadge } from './ui/StatusBadge';
+
+/** Panel gap above the trigger (mirrors the footer dropup's mb-1). */
+const PANEL_GAP_PX = 4;
+/** Floor for the clamped height so tiny viewports keep a usable sliver. */
+const PANEL_MIN_HEIGHT_PX = 96;
+/** Must stay in sync with `.orchid-footer-context-panel` width. */
+const PANEL_MAX_WIDTH_PX = 300;
+const PANEL_VIEWPORT_RATIO = 0.8;
+
+/** Fixed-panel anchor derived from the trigger rect, with viewport clamps. */
+interface PanelAnchor {
+  right: number;
+  /** Distance from the viewport top for a downward panel. */
+  top?: number;
+  /** Distance from the viewport bottom for an upward panel. */
+  bottom?: number;
+  maxHeight: number;
+}
+
+interface ContextRadialButtonProps {
+  usage?: Usage | null;
+  messages?: readonly Message[];
+  maxContext?: number | null;
+  streamingThinkingChars?: number;
+  className?: string;
+}
+
+function contextToneClass(percent: number | null, usedTokens: number): string {
+  if (percent == null) return usedTokens > 0 ? 'text-info' : 'text-base-content/25';
+  if (percent >= 85) return 'text-error';
+  if (percent >= 60) return 'text-warning';
+  return percent > 0 ? 'text-info' : 'text-base-content/25';
+}
+
+function badgeTone(percent: number | null): 'error' | 'warning' | 'info' | 'neutral' {
+  if (percent == null) return 'neutral';
+  if (percent >= 85) return 'error';
+  if (percent >= 60) return 'warning';
+  return percent > 0 ? 'info' : 'neutral';
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+/**
+ * Anchor the panel on the side of the trigger with more room: upward when the
+ * trigger sits in the lower half of the viewport (the footer case), downward
+ * otherwise (the subagent detail header). Both directions clamp height so the
+ * panel scrolls internally instead of leaving the viewport.
+ */
+function anchorFromRect(rect: DOMRect): PanelAnchor {
+  const viewportWidth = window.innerWidth || PANEL_MAX_WIDTH_PX;
+  const viewportHeight = window.innerHeight || PANEL_MAX_WIDTH_PX;
+  const panelWidth = Math.min(PANEL_MAX_WIDTH_PX, viewportWidth * PANEL_VIEWPORT_RATIO);
+  const maxRight = Math.max(0, viewportWidth - panelWidth);
+  const right = Math.max(0, Math.min(viewportWidth - rect.right, maxRight));
+  return rect.top > viewportHeight / 2
+    ? {
+        right,
+        bottom: Math.max(0, viewportHeight - rect.top + PANEL_GAP_PX),
+        maxHeight: Math.max(PANEL_MIN_HEIGHT_PX, rect.top - 2 * PANEL_GAP_PX),
+      }
+    : {
+        right,
+        top: Math.max(0, rect.bottom + PANEL_GAP_PX),
+        maxHeight: Math.max(PANEL_MIN_HEIGHT_PX, viewportHeight - rect.bottom - 2 * PANEL_GAP_PX),
+      };
+}
+
+export function ContextRadialButton({
+  usage,
+  messages,
+  maxContext,
+  streamingThinkingChars,
+  className = '',
+}: ContextRadialButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<PanelAnchor | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+
+  const usedTokens = contextUsedTokens(usage);
+  const percent = contextPercent(usage, maxContext);
+
+  const toggle = () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (rect) setAnchor(anchorFromRect(rect));
+    setOpen(true);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      // The panel lives in a portal outside rootRef — check both subtrees.
+      if (rootRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    const reposition = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) setAnchor(anchorFromRect(rect));
+    };
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [open]);
+
+  const label = percent == null
+    ? usedTokens > 0
+      ? `${formatTokens(usedTokens)} context tokens used; context window loading`
+      : 'Context usage unavailable'
+    : `${percent}% context used`;
+
+  return (
+    <div ref={rootRef} data-context-radial-dropup className={`shrink-0 ${className}`.trim()}>
+      <Button
+        ref={triggerRef}
+        variant="ghost"
+        shape="circle"
+        size="xs"
+        className="orchid-footer-context-btn"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={panelId}
+        title={percent == null
+          ? usedTokens > 0
+            ? `${formatTokens(usedTokens)} context tokens used`
+            : 'Context usage unavailable'
+          : `${percent}% context`}
+        onClick={toggle}
+      >
+        <div
+          className={`radial-progress orchid-footer-context-radial ${contextToneClass(percent, usedTokens)}`}
+          style={
+            {
+              '--value': percent ?? 0,
+              '--size': '1.4rem',
+              '--thickness': '2px',
+            } as CSSProperties
+          }
+          aria-valuenow={percent ?? 0}
+          role="progressbar"
+          aria-label={label}
+        >
+          <span className="footer-context-value">
+            {percent == null ? '—' : percent}
+          </span>
+        </div>
+      </Button>
+      {open && createPortal(
+        <div
+          ref={panelRef}
+          id={panelId}
+          role="dialog"
+          aria-label="Context breakdown"
+          className="orchid-footer-context-panel z-50"
+          style={anchor
+            ? {
+                position: 'fixed',
+                right: `${anchor.right}px`,
+                maxHeight: `${anchor.maxHeight}px`,
+                overflowY: 'auto',
+                ...(anchor.bottom != null
+                  ? { bottom: `${anchor.bottom}px` }
+                  : { top: `${anchor.top}px` }),
+              }
+            : { position: 'fixed', visibility: 'hidden' }}
+        >
+          <div className="footer-context-panel-header">
+            <div className="footer-context-panel-title">
+              <Icon name="layers" size={12} className="opacity-70" />
+              <span>Context</span>
+            </div>
+            <div className="footer-context-panel-meta mono">
+              <StatusBadge tone={badgeTone(percent)} size="xs">
+                {percent == null
+                  ? usedTokens > 0
+                    ? `${formatTokens(usedTokens)} used`
+                    : 'window loading'
+                  : `${percent}% used`}
+              </StatusBadge>
+              {maxContext && maxContext > 0 ? (
+                <span className="footer-context-panel-window">
+                  {formatTokens(maxContext)} window
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <div className="footer-context-panel-body">
+            <ContextBreakdownView
+              usage={usage}
+              messages={messages}
+              maxContext={maxContext}
+              streamingThinkingChars={streamingThinkingChars}
+              variant="panel"
+            />
+          </div>
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/electron/src/renderer/components/Footer.tsx
+++ b/electron/src/renderer/components/Footer.tsx
@@ -5,7 +5,7 @@
  * Right: model picker + context radial with dropup breakdown.
  * Wording mirrors the multi-stage cancel button on the composer.
  */
-import { memo, useCallback, useEffect, useId, useRef, useState, type CSSProperties } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import type { Message, Usage } from '../../shared/types/message';
 import type { CommandContext } from '../../shared/types/ipc-boundary';
 import type {
@@ -21,17 +21,14 @@ import type { PermissionMode } from '../../shared/types/permission';
 import { useElapsedSeconds, type InterruptState } from '../hooks/useChat';
 import { FOOTER_SHORTCUT_IDS, getShortcut } from '../keyboard';
 import { resolveModelNotifyLabel } from '../utils/provider-selection';
-import { ContextBreakdownView, contextPercent as getContextPercent } from './ContextGrid';
-import { contextUsedTokens } from '../../shared/usage';
+import { ContextRadialButton } from './ContextRadialButton';
 import { Icon } from './Icon';
 import { Keycaps } from './Keycaps';
 import { ModelPicker } from './ModelPicker';
 import { PermissionSelector } from './PermissionSelector';
 import { ReasoningSelector, shouldShowReasoningSelector } from './ReasoningSelector';
 import { ServiceTierSelector, shouldShowServiceTierSelector } from './ServiceTierSelector';
-import { Button } from './ui/Button';
 import { Spinner } from './ui/Spinner';
-import { StatusBadge } from './ui/StatusBadge';
 
 /** Orders async permission-mode reads and writes so stale responses cannot commit. */
 export class PermissionModeCoordinator {
@@ -129,8 +126,6 @@ export const Footer = memo(function Footer({
     streamStartTime,
     isVisible && (isStreaming || Boolean(confirming)),
   );
-  const [contextOpen, setContextOpen] = useState(false);
-  const contextMenuId = useId();
   const [reasoningConfig, setReasoningConfig] = useState<SessionReasoningConfigResult | null>(null);
   const [serviceTierConfig, setServiceTierConfig] = useState<SessionServiceTierConfigResult | null>(null);
   const [sessionPermissionMode, setSessionPermissionMode] = useState<PermissionMode | null>(permissionMode);
@@ -142,39 +137,6 @@ export const Footer = memo(function Footer({
   reasoningOverrideRef.current = reasoningEffortOverride;
   serviceTierOverrideRef.current = serviceTierOverride;
   const isDraft = sessionId == null;
-
-  const usedContextTokens = contextUsedTokens(usage);
-  const contextPercent = getContextPercent(usage, maxContext);
-
-  const contextTone =
-    contextPercent == null
-      ? usedContextTokens > 0 ? 'text-info' : 'text-base-content/25'
-      : contextPercent >= 85
-        ? 'text-error'
-        : contextPercent >= 60
-          ? 'text-warning'
-          : contextPercent > 0
-            ? 'text-info'
-            : 'text-base-content/25';
-
-  useEffect(() => {
-    if (!contextOpen) return;
-    const onPointer = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (!target?.closest('[data-footer-context-dropup]')) {
-        setContextOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setContextOpen(false);
-    };
-    document.addEventListener('mousedown', onPointer);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [contextOpen]);
 
   useEffect(() => {
     let cancelled = false;
@@ -272,15 +234,6 @@ export const Footer = memo(function Footer({
     );
     return () => coordinator.invalidate();
   }, [permissionMode, sessionId]);
-
-  const badgeTone =
-    contextPercent != null && contextPercent >= 85
-      ? 'error'
-      : contextPercent != null && contextPercent >= 60
-        ? 'warning'
-        : contextPercent != null && contextPercent > 0
-          ? 'info'
-          : 'neutral';
 
   const availableModels = commandContext?.getAvailableModels() ?? [];
 
@@ -441,86 +394,12 @@ export const Footer = memo(function Footer({
           />
         )}
 
-      <div
-        className={`dropdown dropdown-top dropdown-end shrink-0 ${contextOpen ? 'dropdown-open' : ''}`}
-        data-footer-context-dropup
-      >
-        <Button
-          variant="ghost"
-          shape="circle"
-          size="xs"
-          className="orchid-footer-context-btn"
-          aria-haspopup="dialog"
-          aria-expanded={contextOpen}
-          aria-controls={contextMenuId}
-          title={contextPercent == null
-            ? usedContextTokens > 0
-              ? `${formatTokens(usedContextTokens)} context tokens used`
-              : 'Context usage unavailable'
-            : `${contextPercent}% context`}
-          onClick={() => setContextOpen((o) => !o)}
-        >
-          <div
-            className={`radial-progress orchid-footer-context-radial ${contextTone}`}
-            style={
-              {
-                '--value': contextPercent ?? 0,
-                '--size': '1.4rem',
-                '--thickness': '2px',
-              } as CSSProperties
-            }
-            aria-valuenow={contextPercent ?? 0}
-            role="progressbar"
-            aria-label={contextPercent == null
-              ? usedContextTokens > 0
-                ? `${formatTokens(usedContextTokens)} context tokens used; context window loading`
-                : 'Context usage unavailable'
-              : `${contextPercent}% context used`}
-          >
-            <span className="footer-context-value">
-              {contextPercent == null ? '—' : contextPercent}
-            </span>
-          </div>
-        </Button>
-        {contextOpen && (
-          <div
-            id={contextMenuId}
-            role="dialog"
-            aria-label="Context breakdown"
-            className="dropdown-content orchid-footer-context-panel z-50 mb-1"
-          >
-            <div className="footer-context-panel-header">
-              <div className="footer-context-panel-title">
-                <Icon name="layers" size={12} className="opacity-70" />
-                <span>Context</span>
-              </div>
-              <div className="footer-context-panel-meta mono">
-                <StatusBadge tone={badgeTone} size="xs">
-                  {contextPercent == null
-                    ? usedContextTokens > 0
-                      ? `${formatTokens(usedContextTokens)} used`
-                      : 'window loading'
-                    : `${contextPercent}% used`}
-                </StatusBadge>
-                {maxContext && maxContext > 0 ? (
-                  <span className="footer-context-panel-window">
-                    {formatTokens(maxContext)} window
-                  </span>
-                ) : null}
-              </div>
-            </div>
-            <div className="footer-context-panel-body">
-              <ContextBreakdownView
-                usage={usage}
-                messages={messages}
-                maxContext={maxContext}
-                streamingThinkingChars={streamingThinkingChars}
-                variant="panel"
-              />
-            </div>
-          </div>
-        )}
-      </div>
+        <ContextRadialButton
+          usage={usage}
+          messages={messages}
+          maxContext={maxContext}
+          streamingThinkingChars={streamingThinkingChars}
+        />
       </div>
     </div>
   );
@@ -533,10 +412,4 @@ function formatElapsed(seconds: number): string {
   const mins = Math.floor(seconds / 60);
   const secs = Math.floor(seconds % 60);
   return `${mins}m ${secs}s`;
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
-  return String(n);
 }

--- a/electron/src/renderer/components/SubagentView.tsx
+++ b/electron/src/renderer/components/SubagentView.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
+import type { ProviderModelOption } from '../../shared/types/ipc';
 import type { SubagentSummary } from '../../shared/types/subagent';
+import type { Usage } from '../../shared/types/message';
 import type { UseSubagentsReturn } from '../hooks/useSubagents';
+import { contextTokensForSelection } from '../utils/provider-selection';
 import { formatUsageSummary } from '../utils/format-usage';
+import { ContextRadialButton } from './ContextRadialButton';
 import { SubagentTranscript } from './SubagentTranscript';
 import { Button } from './ui/Button';
 import { Disclosure } from './ui/Disclosure';
@@ -15,6 +19,8 @@ interface SubagentViewProps {
   subagents: UseSubagentsReturn;
   onBackToChat: () => void;
   openRequest: SubagentOpenRequest;
+  /** Typed model metadata used to resolve the selected subagent's context window. */
+  modelDetails?: Readonly<Record<string, ProviderModelOption>>;
 }
 
 export interface SubagentOpenRequest {
@@ -80,10 +86,11 @@ function SubagentRow({
   );
 }
 
-export function SubagentView({ subagents, onBackToChat, openRequest }: SubagentViewProps) {
+export function SubagentView({ subagents, onBackToChat, openRequest, modelDetails }: SubagentViewProps) {
   const initialOpen = resolveSubagentOpenRequest(openRequest);
   const [narrowDetail, setNarrowDetail] = useState(initialOpen.narrowDetail);
   const appliedOpenGeneration = useRef<number | null>(null);
+  const thinkingBaselineRef = useRef<{ id: string; usage: Usage; chars: number } | null>(null);
   const records = subagents.subagents;
   const hasPendingOpenRequest = appliedOpenGeneration.current !== openRequest.generation;
   const effectiveSelectedId = hasPendingOpenRequest ? openRequest.id : subagents.selectedId;
@@ -148,6 +155,40 @@ export function SubagentView({ subagents, onBackToChat, openRequest }: SubagentV
   );
 
   const detail = selected ? subagents.getDetail(selected.id) : null;
+  const transcriptRecord = subagents.transcript.status === 'ready'
+    ? subagents.transcript.record
+    : null;
+  // Guard the one-frame stale transcript after a selection change: only use
+  // the record when it belongs to the selected row.
+  const transcriptChain = transcriptRecord && selected && transcriptRecord.id === selected.id
+    ? transcriptRecord.chain
+    : null;
+  const live = selected ? subagents.getLive(selected.id) : null;
+  const openThinkingChars = live
+    ? live.segments.reduce(
+        (total, segment) =>
+          segment.kind === 'thinking' && segment.endedAt == null
+            ? total + segment.content.length
+            : total,
+        0,
+      )
+    : 0;
+  // Thinking chars not yet covered by a usage event — mirrors the main
+  // agent's streamingUnaccountedThinkingChars (issue 187): the projection
+  // closes segments lazily, so an open segment can already be counted in the
+  // last usage event. Record the open-char baseline per usage reference and
+  // subtract it before estimating in-flight reasoning.
+  if (selected && live?.usage) {
+    const baseline = thinkingBaselineRef.current;
+    if (!baseline || baseline.id !== selected.id || baseline.usage !== live.usage) {
+      thinkingBaselineRef.current = { id: selected.id, usage: live.usage, chars: openThinkingChars };
+    }
+  }
+  const baseline = thinkingBaselineRef.current;
+  const streamingThinkingChars = baseline && selected && baseline.id === selected.id
+    ? Math.max(0, openThinkingChars - baseline.chars)
+    : 0;
+  const subagentMaxContext = contextTokensForSelection(transcriptChain?.selection ?? null, modelDetails);
   const detailRegion = (
     <Panel className="orchid-subagent-view-detail" padded={false} aria-label="Subagent detail">
       <div className="orchid-subagent-view-detail-header">
@@ -155,7 +196,19 @@ export function SubagentView({ subagents, onBackToChat, openRequest }: SubagentV
         {selected ? (
           <SectionHeader
             title={selected.agent_name || 'Subagent'}
-            actions={<StatusBadge tone={statusTone(detail?.state ?? selected.status)}>{statusLabel(detail?.state ?? selected.status)}</StatusBadge>}
+            actions={(
+              <>
+                <StatusBadge tone={statusTone(detail?.state ?? selected.status)}>{statusLabel(detail?.state ?? selected.status)}</StatusBadge>
+                {detail ? (
+                  <ContextRadialButton
+                    usage={detail.usage}
+                    messages={transcriptChain?.messages}
+                    maxContext={subagentMaxContext}
+                    streamingThinkingChars={streamingThinkingChars || undefined}
+                  />
+                ) : null}
+              </>
+            )}
           />
         ) : null}
       </div>

--- a/electron/src/renderer/utils/provider-selection.ts
+++ b/electron/src/renderer/utils/provider-selection.ts
@@ -14,6 +14,19 @@ export function selectionKey(selection: ModelSelection | null | undefined): stri
   return selection ? `${selection.connectionId}\u001f${selection.modelId}` : '';
 }
 
+/**
+ * Context window (tokens) for an arbitrary selection — e.g. a subagent
+ * chain's persisted `chain.selection` — resolved against typed model
+ * metadata. Null when the selection or its model limits are unknown.
+ */
+export function contextTokensForSelection(
+  selection: ModelSelection | null | undefined,
+  optionDetails?: Readonly<Record<string, ProviderModelOption>>,
+): number | null {
+  if (!selection || !optionDetails) return null;
+  return optionDetails[selectionKey(selection)]?.model.limits?.contextTokens ?? null;
+}
+
 export function providerModelOptionDisplayName(option: ProviderModelOption): string {
   return option.model.displayName;
 }

--- a/electron/tests/integration/renderer-style-contract.test.ts
+++ b/electron/tests/integration/renderer-style-contract.test.ts
@@ -574,10 +574,9 @@ const BASELINE_COMPONENT_ROOT_HITS: ReadonlySet<string> = new Set([
   'components/CommandPalette.tsx::input',
   'components/ConfigView.tsx::btn',
   'components/ConfigView.tsx::modal',
-  
-  'components/Footer.tsx::dropdown',
-  'components/Footer.tsx::footer',
-  
+
+  'components/ContextRadialButton.tsx::footer',
+
   'components/InputArea.tsx::alert',
   'components/InputArea.tsx::btn',
   'components/LeftSidebar.tsx::status',
@@ -610,7 +609,7 @@ const BASELINE_COMPONENT_ROOT_HITS: ReadonlySet<string> = new Set([
 ]);
 
 /** Total component-root token occurrences captured at baseline time (count guard). */
-const BASELINE_COMPONENT_ROOT_TOTAL_TOKENS = 68;
+const BASELINE_COMPONENT_ROOT_TOTAL_TOKENS = 66;
 
 const BASELINE_NON_TOKEN_COLORS: ReadonlyMap<string, number> = new Map([
 ]);

--- a/electron/tests/unit/composer-contract.test.ts
+++ b/electron/tests/unit/composer-contract.test.ts
@@ -128,10 +128,13 @@ describe('composer contract (U6)', () => {
 
     it('footer uses the radial context indicator and stacked dropup bar', () => {
       const src = read('components/Footer.tsx');
-      expect(src).toMatch(/radial-progress/);
-      expect(src).toMatch(/ContextBreakdownView/);
+      expect(src).toMatch(/ContextRadialButton/);
       expect(src).toMatch(/<Spinner\b/);
       expect(src).toMatch(/Keycaps/);
+      // The shared radial (footer + subagent view) owns the indicator markup.
+      const radialSrc = read('components/ContextRadialButton.tsx');
+      expect(radialSrc).toMatch(/radial-progress/);
+      expect(radialSrc).toMatch(/ContextBreakdownView/);
     });
 
     it('command palette avoids arbitrary Tailwind values for layout chrome', () => {

--- a/electron/tests/unit/context-radial-button.test.tsx
+++ b/electron/tests/unit/context-radial-button.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * ContextRadialButton — the shared context ring + dropup breakdown extracted
+ * from the chat footer and reused per-subagent in the subagent view (issue 168).
+ */
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ContextRadialButton } from '../../src/renderer/components/ContextRadialButton';
+import type { Usage } from '../../src/shared/types/message';
+
+const CONTEXT_USAGE: Usage = {
+  prompt_tokens: 900,
+  completion_tokens: 100,
+  total_tokens: 1_000,
+  cached_tokens: 0,
+  context: {
+    input_tokens: 800,
+    output_tokens: 200,
+    used_tokens: 500,
+    system_tokens: 100,
+    tools_tokens: 50,
+    tool_use_tokens: 100,
+    user_tokens: 150,
+    assistant_tokens: 100,
+  },
+};
+
+afterEach(cleanup);
+
+/** The panel is portaled to document.body — not inside the render container. */
+function queryPanel(): HTMLElement | null {
+  return document.body.querySelector('[role="dialog"]');
+}
+
+describe('ContextRadialButton', () => {
+  it('renders the percent of the resolved window without opening the panel', () => {
+    const { container } = render(
+      <ContextRadialButton usage={CONTEXT_USAGE} maxContext={1_000} />,
+    );
+    const radial = container.querySelector('.orchid-footer-context-radial');
+    expect(radial).not.toBeNull();
+    expect(radial?.getAttribute('aria-valuenow')).toBe('50');
+    expect(container.querySelector('.footer-context-value')?.textContent).toBe('50');
+    expect(queryPanel()).toBeNull();
+  });
+
+  it('shows the em dash while the window is unknown but tokens were used', () => {
+    const { container } = render(
+      <ContextRadialButton usage={CONTEXT_USAGE} maxContext={null} />,
+    );
+    expect(container.querySelector('.footer-context-value')?.textContent).toBe('—');
+    expect(container.querySelector('.orchid-footer-context-radial')?.getAttribute('aria-label'))
+      .toContain('context window loading');
+  });
+
+  it('opens the fixed-position breakdown panel on click and closes it on Escape', () => {
+    const { container } = render(
+      <ContextRadialButton usage={CONTEXT_USAGE} maxContext={1_000} messages={[]} />,
+    );
+    fireEvent.click(container.querySelector('button')!);
+    const panel = queryPanel();
+    expect(panel).not.toBeNull();
+    // Portal: the panel escapes any ancestor containment (container-type,
+    // transforms) that would skew fixed-position coordinates.
+    expect(panel?.parentElement).toBe(document.body);
+    expect(panel?.getAttribute('aria-label')).toBe('Context breakdown');
+    expect(panel?.textContent).toContain('System');
+    expect(panel?.textContent).toContain('1.0k window');
+    expect(panel?.getAttribute('style')).toContain('position: fixed');
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(queryPanel()).toBeNull();
+  });
+
+  it('closes the panel on an outside mousedown', () => {
+    const { container } = render(
+      <ContextRadialButton usage={CONTEXT_USAGE} maxContext={1_000} />,
+    );
+    fireEvent.click(container.querySelector('button')!);
+    expect(queryPanel()).not.toBeNull();
+    fireEvent.mouseDown(document.body);
+    expect(queryPanel()).toBeNull();
+  });
+
+  it('keeps the panel open for clicks inside the portaled panel', () => {
+    const { container } = render(
+      <ContextRadialButton usage={CONTEXT_USAGE} maxContext={1_000} messages={[]} />,
+    );
+    fireEvent.click(container.querySelector('button')!);
+    fireEvent.mouseDown(queryPanel()!);
+    expect(queryPanel()).not.toBeNull();
+  });
+
+  it('opens downward with a clamped max-height when the trigger is near the top', () => {
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({ top: 100, bottom: 130, right: 900 } as DOMRect);
+    try {
+      const { container } = render(
+        <ContextRadialButton usage={CONTEXT_USAGE} maxContext={1_000} />,
+      );
+      fireEvent.click(container.querySelector('button')!);
+      const style = queryPanel()?.getAttribute('style') ?? '';
+      expect(style).toContain(`top: ${130 + 4}px`);
+      expect(style).not.toContain('bottom:');
+      expect(style).toContain('max-height:');
+      expect(style).toContain('overflow-y: auto');
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('opens upward (footer parity) when the trigger is near the bottom', () => {
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({ top: 700, bottom: 730, right: 900 } as DOMRect);
+    try {
+      const { container } = render(
+        <ContextRadialButton usage={CONTEXT_USAGE} maxContext={1_000} />,
+      );
+      fireEvent.click(container.querySelector('button')!);
+      const style = queryPanel()?.getAttribute('style') ?? '';
+      expect(style).toContain(`bottom: ${768 - 700 + 4}px`);
+      expect(style).not.toContain('top:');
+      expect(style).toContain('max-height:');
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+});

--- a/electron/tests/unit/subagent-view-context.test.tsx
+++ b/electron/tests/unit/subagent-view-context.test.tsx
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+/**
+ * SubagentView context ring (issue 168): the selected subagent's detail header
+ * shows the same context radial as the main agent footer, with the context
+ * window resolved from the subagent chain's persisted model selection.
+ */
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SubagentView } from '../../src/renderer/components/SubagentView';
+import { buildSubagentDetail, type UseSubagentsReturn } from '../../src/renderer/hooks/useSubagents';
+import { contextTokensForSelection } from '../../src/renderer/utils/provider-selection';
+import type { ProviderModelOption } from '../../src/shared/types/ipc';
+import type { Chain } from '../../src/shared/types/chain';
+import type { ModelSelection } from '../../src/shared/types/provider';
+import { MessageRole, MessageType, type Message, type Usage } from '../../src/shared/types/message';
+import type {
+  SubagentLiveProjection,
+  SubagentRecord,
+  SubagentSummary,
+} from '../../src/shared/types/subagent';
+import { EMPTY_SUBAGENT_USAGE_SUMMARY } from '../../src/shared/usage';
+
+const CONNECTION_ID = '11111111-1111-4111-8111-111111111111';
+const SELECTION: ModelSelection = { connectionId: CONNECTION_ID, modelId: 'sonnet' };
+const SELECTION_KEY = `${CONNECTION_ID}\u001fsonnet`;
+
+const MODEL_DETAILS: Readonly<Record<string, ProviderModelOption>> = {
+  [SELECTION_KEY]: {
+    selection: SELECTION,
+    connectionName: 'Main',
+    providerId: 'anthropic',
+    providerDisplayName: 'Anthropic',
+    model: {
+      id: 'sonnet',
+      displayName: 'Sonnet',
+      protocol: 'anthropic-messages',
+      lifecycle: 'active',
+      source: 'catalog',
+      capabilities: null,
+      limits: { contextTokens: 200_000, outputTokens: 8_192 },
+    },
+    enabled: true,
+    customized: false,
+    discoveredAt: null,
+    available: true,
+    unavailableReason: null,
+  },
+};
+
+const USAGE: Usage = {
+  prompt_tokens: 900,
+  completion_tokens: 100,
+  total_tokens: 1_000,
+  cached_tokens: 0,
+  context: {
+    input_tokens: 800,
+    output_tokens: 200,
+    used_tokens: 100_000,
+    system_tokens: 10_000,
+    tools_tokens: 5_000,
+    tool_use_tokens: 20_000,
+    user_tokens: 30_000,
+    assistant_tokens: 35_000,
+  },
+};
+
+function message(id: string, content: string): Message {
+  return {
+    id,
+    role: MessageRole.ASSISTANT,
+    content,
+    type: MessageType.TEXT,
+    tool_calls: null,
+    tool_call_id: null,
+    name: null,
+    thinking: null,
+    timestamp: '2026-08-21T00:00:00.000Z',
+    usage: null,
+    hidden: false,
+    tool_result: null,
+  };
+}
+
+function makeChain(selection: ModelSelection | null): Chain {
+  return {
+    id: 'chain-1',
+    sessionId: 'session-1',
+    status: 'completed',
+    messages: [message('m-1', 'explored the repo')],
+    selection,
+    modelLabel: selection?.modelId ?? null,
+    agentName: 'explorer',
+    agentType: 'explorer',
+    agentTier: 'bloom',
+    startTime: '2026-08-21T00:00:00.000Z',
+    endTime: '2026-08-21T00:01:00.000Z',
+    subagentRecord: null,
+  };
+}
+
+function makeRecord(chain: Chain, id = 'sub-1'): SubagentRecord {
+  return {
+    id,
+    agent_name: 'explorer',
+    agent_type: 'explorer',
+    agent_tier: 'bloom',
+    task: 'explore',
+    status: 'completed',
+    chain_id: chain.id,
+    start_time: '2026-08-21T00:00:00.000Z',
+    end_time: '2026-08-21T00:01:00.000Z',
+    result: null,
+    error: null,
+    parentChainIndex: null,
+    usage: USAGE,
+    closed: false,
+    chain,
+  };
+}
+
+function makeSummary(): SubagentSummary {
+  return {
+    id: 'sub-1',
+    agent_name: 'explorer',
+    agent_type: 'explorer',
+    agent_tier: 'bloom',
+    agentRole: 'explorer',
+    task: 'explore',
+    status: 'completed',
+    chain_id: 'chain-1',
+    start_time: '2026-08-21T00:00:00.000Z',
+    end_time: '2026-08-21T00:01:00.000Z',
+    parentChainIndex: null,
+    usage: USAGE,
+  };
+}
+
+function makeHook(record: SubagentRecord, live: SubagentLiveProjection | null = null): UseSubagentsReturn {
+  const summary = makeSummary();
+  return {
+    state: { status: 'ready', subagents: [summary] },
+    subagents: [summary],
+    groups: { queued: [], running: [], ended: [summary] },
+    totalUsage: USAGE,
+    usageByParentChain: new Map(),
+    usageSummary: EMPTY_SUBAGENT_USAGE_SUMMARY,
+    refresh: vi.fn(),
+    retry: vi.fn(),
+    isRetrying: false,
+    selectedId: 'sub-1',
+    select: vi.fn(),
+    getDetail: (id: string) => (id === 'sub-1' ? buildSubagentDetail(summary, Date.parse('2026-08-21T00:01:00.000Z'), live) : null),
+    transcript: { status: 'ready', record },
+    retryTranscript: vi.fn(),
+    live: new Map(),
+    getLive: () => live,
+  };
+}
+
+function liveWithOpenThinking(usage: Usage, thinkingChars: number): SubagentLiveProjection {
+  return {
+    sessionId: 'session-1',
+    subagentId: 'sub-1',
+    runId: 'run-1',
+    sequence: 1,
+    state: 'running',
+    segments: [
+      // Closed segments must never contribute to the streaming estimate.
+      { kind: 'thinking', id: 'seg-closed', content: 'y'.repeat(500_000), startedAt: '2026-08-21T00:00:10.000Z', endedAt: '2026-08-21T00:00:20.000Z' },
+      { kind: 'thinking', id: 'seg-open', content: 'x'.repeat(thinkingChars), startedAt: '2026-08-21T00:00:21.000Z', endedAt: null },
+    ],
+    toolCalls: [],
+    usage,
+    result: null,
+    error: null,
+    compactionProgress: null,
+  };
+}
+
+function renderView(hook: UseSubagentsReturn, modelDetails?: Readonly<Record<string, ProviderModelOption>>) {
+  return render(
+    <SubagentView
+      subagents={hook}
+      openRequest={{ generation: 0, id: 'sub-1' }}
+      modelDetails={modelDetails}
+      onBackToChat={() => {}}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+/** The context panel is portaled to document.body by ContextRadialButton. */
+function queryPanel(): HTMLElement | null {
+  return document.body.querySelector('[role="dialog"]');
+}
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(),
+  });
+});
+
+describe('contextTokensForSelection', () => {
+  it('resolves the window from typed model metadata', () => {
+    expect(contextTokensForSelection(SELECTION, MODEL_DETAILS)).toBe(200_000);
+  });
+
+  it('returns null without a selection or matching metadata', () => {
+    expect(contextTokensForSelection(null, MODEL_DETAILS)).toBeNull();
+    expect(contextTokensForSelection(SELECTION, undefined)).toBeNull();
+    expect(contextTokensForSelection(SELECTION, {})).toBeNull();
+  });
+});
+
+describe('SubagentView context ring', () => {
+  it('renders the radial for the selected subagent with the chain model window', () => {
+    const { container } = renderView(makeHook(makeRecord(makeChain(SELECTION))), MODEL_DETAILS);
+    const radial = container.querySelector('.orchid-footer-context-radial');
+    expect(radial).not.toBeNull();
+    expect(radial?.getAttribute('aria-valuenow')).toBe('50');
+
+    fireEvent.click(container.querySelector('.orchid-footer-context-btn')!);
+    expect(queryPanel()?.textContent).toContain('200.0k window');
+  });
+
+  it('degrades to the unknown-window state for legacy chains without a selection', () => {
+    const { container } = renderView(makeHook(makeRecord(makeChain(null))), MODEL_DETAILS);
+    const radial = container.querySelector('.orchid-footer-context-radial');
+    expect(radial).not.toBeNull();
+    expect(container.querySelector('.footer-context-value')?.textContent).toBe('—');
+    expect(radial?.getAttribute('aria-label')).toContain('context window loading');
+  });
+
+  it('degrades to the unknown-window state when model metadata is unavailable', () => {
+    const { container } = renderView(makeHook(makeRecord(makeChain(SELECTION))), undefined);
+    expect(container.querySelector('.footer-context-value')?.textContent).toBe('—');
+  });
+
+  it('counts only open thinking chars that arrived after the last usage event', () => {
+    const record = makeRecord(makeChain(SELECTION));
+    const view = renderView(makeHook(record, liveWithOpenThinking(USAGE, 800)), MODEL_DETAILS);
+    fireEvent.click(view.container.querySelector('.orchid-footer-context-btn')!);
+    // The usage event covered the open segment's 800 chars: free stays 100.0k
+    // (used 100k of the 200k window) with no double-counted estimate.
+    expect(queryPanel()?.textContent).toContain('100.0k');
+    // The segment grows by 40,000 chars with the same usage reference → only
+    // the growth (10k tokens) joins the estimate: free drops to 90.0k.
+    view.rerender(
+      <SubagentView
+        subagents={makeHook(record, liveWithOpenThinking(USAGE, 40_800))}
+        openRequest={{ generation: 0, id: 'sub-1' }}
+        modelDetails={MODEL_DETAILS}
+        onBackToChat={() => {}}
+      />,
+    );
+    const panel = queryPanel();
+    expect(panel?.textContent).toContain('90.0k');
+    expect(panel?.textContent).not.toContain('100.0k');
+  });
+
+  it('ignores a stale transcript that belongs to another subagent', () => {
+    const otherRecord = makeRecord(makeChain(SELECTION), 'sub-other');
+    const { container } = renderView(makeHook(otherRecord), MODEL_DETAILS);
+    const radial = container.querySelector('.orchid-footer-context-radial');
+    expect(radial).not.toBeNull();
+    // Window cannot resolve from another row's chain selection.
+    expect(container.querySelector('.footer-context-value')?.textContent).toBe('—');
+    fireEvent.click(container.querySelector('.orchid-footer-context-btn')!);
+    expect(queryPanel()?.textContent).not.toContain('200.0k window');
+  });
+});


### PR DESCRIPTION
## Summary

Selecting a subagent now shows its own context ring — the same radial + breakdown dropup as the main agent's footer — in the detail header. The window, usage, and per-category split all come from that subagent's run: its model's context window, its live (or persisted) usage snapshot, and its transcript messages for the category split. Previously there was no way to see how full a subagent's context was, even though subagents compact and overflow independently of the main conversation.

Degradation paths match the footer: a legacy chain without a persisted model selection, or a model missing from the provider metadata, renders the existing "— / window loading" ring instead of a wrong number.

Design notes:

- The footer's radial + dropup markup was extracted into a shared `ContextRadialButton` rather than duplicated — both surfaces now share tone thresholds, aria wiring, and the breakdown panel.
- The panel renders through a portal to `document.body` with fixed positioning computed from the trigger rect. The subagent view's `container-type: inline-size` containment (and view-enter `transform` animations) would otherwise become the containing block for fixed descendants and push the panel off-screen. It opens toward whichever side of the trigger has room and clamps height with internal scroll.
- The subagent window resolves from the chain's persisted `ModelSelection` (`contextTokensForSelection`), so subagents running a different model than the chat show their real window.
- In-flight reasoning passes only thinking chars that arrived after the last usage event — the same accounting as the main agent (issue 187) — so open thinking segments don't double-count against provider-reported tokens.
- A transcript owned by a different subagent (one-frame stale after a selection change) is ignored rather than mixing one row's usage with another's window/messages.

## Test plan

- `context-radial-button.test.tsx` — percent/unknown-window rendering, open/close (click, Escape, outside-click, click inside the portaled panel), downward vs upward anchoring with clamped max-height, portal parent assertion.
- `subagent-view-context.test.tsx` — window resolution from chain selection, legacy/no-metadata degradation, usage-event thinking baseline (no double count on growth), stale-transcript guard.
- Baseline ratchets: style-contract component-root baseline re-pointed from Footer to ContextRadialButton; composer-contract assertion now checks the shared component owns the radial markup.
- Full suite: 311 files / 4847 tests, typecheck and lint clean.

Stacked on #198 (`feat/index-auto-refresh`) — rebase or merge that first.

Fixes #168
