### PR TITLE
Refactor/tool param cleanup

### DIFF
--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -51,7 +51,7 @@ import {
   EagerToolBridge,
 } from './stream/eager-tool-bridge';
 import { NormalizedStream } from './stream/normalized-stream';
-import { classifyStreamError, toProviderMcpToolName } from './stream/sdk-event-adapter';
+import { classifyStreamError, buildMcpProviderToolAliases } from './stream/sdk-event-adapter';
 import type { ProviderStepUsage } from './stream/sdk-event-adapter';
 import type { StreamEvent } from './stream/events';
 import { buildSystemPrompt, type SystemPromptContext } from './system-prompt';
@@ -575,6 +575,11 @@ export function buildToolMap(
   // Add MCP tools if available
   if (mcpManager) {
     const mcpTools = mcpManager.getTools();
+    // Aliases are built from the full tool set (not the allowed subset) so the
+    // stream-time resolver and this registration always agree.
+    const mcpAliases = buildMcpProviderToolAliases(
+      mcpTools.map(({ definition }) => definition.name),
+    );
     for (const { definition, handler } of mcpTools) {
       const isAllowed = allowedTools.some((pattern) => {
         if (pattern === '*') return true;
@@ -588,7 +593,7 @@ export function buildToolMap(
       if (!isAllowed) continue;
 
       const internalName = definition.name;
-      const providerName = toProviderMcpToolName(internalName);
+      const providerName = mcpAliases.get(internalName)!;
       if (providerName in toolMap) {
         throw new Error(
           `Provider tool name collision for MCP tool "${internalName}": "${providerName}"`,

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -51,7 +51,7 @@ import {
   EagerToolBridge,
 } from './stream/eager-tool-bridge';
 import { NormalizedStream } from './stream/normalized-stream';
-import { classifyStreamError, buildMcpProviderToolAliases } from './stream/sdk-event-adapter';
+import { classifyStreamError, getMcpProviderToolAliases } from './stream/sdk-event-adapter';
 import type { ProviderStepUsage } from './stream/sdk-event-adapter';
 import type { StreamEvent } from './stream/events';
 import { buildSystemPrompt, type SystemPromptContext } from './system-prompt';
@@ -575,11 +575,10 @@ export function buildToolMap(
   // Add MCP tools if available
   if (mcpManager) {
     const mcpTools = mcpManager.getTools();
-    // Aliases are built from the full tool set (not the allowed subset) so the
-    // stream-time resolver and this registration always agree.
-    const mcpAliases = buildMcpProviderToolAliases(
-      mcpTools.map(({ definition }) => definition.name),
-    );
+    // Aliases are pinned per manager over the full (sticky-union) tool set,
+    // not the allowed subset, so the stream-time resolver and this
+    // registration always agree and survive mid-session tool-set churn.
+    const mcpAliases = getMcpProviderToolAliases(mcpManager);
     for (const { definition, handler } of mcpTools) {
       const isAllowed = allowedTools.some((pattern) => {
         if (pattern === '*') return true;

--- a/electron/src/main/llm/orchestrator.ts
+++ b/electron/src/main/llm/orchestrator.ts
@@ -593,7 +593,10 @@ export function buildToolMap(
       if (!isAllowed) continue;
 
       const internalName = definition.name;
-      const providerName = mcpAliases.get(internalName)!;
+      const providerName = mcpAliases.get(internalName);
+      if (!providerName) {
+        throw new TypeError(`No provider alias for MCP tool '${internalName}'`);
+      }
       if (providerName in toolMap) {
         throw new Error(
           `Provider tool name collision for MCP tool "${internalName}": "${providerName}"`,

--- a/electron/src/main/llm/stream/sdk-event-adapter.ts
+++ b/electron/src/main/llm/stream/sdk-event-adapter.ts
@@ -439,14 +439,45 @@ export function payloadFromProviderMetadata(
 
 export type ToolNameResolver = (providerToolName: string) => string;
 
+/** Per-manager alias pins: first assignment wins for the manager's lifetime. */
+interface McpAliasPins {
+  /** Every internal name ever observed (sticky membership). */
+  seen: Set<string>;
+  /** internalName -> alias, assigned once, never revoked. */
+  assigned: Map<string, string>;
+}
+
+const mcpAliasPins = new WeakMap<MCPManager, McpAliasPins>();
+
+/**
+ * Derive provider-safe MCP aliases for a manager's current tool set.
+ *
+ * Delegates to {@link buildMcpProviderToolAliases} over the sticky union of
+ * every tool name the manager has exposed (not just the current snapshot), so
+ * tool registration (orchestrator) and stream-time alias reversal
+ * (createToolNameResolver) always agree even if the set mutates between them.
+ * Pinning also keeps aliases stable across mid-session server reconnects: a
+ * tool's alias may flip plain->hashed as colliding siblings appear, but never
+ * back, so the model never sees a learned name disappear.
+ */
+export function getMcpProviderToolAliases(mcpManager: MCPManager): Map<string, string> {
+  let pins = mcpAliasPins.get(mcpManager);
+  if (!pins) {
+    pins = { seen: new Set(), assigned: new Map() };
+    mcpAliasPins.set(mcpManager, pins);
+  }
+  for (const { definition } of mcpManager.getTools()) {
+    pins.seen.add(definition.name);
+  }
+  return buildMcpProviderToolAliases([...pins.seen], pins.assigned);
+}
+
 /** Snapshot provider-safe MCP aliases once for this frozen stream attempt. */
 export function createToolNameResolver(mcpManager: MCPManager | null): ToolNameResolver {
   if (!mcpManager) return (toolName) => toolName;
 
   const internalNamesByAlias = new Map<string, string>();
-  for (const [internalName, alias] of buildMcpProviderToolAliases(
-    mcpManager.getTools().map((tool) => tool.definition.name),
-  )) {
+  for (const [internalName, alias] of getMcpProviderToolAliases(mcpManager)) {
     internalNamesByAlias.set(alias, internalName);
   }
   return (toolName) => toolName.startsWith('mcp::')
@@ -483,11 +514,19 @@ function hashedMcpToolAlias(internalName: string, safeName: string): string {
  * truncation can never merge two tools into one alias; if even the hashed
  * form collides (truncated sha256 prefix tie), the builder throws.
  *
+ * Optional `pinned` aliases (internalName -> alias, from
+ * {@link getMcpProviderToolAliases}) are reused as-is and reserve their values
+ * in the taken set, so a pinned tool keeps its alias even if the reason it was
+ * hashed (a colliding sibling) has since disappeared.
+ *
  * Deterministic for a given set: tool registration (orchestrator) and
  * stream-time alias reversal (createToolNameResolver) both derive aliases from
  * the same full MCP tool set, so they always agree.
  */
-export function buildMcpProviderToolAliases(internalNames: string[]): Map<string, string> {
+export function buildMcpProviderToolAliases(
+  internalNames: string[],
+  pinned?: ReadonlyMap<string, string>,
+): Map<string, string> {
   const safeNames = internalNames.map(sanitizeMcpToolName);
   const counts = new Map<string, number>();
   for (const safe of safeNames) {
@@ -503,7 +542,15 @@ export function buildMcpProviderToolAliases(internalNames: string[]): Map<string
     const safe = safeNames[i]!;
     let alias: string;
 
-    if ((counts.get(safe) ?? 0) === 1 && safe.length <= unhashedBudget && !taken.has(safe)) {
+    const pinnedAlias = pinned?.get(internalName);
+    if (pinnedAlias !== undefined) {
+      alias = pinnedAlias;
+      if (taken.has(alias)) {
+        throw new Error(
+          `MCP tool alias collision for '${internalName}': '${alias}'`,
+        );
+      }
+    } else if ((counts.get(safe) ?? 0) === 1 && safe.length <= unhashedBudget && !taken.has(safe)) {
       alias = safe;
     } else {
       alias = hashedMcpToolAlias(internalName, safe);

--- a/electron/src/main/llm/stream/sdk-event-adapter.ts
+++ b/electron/src/main/llm/stream/sdk-event-adapter.ts
@@ -444,11 +444,10 @@ export function createToolNameResolver(mcpManager: MCPManager | null): ToolNameR
   if (!mcpManager) return (toolName) => toolName;
 
   const internalNamesByAlias = new Map<string, string>();
-  for (const { definition } of mcpManager.getTools()) {
-    const alias = toProviderMcpToolName(definition.name);
-    if (!internalNamesByAlias.has(alias)) {
-      internalNamesByAlias.set(alias, definition.name);
-    }
+  for (const [internalName, alias] of buildMcpProviderToolAliases(
+    mcpManager.getTools().map((tool) => tool.definition.name),
+  )) {
+    internalNamesByAlias.set(alias, internalName);
   }
   return (toolName) => toolName.startsWith('mcp::')
     ? toolName
@@ -457,14 +456,69 @@ export function createToolNameResolver(mcpManager: MCPManager | null): ToolNameR
 
 const PROVIDER_TOOL_NAME_MAX_LENGTH = 64;
 const PROVIDER_TOOL_NAME_HASH_LENGTH = 16;
+/** Longest hash extension tried before accepting a (practically impossible) tie. */
+const PROVIDER_TOOL_NAME_HASH_MAX_LENGTH = 32;
 
-/** Kept alongside alias reversal so provider naming is one coherent concern. */
-export function toProviderMcpToolName(internalName: string): string {
-  const safePrefix = internalName
+function sanitizeMcpToolName(internalName: string): string {
+  return internalName
     .replace(/[^A-Za-z0-9_-]+/g, '_')
     .replace(/^_+|_+$/g, '') || 'mcp_tool';
-  const hash = createHash('sha256').update(internalName).digest('hex').slice(0, PROVIDER_TOOL_NAME_HASH_LENGTH);
-  return `${safePrefix.slice(0, PROVIDER_TOOL_NAME_MAX_LENGTH - hash.length - 1)}_${hash}`;
+}
+
+function hashedMcpToolAlias(internalName: string, safeName: string, hashLength: number): string {
+  const hash = createHash('sha256').update(internalName).digest('hex').slice(0, hashLength);
+  const budget = PROVIDER_TOOL_NAME_MAX_LENGTH - hashLength - 1;
+  return `${safeName.slice(0, budget)}_${hash}`;
+}
+
+/**
+ * Build provider-safe aliases for a set of MCP internal tool names.
+ *
+ * The sanitized name (`mcp::server::tool` → `mcp_server_tool`) is used as the
+ * alias when it is unique within the set and no longer than 47 chars — the
+ * 64-char provider budget minus the room a hash suffix would need, so a name
+ * that later needs hashing keeps its exact prefix. Longer or colliding
+ * sanitized names get a content hash appended so sanitization collisions and
+ * truncation can never merge two tools into one alias.
+ *
+ * Deterministic for a given set: tool registration (orchestrator) and
+ * stream-time alias reversal (createToolNameResolver) both derive aliases from
+ * the same full MCP tool set, so they always agree.
+ */
+export function buildMcpProviderToolAliases(internalNames: string[]): Map<string, string> {
+  const safeNames = internalNames.map(sanitizeMcpToolName);
+  const counts = new Map<string, number>();
+  for (const safe of safeNames) {
+    counts.set(safe, (counts.get(safe) ?? 0) + 1);
+  }
+
+  const unhashedBudget = PROVIDER_TOOL_NAME_MAX_LENGTH - PROVIDER_TOOL_NAME_HASH_LENGTH - 1;
+  const taken = new Set<string>();
+  const aliases = new Map<string, string>();
+
+  for (let i = 0; i < internalNames.length; i++) {
+    const internalName = internalNames[i]!;
+    const safe = safeNames[i]!;
+    let alias: string;
+
+    if ((counts.get(safe) ?? 0) === 1 && safe.length <= unhashedBudget && !taken.has(safe)) {
+      alias = safe;
+    } else {
+      alias = hashedMcpToolAlias(internalName, safe, PROVIDER_TOOL_NAME_HASH_LENGTH);
+      for (
+        let hashLength = PROVIDER_TOOL_NAME_HASH_LENGTH + 1;
+        hashLength <= PROVIDER_TOOL_NAME_HASH_MAX_LENGTH && taken.has(alias);
+        hashLength++
+      ) {
+        alias = hashedMcpToolAlias(internalName, safe, hashLength);
+      }
+    }
+
+    taken.add(alias);
+    aliases.set(internalName, alias);
+  }
+
+  return aliases;
 }
 
 function genericSdkExecution(

--- a/electron/src/main/llm/stream/sdk-event-adapter.ts
+++ b/electron/src/main/llm/stream/sdk-event-adapter.ts
@@ -456,8 +456,6 @@ export function createToolNameResolver(mcpManager: MCPManager | null): ToolNameR
 
 const PROVIDER_TOOL_NAME_MAX_LENGTH = 64;
 const PROVIDER_TOOL_NAME_HASH_LENGTH = 16;
-/** Longest hash extension tried before accepting a (practically impossible) tie. */
-const PROVIDER_TOOL_NAME_HASH_MAX_LENGTH = 32;
 
 function sanitizeMcpToolName(internalName: string): string {
   return internalName
@@ -465,9 +463,12 @@ function sanitizeMcpToolName(internalName: string): string {
     .replace(/^_+|_+$/g, '') || 'mcp_tool';
 }
 
-function hashedMcpToolAlias(internalName: string, safeName: string, hashLength: number): string {
-  const hash = createHash('sha256').update(internalName).digest('hex').slice(0, hashLength);
-  const budget = PROVIDER_TOOL_NAME_MAX_LENGTH - hashLength - 1;
+function hashedMcpToolAlias(internalName: string, safeName: string): string {
+  const hash = createHash('sha256')
+    .update(internalName)
+    .digest('hex')
+    .slice(0, PROVIDER_TOOL_NAME_HASH_LENGTH);
+  const budget = PROVIDER_TOOL_NAME_MAX_LENGTH - PROVIDER_TOOL_NAME_HASH_LENGTH - 1;
   return `${safeName.slice(0, budget)}_${hash}`;
 }
 
@@ -479,7 +480,8 @@ function hashedMcpToolAlias(internalName: string, safeName: string, hashLength: 
  * 64-char provider budget minus the room a hash suffix would need, so a name
  * that later needs hashing keeps its exact prefix. Longer or colliding
  * sanitized names get a content hash appended so sanitization collisions and
- * truncation can never merge two tools into one alias.
+ * truncation can never merge two tools into one alias; if even the hashed
+ * form collides (truncated sha256 prefix tie), the builder throws.
  *
  * Deterministic for a given set: tool registration (orchestrator) and
  * stream-time alias reversal (createToolNameResolver) both derive aliases from
@@ -504,13 +506,14 @@ export function buildMcpProviderToolAliases(internalNames: string[]): Map<string
     if ((counts.get(safe) ?? 0) === 1 && safe.length <= unhashedBudget && !taken.has(safe)) {
       alias = safe;
     } else {
-      alias = hashedMcpToolAlias(internalName, safe, PROVIDER_TOOL_NAME_HASH_LENGTH);
-      for (
-        let hashLength = PROVIDER_TOOL_NAME_HASH_LENGTH + 1;
-        hashLength <= PROVIDER_TOOL_NAME_HASH_MAX_LENGTH && taken.has(alias);
-        hashLength++
-      ) {
-        alias = hashedMcpToolAlias(internalName, safe, hashLength);
+      alias = hashedMcpToolAlias(internalName, safe);
+      if (taken.has(alias)) {
+        // Two distinct internal names sharing a truncated sha256 prefix (~2^-64).
+        // Fail closed so registration and stream-time reversal fail identically
+        // instead of the resolver silently remapping one tool onto the other.
+        throw new Error(
+          `MCP tool alias collision for '${internalName}': '${alias}'`,
+        );
       }
     }
 

--- a/electron/src/main/llm/stream/sdk-event-adapter.ts
+++ b/electron/src/main/llm/stream/sdk-event-adapter.ts
@@ -456,9 +456,9 @@ const mcpAliasPins = new WeakMap<MCPManager, McpAliasPins>();
  * every tool name the manager has exposed (not just the current snapshot), so
  * tool registration (orchestrator) and stream-time alias reversal
  * (createToolNameResolver) always agree even if the set mutates between them.
- * Pinning also keeps aliases stable across mid-session server reconnects: a
- * tool's alias may flip plain->hashed as colliding siblings appear, but never
- * back, so the model never sees a learned name disappear.
+ * Pinning also keeps aliases stable across mid-session server reconnects: an
+ * assigned alias never changes, so the model never sees a learned name
+ * disappear — colliding siblings that appear later hash around it.
  */
 export function getMcpProviderToolAliases(mcpManager: MCPManager): Map<string, string> {
   let pins = mcpAliasPins.get(mcpManager);
@@ -469,7 +469,11 @@ export function getMcpProviderToolAliases(mcpManager: MCPManager): Map<string, s
   for (const { definition } of mcpManager.getTools()) {
     pins.seen.add(definition.name);
   }
-  return buildMcpProviderToolAliases([...pins.seen], pins.assigned);
+  const aliases = buildMcpProviderToolAliases([...pins.seen], pins.assigned);
+  for (const [internalName, alias] of aliases) {
+    pins.assigned.set(internalName, alias);
+  }
+  return aliases;
 }
 
 /** Snapshot provider-safe MCP aliases once for this frozen stream attempt. */

--- a/electron/src/main/tools/todo/create.ts
+++ b/electron/src/main/tools/todo/create.ts
@@ -91,9 +91,9 @@ export function buildCreateTool(
     name: 'todo_create',
     description:
       'Create a new task in the session todo list. Tasks are scoped to the ' +
-      'calling agent (main or a specific subagent). Subagents only see and ' +
-      'modify their own tasks. Accepts a single title or an array of titles ' +
-      'for batch creation.',
+      'calling agent (main or a subagent). Subagents only see and modify ' +
+      'their own tasks. Accepts a single title or an array of titles for ' +
+      'batch creation.',
     inputSchema: z.object({
       title: z.preprocess(
         expandStringifiedBatch,

--- a/electron/src/main/tools/todo/create.ts
+++ b/electron/src/main/tools/todo/create.ts
@@ -1,8 +1,8 @@
 /**
  * todo_create tool — create a new task in the session todo list.
  *
- * Ownership is agent-scoped: empty/null subagent_id = main. Subagents auto-stamp
- * their scope id so peers and main do not share ownership by default.
+ * Ownership is agent-scoped: main creates main-owned tasks (null owner);
+ * subagents auto-stamp their own scope id.
  */
 import { z } from 'zod';
 import type { ToolDefinition, ToolExecutionContext, ToolHandler } from '../types';
@@ -65,18 +65,12 @@ export function expandStringifiedBatch(value: unknown): unknown {
 /**
  * Resolve ownership for a new todo under the calling agent scope.
  * - Subagents: always own the todo (caller cannot forge another scope).
- * - Main: may optionally tag a subagent_id (assigns ownership to that subagent).
+ * - Main: store null (empty owner).
  */
-export function resolveCreateOwner(
-  agentScopeId: string | undefined,
-  requestedSubagentId?: string,
-): string | undefined {
+export function resolveCreateOwner(agentScopeId: string | undefined): string | undefined {
   const scope = normalizeAgentScopeId(agentScopeId);
   if (!isMainAgentScope(scope)) {
     return scope;
-  }
-  if (requestedSubagentId !== undefined && requestedSubagentId.trim() !== '') {
-    return requestedSubagentId.trim();
   }
   // Main-owned: store null (empty owner)
   return undefined;
@@ -107,25 +101,17 @@ export function buildCreateTool(
           'Task title or array of task titles for batch creation.',
         ),
       ),
-      subagent_id: z
-        .string()
-        .optional()
-        .describe(
-          'Main agent only: assign ownership to a subagent id. ' +
-            'Ignored when called by a subagent (auto-stamped to caller).',
-        ),
     }),
     category: 'todo',
     riskClass: RiskClass.MUTATION,
   };
 
   const handler: ToolHandler = async (input: unknown, ctx): Promise<TodoToolResult> => {
-    const { title, subagent_id } = input as {
+    const { title } = input as {
       title: string | string[];
-      subagent_id?: string;
     };
 
-    const owner = resolveCreateOwner(ctx.agentScopeId, subagent_id);
+    const owner = resolveCreateOwner(ctx.agentScopeId);
     const titles = Array.isArray(title) ? title : [title];
     const todoStore = resolveTodoStore(store, ctx);
     const created = titles.map((t) => todoStore.create(t, owner));

--- a/electron/src/main/tools/todo/list.ts
+++ b/electron/src/main/tools/todo/list.ts
@@ -3,7 +3,6 @@
  *
  * Agent isolation: main only lists main-owned tasks; subagents only list
  * their own. Optional status filter still applies within the scope.
- * The subagent_id param is ignored for isolation (scope is always the caller).
  */
 import { z } from 'zod';
 import type { ToolDefinition, ToolHandler } from '../types';
@@ -45,11 +44,6 @@ export function buildListTool(
         .describe(
           `Filter by status. Must be one of: ${Object.values(TodoStatus).join(', ')}.`,
         ),
-      // Kept for schema stability; enforced scope always overrides.
-      subagent_id: z
-        .string()
-        .optional()
-        .describe('Deprecated: scope is always the calling agent. Ignored.'),
     }),
     category: 'todo',
     riskClass: RiskClass.READ_ONLY,

--- a/electron/src/main/tools/todo/store.ts
+++ b/electron/src/main/tools/todo/store.ts
@@ -84,20 +84,16 @@ export class TodoStore {
   }
 
   /**
-   * List tasks, optionally filtered by status and/or subagent_id.
+   * List tasks, optionally filtered by status.
    *
    * @param status - Filter by status (optional)
-   * @param subagent_id - Filter by subagent ID (optional)
    * @returns Array of matching tasks
    */
-  list(status?: TodoStatus, subagent_id?: string): Todo[] {
+  list(status?: TodoStatus): Todo[] {
     let tasks = Array.from(this._tasks.values());
 
     if (status !== undefined) {
       tasks = tasks.filter((t) => t.status === status);
-    }
-    if (subagent_id !== undefined) {
-      tasks = tasks.filter((t) => t.subagent_id === subagent_id);
     }
 
     return tasks;
@@ -109,12 +105,12 @@ export class TodoStore {
    * No status-transition restrictions — any status can go to any status.
    *
    * @param id - Task ID to update
-   * @param updates - Fields to update (title, status, subagent_id)
+   * @param updates - Fields to update (title, status)
    * @returns Tuple of [updated task | null, error message | null]
    */
   update(
     id: string,
-    updates: { title?: string; status?: TodoStatus; subagent_id?: string },
+    updates: { title?: string; status?: TodoStatus },
   ): [Todo | null, string | null] {
     const task = this._tasks.get(id);
     if (!task) {
@@ -127,13 +123,6 @@ export class TodoStore {
       ...task,
       title: updates.title ?? task.title,
       status: updates.status ?? task.status,
-      // Empty string reassigns ownership to main (null).
-      subagent_id:
-        updates.subagent_id !== undefined
-          ? updates.subagent_id.trim() === ''
-            ? null
-            : updates.subagent_id
-          : task.subagent_id,
       updated_at: now,
     };
 

--- a/electron/src/main/tools/todo/update.ts
+++ b/electron/src/main/tools/todo/update.ts
@@ -100,6 +100,13 @@ export function buildUpdateTool(
         'error',
       );
     }
+    if (title === undefined && status === undefined) {
+      return genericBuiltInToolOutcome(
+        'todo_update',
+        'Error: Nothing to update — provide title and/or status.',
+        'error',
+      );
+    }
 
     const titles = title === undefined ? undefined : Array.isArray(title) ? title : ids.map(() => title);
     const statuses = status === undefined ? undefined : Array.isArray(status) ? status : ids.map(() => status);

--- a/electron/src/main/tools/todo/update.ts
+++ b/electron/src/main/tools/todo/update.ts
@@ -2,7 +2,6 @@
  * todo_update tool — update a task owned by the calling agent scope.
  *
  * Cross-scope updates are rejected (Sub1 cannot mutate main/Sub2 todos).
- * Subagents cannot reassign ownership away from themselves.
  */
 import { z } from 'zod';
 import type { ToolDefinition, ToolHandler } from '../types';
@@ -13,7 +12,6 @@ import type { TodoToolResult, NotifyTodoChanged, TodoStoreSource } from './creat
 import { resolveTodoStore, TODO_BATCH_MAX_SIZE, expandStringifiedBatch } from './create';
 import { TodoStatus, type Todo } from '../../../shared/types/todo';
 import {
-  isMainAgentScope,
   normalizeAgentScopeId,
   todoBelongsToScope,
 } from '../../../shared/types/agent-scope';
@@ -72,23 +70,16 @@ export function buildUpdateTool(
           ),
         )
         .optional(),
-      subagent_id: z
-        .string()
-        .optional()
-        .describe(
-          'Main agent only: reassign ownership. Subagents cannot change owner.',
-        ),
     }),
     category: 'todo',
     riskClass: RiskClass.MUTATION,
   };
 
   const handler: ToolHandler = async (input: unknown, ctx): Promise<TodoToolResult> => {
-    const { id, title, status, subagent_id } = input as {
+    const { id, title, status } = input as {
       id: string | string[];
       title?: string | string[];
       status?: TodoStatus | TodoStatus[];
-      subagent_id?: string;
     };
 
     const scope = normalizeAgentScopeId(ctx.agentScopeId);
@@ -113,7 +104,7 @@ export function buildUpdateTool(
     const titles = title === undefined ? undefined : Array.isArray(title) ? title : ids.map(() => title);
     const statuses = status === undefined ? undefined : Array.isArray(status) ? status : ids.map(() => status);
 
-    const results: { task: Todo | null; error: string | null; changes: { title?: string; status?: string; owner?: string } }[] = [];
+    const results: { task: Todo | null; error: string | null; changes: { title?: string; status?: string } }[] = [];
 
     for (let i = 0; i < ids.length; i++) {
       const existing = todoStore.get(ids[i]);
@@ -126,15 +117,12 @@ export function buildUpdateTool(
         continue;
       }
 
-      const updates: { title?: string; status?: TodoStatus; subagent_id?: string } = {};
+      const updates: { title?: string; status?: TodoStatus } = {};
       if (titles !== undefined && titles[i] !== undefined) {
         updates.title = titles[i];
       }
       if (statuses !== undefined && statuses[i] !== undefined) {
         updates.status = statuses[i];
-      }
-      if (isMainAgentScope(scope) && subagent_id !== undefined) {
-        updates.subagent_id = subagent_id;
       }
 
       const [task, error] = todoStore.update(ids[i], updates);
@@ -142,12 +130,9 @@ export function buildUpdateTool(
         results.push({ task: null, error: error ?? 'Unknown error.', changes: {} });
         continue;
       }
-      const changes: { title?: string; status?: string; owner?: string } = {};
+      const changes: { title?: string; status?: string } = {};
       if (updates.title !== undefined) changes.title = task.title;
       if (updates.status !== undefined) changes.status = task.status;
-      if (isMainAgentScope(scope) && subagent_id !== undefined) {
-        changes.owner = task.subagent_id || 'main';
-      }
       results.push({ task, error: null, changes });
     }
 

--- a/electron/src/shared/types/agent-scope.ts
+++ b/electron/src/shared/types/agent-scope.ts
@@ -27,7 +27,7 @@ export function isMainAgentScope(scope?: string | null): boolean {
  * Owner of a todo for scope checks.
  * Empty/null `subagent_id` → main.
  */
-export function todoOwnerScopeId(subagentId: string | null | undefined): AgentScopeId {
+function todoOwnerScopeId(subagentId: string | null | undefined): AgentScopeId {
   return normalizeAgentScopeId(subagentId);
 }
 

--- a/electron/tests/unit/agent-scope-isolation.test.ts
+++ b/electron/tests/unit/agent-scope-isolation.test.ts
@@ -123,6 +123,19 @@ describe('todo tools agent isolation', () => {
     expect(tasks).toHaveLength(1);
     expect(tasks[0]!.subagent_id).toBe('sub-a');
   });
+
+  it('main-scope create ignores a stale subagent_id key (param removed)', async () => {
+    const create = buildCreateTool(store);
+    // Models holding pre-removal tool schemas may still emit subagent_id;
+    // the schema strips it and ownership stays with the caller.
+    await create.handler(
+      { title: 'Stale', subagent_id: 'sub-9' } as never,
+      ctx('main'),
+    );
+    const tasks = store.list();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.subagent_id).toBeNull();
+  });
 });
 
 describe('prompt context agent isolation', () => {

--- a/electron/tests/unit/agent-scope-isolation.test.ts
+++ b/electron/tests/unit/agent-scope-isolation.test.ts
@@ -53,10 +53,9 @@ describe('agent-scope helpers', () => {
     expect(todoBelongsToScope({ subagent_id: 'sub-a' }, 'sub-b')).toBe(false);
   });
 
-  it('resolveCreateOwner stamps subagent and lets main assign', () => {
-    expect(resolveCreateOwner('sub-a', 'forged')).toBe('sub-a');
-    expect(resolveCreateOwner('main', 'sub-b')).toBe('sub-b');
-    expect(resolveCreateOwner('main', undefined)).toBeUndefined();
+  it('resolveCreateOwner stamps subagent scope and main to null owner', () => {
+    expect(resolveCreateOwner('sub-a')).toBe('sub-a');
+    expect(resolveCreateOwner('main')).toBeUndefined();
   });
 });
 

--- a/electron/tests/unit/llm-orchestrator.test.ts
+++ b/electron/tests/unit/llm-orchestrator.test.ts
@@ -40,6 +40,7 @@ import {
   type StreamChatParams,
 } from '../../src/main/llm/orchestrator';
 import { combineAbortSignals } from '../../src/main/llm/stream/attempt-controller';
+import { createToolNameResolver } from '../../src/main/llm/stream/sdk-event-adapter';
 import { ToolRegistry } from '../../src/main/tools/registry';
 import type { MCPManager } from '../../src/main/mcp/manager';
 import { defaults } from '../../src/main/config/schema';
@@ -1300,6 +1301,42 @@ describe('ToolRegistry integration with dispatch', () => {
       '<tool_result name="mcp::context7::query.docs"',
     );
     expect(routedResult.agentProjection.content).not.toContain(aliases[0]);
+  });
+
+  it('allowed-tools filtering keeps full-set aliases: hashed name survives exclusion and the resolver agrees', () => {
+    // Both tools sanitize to mcp_s_search_web, so the FULL set assigns both
+    // hashed aliases. Registration may exclude one, but the excluded sibling
+    // still counts toward collision detection — the allowed tool must keep its
+    // hashed alias (not flip to the plain name) or stream-time reversal
+    // (built from the full set) would miss it.
+    const internalNames = ['mcp::s::search:web', 'mcp::s::search_web'];
+    const mcpManager = {
+      getTools: () => internalNames.map((name, index) => ({
+        definition: {
+          name,
+          riskClass: 'read-only',
+          description: `MCP tool ${index}`,
+          inputSchema: z.object({ query: z.string().optional() }),
+          resultFamily: 'generic',
+          outputDataSchema: genericToolResultDataSchema,
+          category: 'mcp',
+        },
+        handler: vi.fn(async () => 'ok'),
+      })),
+    } as unknown as MCPManager;
+
+    const allowed = buildToolMap(['mcp::s::search:web'], registry, mcpManager, {
+      cwd: TEST_TOOL_CWD,
+    });
+    const aliasKeys = Object.keys(allowed).filter((key) => key.startsWith('mcp_'));
+
+    expect(aliasKeys).toHaveLength(1);
+    expect(aliasKeys[0]).toMatch(/^mcp_s_search_web_[0-9a-f]{16}$/);
+
+    const resolve = createToolNameResolver(mcpManager);
+    expect(resolve(aliasKeys[0])).toBe('mcp::s::search:web');
+    // The plain sanitized name resolves to no tool — it was never registered.
+    expect(resolve('mcp_s_search_web')).toBe('mcp_s_search_web');
   });
 });
 

--- a/electron/tests/unit/sdk-event-adapter.test.ts
+++ b/electron/tests/unit/sdk-event-adapter.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ModelMessage } from 'ai';
 import {
+  buildMcpProviderToolAliases,
   classifyStreamError,
   createToolNameResolver,
   SdkEventAdapter,
-  toProviderMcpToolName,
 } from '../../src/main/llm/stream/sdk-event-adapter';
 import type { MCPManager } from '../../src/main/mcp/manager';
 import type { EagerToolBridge } from '../../src/main/llm/stream/eager-tool-bridge';
@@ -294,7 +294,7 @@ describe('SdkEventAdapter', () => {
     expect(adapt(aliasAdapter, {
       type: 'tool-call',
       toolCallId: 'mcp-call',
-      toolName: toProviderMcpToolName(internalName),
+      toolName: buildMcpProviderToolAliases([internalName]).get(internalName),
       input: {},
     })).toEqual([
       { type: 'tool_call', toolCallId: 'mcp-call', toolName: internalName, args: '{}' },
@@ -302,7 +302,7 @@ describe('SdkEventAdapter', () => {
     adapt(aliasAdapter, {
       type: 'tool-input-start',
       toolCallId: 'mcp-call-2',
-      toolName: toProviderMcpToolName(internalName),
+      toolName: buildMcpProviderToolAliases([internalName]).get(internalName),
     });
     expect(getTools).toHaveBeenCalledOnce();
   });
@@ -344,5 +344,55 @@ describe('SdkEventAdapter', () => {
       title: 'Unexpected Error',
       detail: '[object Object]',
     });
+  });
+});
+
+describe('buildMcpProviderToolAliases', () => {
+  it('uses the sanitized name without a hash when it is unique and short enough', () => {
+    const aliases = buildMcpProviderToolAliases(['mcp::context7::resolve-library-id']);
+
+    expect(aliases.get('mcp::context7::resolve-library-id')).toBe('mcp_context7_resolve-library-id');
+  });
+
+  it('appends a deterministic hash when sanitized names collide', () => {
+    const internalNames = ['mcp::s::search:web', 'mcp::s::search_web'];
+    const aliases = buildMcpProviderToolAliases(internalNames);
+    const values = [...aliases.values()];
+
+    expect(values[0]).toMatch(/^mcp_s_search_web_[0-9a-f]{16}$/);
+    expect(values[1]).toMatch(/^mcp_s_search_web_[0-9a-f]{16}$/);
+    expect(values[0]).not.toBe(values[1]);
+    expect(aliases).toEqual(buildMcpProviderToolAliases([...internalNames].reverse()));
+  });
+
+  it('hashes names that exceed the provider length budget so truncation cannot merge them', () => {
+    const longA = `mcp::s::${'a'.repeat(60)}A`;
+    const longB = `mcp::s::${'a'.repeat(60)}B`;
+    const aliases = buildMcpProviderToolAliases([longA, longB]);
+    const values = [...aliases.values()];
+
+    for (const value of values) {
+      expect(value.length).toBeLessThanOrEqual(64);
+    }
+    expect(values[0]).not.toBe(values[1]);
+    expect(values[0]).toMatch(/_[0-9a-f]{16}$/);
+  });
+
+  it('resolves aliases back to internal names for the full set', () => {
+    const internalNames = [
+      'mcp::context7::resolve-library-id',
+      'mcp::s::search:web',
+      'mcp::s::search_web',
+    ];
+    const getTools = vi.fn(() => internalNames.map((name) => ({ definition: { name } })));
+    const mcpManager = { getTools } as unknown as MCPManager;
+    const resolve = createToolNameResolver(mcpManager);
+    const aliases = buildMcpProviderToolAliases(internalNames);
+
+    for (const internalName of internalNames) {
+      expect(resolve(aliases.get(internalName)!)).toBe(internalName);
+    }
+    expect(resolve('mcp::direct::name')).toBe('mcp::direct::name');
+    expect(resolve('todo_list')).toBe('todo_list');
   });
 });

--- a/electron/tests/unit/sdk-event-adapter.test.ts
+++ b/electron/tests/unit/sdk-event-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   buildMcpProviderToolAliases,
   classifyStreamError,
   createToolNameResolver,
+  getMcpProviderToolAliases,
   SdkEventAdapter,
 } from '../../src/main/llm/stream/sdk-event-adapter';
 import type { MCPManager } from '../../src/main/mcp/manager';
@@ -394,5 +395,98 @@ describe('buildMcpProviderToolAliases', () => {
     }
     expect(resolve('mcp::direct::name')).toBe('mcp::direct::name');
     expect(resolve('todo_list')).toBe('todo_list');
+  });
+
+  it('reuses pinned aliases as-is and reserves their values', () => {
+    // search:web was pinned to a hashed alias; search_web (which would
+    // otherwise take the plain name) must not collide with any future sibling.
+    const pinned = new Map([['mcp::s::search:web', 'mcp_s_search_web_pinned00000000']]);
+    const aliases = buildMcpProviderToolAliases(['mcp::s::search:web'], pinned);
+
+    expect(aliases.get('mcp::s::search:web')).toBe('mcp_s_search_web_pinned00000000');
+
+    // A different tool whose plain name equals the pinned value must be hashed,
+    // not silently merged onto the pinned alias.
+    const displaced = buildMcpProviderToolAliases(
+      ['mcp::s::search:web', 'mcp::s::x', 'mcp::other'],
+      pinned,
+    );
+    const bySafe = new Map(
+      [...displaced.entries()].map(([k, v]) => [k, v] as const),
+    );
+    expect(bySafe.get('mcp::s::search:web')).toBe('mcp_s_search_web_pinned00000000');
+    expect(new Set(displaced.values()).size).toBe(displaced.size);
+  });
+
+  it('throws on a hashed-alias collision instead of silently merging', () => {
+    // Two names whose hashed aliases coincide cannot be constructed via sha256
+    // truncation, so force it via a pin: pin the first tool to the second
+    // tool's natural hashed alias.
+    const pair = buildMcpProviderToolAliases(['mcp::s::search:web', 'mcp::s::search_web']);
+    const firstAlias = pair.get('mcp::s::search:web')!;
+    const second = 'mcp::s::search_web';
+    const pinned = new Map([[second, firstAlias]]);
+
+    expect(() =>
+      buildMcpProviderToolAliases(['mcp::s::search:web', second], pinned),
+    ).toThrow(/MCP tool alias collision/);
+  });
+});
+
+describe('getMcpProviderToolAliases (sticky pinning)', () => {
+  it('keeps a hashed alias after its colliding sibling disappears', () => {
+    const collidingSet = ['mcp::s::search:web', 'mcp::s::search_web'];
+    const getTools = vi.fn(() => collidingSet.map((name) => ({ definition: { name } })));
+    const manager = { getTools } as unknown as MCPManager;
+
+    const before = getMcpProviderToolAliases(manager);
+    const survivor = 'mcp::s::search:web';
+    expect(before.get(survivor)).toMatch(/^mcp_s_search_web_[0-9a-f]{16}$/);
+
+    // Server reconnects with only one tool left; the survivor keeps its alias.
+    getTools.mockImplementation(() => [{ definition: { name: survivor } }]);
+    const after = getMcpProviderToolAliases(manager);
+    expect(after.get(survivor)).toBe(before.get(survivor));
+  });
+
+  it('never revokes a name: dropped tools still reserve their aliases', () => {
+    const getTools = vi.fn(() => [
+      { definition: { name: 'mcp::s::search:web' } },
+      { definition: { name: 'mcp::s::search_web' } },
+    ]);
+    const manager = { getTools } as unknown as MCPManager;
+
+    const withPair = getMcpProviderToolAliases(manager);
+    const dropped = 'mcp::s::search_web';
+
+    getTools.mockImplementation(() => [{ definition: { name: 'mcp::s::search:web' } }]);
+    const afterDrop = getMcpProviderToolAliases(manager);
+    expect(afterDrop.get(dropped)).toBe(withPair.get(dropped));
+
+    // A newly appearing tool sanitizing to the dropped name's plain form must
+    // not reuse it (the dropped tool's alias is still pinned).
+    getTools.mockImplementation(() => [
+      { definition: { name: 'mcp::s::search:web' } },
+      { definition: { name: 'mcp::s::search_web' } },
+    ]);
+    const restored = getMcpProviderToolAliases(manager);
+    expect(restored.get('mcp::s::search_web')).toBe(withPair.get('mcp::s::search_web'));
+    expect(new Set(restored.values()).size).toBe(restored.size);
+  });
+
+  it('pins are per-manager: separate managers assign independently', () => {
+    const a = { getTools: () => [{ definition: { name: 'mcp::s::tool' } }] } as unknown as MCPManager;
+    const b = { getTools: () => [{ definition: { name: 'mcp::s::tool' } }] } as unknown as MCPManager;
+
+    expect(getMcpProviderToolAliases(a).get('mcp::s::tool')).toBe('mcp_s_tool');
+    expect(getMcpProviderToolAliases(b).get('mcp::s::tool')).toBe('mcp_s_tool');
+
+    // Manager A later sees a colliding sibling; B stays untouched.
+    (a as unknown as { getTools: () => unknown[] }).getTools = () => [
+      { definition: { name: 'mcp::s::tool' } },
+      { definition: { name: 'mcp::s::tool!' } },
+    ];
+    expect(getMcpProviderToolAliases(a).get('mcp::s::tool')).toMatch(/_[0-9a-f]{16}$/);
+    expect(getMcpProviderToolAliases(b).get('mcp::s::tool')).toBe('mcp_s_tool');
   });
 });

--- a/electron/tests/unit/sdk-event-adapter.test.ts
+++ b/electron/tests/unit/sdk-event-adapter.test.ts
@@ -481,12 +481,15 @@ describe('getMcpProviderToolAliases (sticky pinning)', () => {
     expect(getMcpProviderToolAliases(a).get('mcp::s::tool')).toBe('mcp_s_tool');
     expect(getMcpProviderToolAliases(b).get('mcp::s::tool')).toBe('mcp_s_tool');
 
-    // Manager A later sees a colliding sibling; B stays untouched.
+    // Manager A later sees a colliding sibling: A's pinned plain alias survives
+    // (only the newcomer hashes); B stays untouched.
     (a as unknown as { getTools: () => unknown[] }).getTools = () => [
       { definition: { name: 'mcp::s::tool' } },
       { definition: { name: 'mcp::s::tool!' } },
     ];
-    expect(getMcpProviderToolAliases(a).get('mcp::s::tool')).toMatch(/_[0-9a-f]{16}$/);
+    const afterCollision = getMcpProviderToolAliases(a);
+    expect(afterCollision.get('mcp::s::tool')).toBe('mcp_s_tool');
+    expect(afterCollision.get('mcp::s::tool!')).toMatch(/^mcp_s_tool_[0-9a-f]{16}$/);
     expect(getMcpProviderToolAliases(b).get('mcp::s::tool')).toBe('mcp_s_tool');
   });
 });

--- a/electron/tests/unit/todo-web-tools.test.ts
+++ b/electron/tests/unit/todo-web-tools.test.ts
@@ -111,12 +111,11 @@ describe('Todo Tools', () => {
       expect(notifyCalled).toBe(true);
     });
 
-    it('should create a task with optional subagent_id', async () => {
+    it('should create a task owned by the calling subagent scope', async () => {
       const { handler } = buildCreateTool(store);
       const result = (await callTool(handler, {
         title: 'Subagent task',
-        subagent_id: 'sub-123',
-      })) as ToolExecutionResult;
+      }, 'sub-123')) as ToolExecutionResult;
 
       const idMatch = result.agentProjection.content.match(/<task id="([a-f0-9]{8})"/);
       const id = idMatch![1];
@@ -529,8 +528,8 @@ describe('Todo Tools', () => {
     it('should isolate list by agent scope (not peer todos)', async () => {
       const createHandler = buildCreateTool(store).handler;
       await callTool(createHandler, { title: 'Main task' }, 'main');
-      // Main assigns ownership to sub-1
-      await callTool(createHandler, { title: 'Sub task', subagent_id: 'sub-1' }, 'main');
+      // Sub-1 owns its own task (subagent calls auto-stamp their scope)
+      await callTool(createHandler, { title: 'Sub task' }, 'sub-1');
 
       const listHandler = buildListTool(store).handler;
       const asSub = (await callTool(listHandler, {}, 'sub-1')) as {

--- a/electron/tests/unit/todo-web-tools.test.ts
+++ b/electron/tests/unit/todo-web-tools.test.ts
@@ -231,6 +231,23 @@ describe('Todo Tools', () => {
       expect(parsed.success).toBe(false);
     });
 
+    it('todo_update with neither title nor status errors without mutating or notifying', async () => {
+      const createHandler = buildCreateTool(store).handler;
+      const created = (await callTool(createHandler, { title: 'Untouched' })) as ToolExecutionResult;
+      const id = created.agentProjection.content.match(/<task id="([a-f0-9]{8})"/)![1];
+
+      let notifyCount = 0;
+      const { handler } = buildUpdateTool(store, () => {
+        notifyCount++;
+      });
+      const result = (await callTool(handler, { id })) as ToolExecutionResult;
+
+      expect(result.canonical.status).toBe('error');
+      expect(result.agentProjection.content).toContain('Nothing to update');
+      expect(store.get(id)!.title).toBe('Untouched');
+      expect(notifyCount).toBe(0);
+    });
+
     it('todo_update batch collects per-item errors without failing the whole call', async () => {
       const createHandler = buildCreateTool(store).handler;
       const created = (await callTool(createHandler, { title: 'Real' })) as ToolExecutionResult;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved MCP tool naming to provide stable, collision-resistant aliases across tool changes and reconnections.
  * Enhanced tool resolution when multiple providers expose similarly named tools.

* **Bug Fixes**
  * Fixed cases where allowed-tool filtering could produce inconsistent MCP aliases.
  * Prevented ambiguous aliases from resolving to the wrong tool.

* **Todo Lists**
  * Todo ownership is now automatically based on the calling agent’s scope.
  * Removed manual ownership assignment and filtering by subagent from todo creation, updates, and listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->