### PR TITLE
fix(build): require onnxruntime-node as a mandatory dependency

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -24,6 +24,7 @@
         "diff": "^9.0.0",
         "electron-updater": "^6.3.0",
         "node-pty": "^1.0.0",
+        "onnxruntime-node": "^1.20.0",
         "react-markdown": "^10.1.0",
         "recharts": "^3.10.1",
         "rehype-highlight": "^7.0.2",
@@ -64,9 +65,6 @@
       },
       "engines": {
         "node": ">=24.15.0 <25"
-      },
-      "optionalDependencies": {
-        "onnxruntime-node": "^1.20.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -3302,7 +3300,6 @@
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
       "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=12.0"
       }
@@ -4685,7 +4682,6 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -4703,7 +4699,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -5509,7 +5504,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6274,7 +6268,6 @@
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz",
       "integrity": "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "globalthis": "^1.0.2",
         "matcher": "^4.0.0",
@@ -6290,7 +6283,6 @@
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -6361,7 +6353,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -7488,7 +7479,6 @@
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
       "integrity": "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -8705,7 +8695,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -8749,8 +8738,7 @@
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz",
       "integrity": "sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
       "version": "1.27.0",
@@ -8758,7 +8746,6 @@
       "integrity": "sha512-QEzGwrvNBgv4uPVdnbHsOGG4G6T96mdlcFI8aAKPjMU8wOPpVocPXb6k3QGkaZagVTv2G9Bnnbo6Z3JdXr1fQw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32",
         "darwin",
@@ -9809,7 +9796,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9857,7 +9843,6 @@
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
       "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -10532,7 +10517,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },

--- a/electron/package.json
+++ b/electron/package.json
@@ -59,6 +59,7 @@
     "diff": "^9.0.0",
     "electron-updater": "^6.3.0",
     "node-pty": "^1.0.0",
+    "onnxruntime-node": "^1.20.0",
     "react-markdown": "^10.1.0",
     "recharts": "^3.10.1",
     "rehype-highlight": "^7.0.2",
@@ -68,9 +69,6 @@
     "web-tree-sitter": "^0.26.11",
     "xstate": "^5.32.5",
     "zod": "^3.23.0"
-  },
-  "optionalDependencies": {
-    "onnxruntime-node": "^1.20.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.0",


### PR DESCRIPTION
Packaged builds could silently ship without `onnxruntime-node`, so local RAG embedding failed at runtime with "onnxruntime-node is not available" instead of failing the install. It now sits in `dependencies`, making install failures loud and keeping the packager's existing `asarUnpack` glob meaningful. Verified: fresh `npm install` resolves it and `require('onnxruntime-node').InferenceSession` loads.

Partially addresses #94 (the upstream missing darwin/x64 binary and an `afterPack` presence assertion remain).
