### PR TITLE
fix(subagents): persist queued spawns and bypass breaker at shutdown …

### DIFF
--- a/electron/src/main/agents/manager.ts
+++ b/electron/src/main/agents/manager.ts
@@ -511,7 +511,10 @@ export class SubagentManager {
     };
 
     this._storeRecord(record);
-    this._persistence.register(id, sessionId, { admitted });
+    // Queued spawns register durably too: a spawn parked in admission when the
+    // app closes must leave a row, or post-restart hydration has nothing to
+    // materialize and the prompt's subagent block omits it entirely (#121).
+    this._persistence.register(id, sessionId);
     this._liveProjection.start({
       subagentId: id,
       sessionId,
@@ -874,21 +877,12 @@ export class SubagentManager {
       this._finishLive(record, SubagentState.INTERRUPTED);
     }
     if (transition.resolveWaiters) this._lifecycle.resolveWaiters(record.id);
-    if (wasQueued && !this._persistence.hasDurableEligibility(record.id)) {
-      // A record cancelled while QUEUED was never admitted, so it never gets a
-      // durable row (persistence eligibility begins at admission) — but it must
-      // not linger as a full record either. Evict it to a lean terminal summary
-      // under the same retention FIFO as persisted records; the terminal delta
-      // above already carried the full record to the renderer. Eviction runs
-      // after resolving waiters because eviction clears runtime lifecycle state.
-      this._applySummaryConfirmation(record, this._persistence.summarizeUndurable(record.id));
-    }
-    // A resume-queued record owns a durable row (persist-subagent-chains
-    // eligibility carve-out), so evicting it here would strand the row with a
-    // stale pre-interrupt status and drop the follow-up message — every later
-    // checkpoint skips summaries. Leave it as a full dirty INTERRUPTED
-    // record: the terminal wave persists it, then confirmRecordsPersisted
-    // evicts it through the normal row-confirmed path.
+    // A cancelled-while-queued record owns a durable row (both fresh spawns
+    // and resume-queued follow-ups register durably), so evicting it here
+    // would strand the row with a stale pre-interrupt status and drop the
+    // follow-up message — every later checkpoint skips summaries. Leave it as
+    // a full dirty INTERRUPTED record: the terminal wave persists it, then
+    // confirmRecordsPersisted evicts it through the normal row-confirmed path.
     if (transition.notify) this._notify();
     if (!wasQueued && transition.admitNext) this._admitFromQueue();
     return true;
@@ -1393,7 +1387,6 @@ export class SubagentManager {
   private _admit(record: SubagentRecord): void {
     const transition = this._lifecycle.transition(record, { type: 'admit' });
     if (!transition) return;
-    this._persistence.markAdmitted(record.id);
     this._admission.markAdmitted(record.sessionId);
     if (transition.persist) this._markRecordDirty(record);
     this._updateLive(record, { state: SubagentState.PENDING });
@@ -1442,15 +1435,6 @@ export class SubagentManager {
       record.chain = { ...record.chain, messages: [] };
     }
     this._liveProjection.clearLiveTail(record.id);
-  }
-
-  /** Apply one summary declaration and any FIFO removals chosen by persistence. */
-  private _applySummaryConfirmation(
-    record: SubagentRecord,
-    effect: { evict: boolean; removeIds: readonly string[] },
-  ): void {
-    if (effect.evict) this._evictToSummary(record);
-    for (const id of effect.removeIds) this._removeRuntimeState(id);
   }
 
   private _removeRuntimeState(subagentId: string): void {

--- a/electron/src/main/agents/persist-subagent-chains.ts
+++ b/electron/src/main/agents/persist-subagent-chains.ts
@@ -34,6 +34,17 @@ export interface SubagentPersistenceSchedulerOptions {
   maxRetries?: number;
 }
 
+interface SubagentPersistenceFlushOptions {
+  /**
+   * Orderly-shutdown flush. Bypasses the degraded breaker — this is the last
+   * chance to persist terminal records, and a failure here is final (the
+   * process is exiting), so the retry-storm protection the breaker provides
+   * does not apply (issue #121 path b). Forced failures are logged but never
+   * counted against the budget and never rescheduled.
+   */
+  force?: boolean;
+}
+
 const CHECKPOINT_DELAY_MS = 2000;
 const RETRY_BASE_DELAY_MS = 100;
 const RETRY_MAX_DELAY_MS = 2000;
@@ -68,11 +79,14 @@ export function createSubagentPersistenceScheduler(
     }
   };
 
-  const flush = (sessionId: string): void => {
+  const flush = (sessionId: string, options: SubagentPersistenceFlushOptions = {}): void => {
+    const force = options.force === true;
     clearScheduled(sessionId);
     // A persistent failure is kept dirty for a later recovery trigger, but it
     // must not keep scheduling work by itself once its retry budget is spent.
-    if (degraded.has(sessionId)) return;
+    // A forced (shutdown) flush ignores the breaker: dropping it would strand
+    // terminal statuses held only in memory (#121).
+    if (degraded.has(sessionId) && !force) return;
     if (writing.has(sessionId)) {
       dirty.add(sessionId);
       return;
@@ -83,23 +97,31 @@ export function createSubagentPersistenceScheduler(
     try {
       write(sessionId, { recovery });
       failures.delete(sessionId);
+      if (force) degraded.delete(sessionId);
       recoveryPending.delete(sessionId);
     } catch (error) {
       dirty.add(sessionId);
-      const attempt = (failures.get(sessionId) ?? 0) + 1;
-      failures.set(sessionId, attempt);
-      if (attempt > maxRetries) {
-        degraded.add(sessionId);
+      if (force) {
         console.warn(
-          `Subagent persistence degraded for session ${sessionId}; automatic retries paused:`,
+          `Subagent persistence shutdown flush failed for session ${sessionId}:`,
           error,
         );
       } else {
-        console.debug('Subagent persistence retry scheduled:', error);
+        const attempt = (failures.get(sessionId) ?? 0) + 1;
+        failures.set(sessionId, attempt);
+        if (attempt > maxRetries) {
+          degraded.add(sessionId);
+          console.warn(
+            `Subagent persistence degraded for session ${sessionId}; automatic retries paused:`,
+            error,
+          );
+        } else {
+          console.debug('Subagent persistence retry scheduled:', error);
+        }
       }
     } finally {
       writing.delete(sessionId);
-      if (dirty.has(sessionId) && !degraded.has(sessionId)) {
+      if (dirty.has(sessionId) && !degraded.has(sessionId) && !force) {
         const attempt = failures.get(sessionId) ?? 0;
         const delay = attempt > 0
           ? Math.min(RETRY_MAX_DELAY_MS, RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
@@ -176,8 +198,10 @@ export function createSubagentPersistenceScheduler(
       }
     },
     flushAll(): void {
-      for (const sessionId of new Set([...dirty, ...scheduled.keys(), ...waves.keys()])) {
-        flush(sessionId);
+      for (const sessionId of new Set([
+        ...degraded, ...dirty, ...scheduled.keys(), ...waves.keys(),
+      ])) {
+        flush(sessionId, { force: true });
       }
     },
     /** Remove all state for a deleted session so no late timer can recreate it. */

--- a/electron/src/main/agents/subagent-persistence.ts
+++ b/electron/src/main/agents/subagent-persistence.ts
@@ -53,8 +53,6 @@ interface PersistenceState {
   timeline: SubagentPersistenceTimeline;
   dirtyRevision: number;
   confirmedRevision: number;
-  /** A spawn parked in admission has no durable row; resumed queues do. */
-  durableEligible: boolean;
   summary: boolean;
   /** Last revision at which compaction was applied (separate from summary eviction). */
   lastCompactionRevision: number | null;
@@ -79,13 +77,18 @@ export class SubagentPersistence {
     this.compactionSink = compactionSink;
   }
 
-  register(id: string, sessionId: string | null, options: { admitted: boolean }): void {
+  /**
+   * Every record starts durable: a spawn parked in the admission queue must
+   * still own a durable row, or an app close while queued leaves no record to
+   * hydrate after restart (issue #121 path a) while the frozen transcript
+   * still claims status "queued".
+   */
+  register(id: string, sessionId: string | null): void {
     this.records.set(id, {
       sessionId,
       timeline: this.nextTimeline(),
       dirtyRevision: 0,
       confirmedRevision: -1,
-      durableEligible: options.admitted,
       summary: false,
       lastCompactionRevision: null,
     });
@@ -163,15 +166,9 @@ export class SubagentPersistence {
     return state.lastCompactionRevision > state.confirmedRevision;
   }
 
-  /** Admission makes a fresh spawn durable and ends resume-queue state. */
-  markAdmitted(id: string): void {
-    this.require(id).durableEligible = true;
-  }
-
   /** A follow-up always owns an already durable record, even while queued. */
   beginFollowUp(id: string): void {
     const state = this.require(id);
-    state.durableEligible = true;
     state.summary = false;
     // The follow-up keeps the prior compaction revision: the resumed chain already carries compacted flags, so checkpoint must not treat compaction as new work.
     this.untrackSummary(state.sessionId, id);
@@ -187,7 +184,6 @@ export class SubagentPersistence {
       timeline: this.nextTimeline(),
       dirtyRevision: 0,
       confirmedRevision: -1,
-      durableEligible: true,
       summary: false,
       lastCompactionRevision: null,
     });
@@ -199,11 +195,6 @@ export class SubagentPersistence {
 
   needsHydration(id: string): boolean {
     return !this.records.has(id) || this.isSummary(id);
-  }
-
-  /** Whether the record owns a durable row (including a queued follow-up). */
-  hasDurableEligibility(id: string): boolean {
-    return this.records.get(id)?.durableEligible === true;
   }
 
   /**
@@ -218,7 +209,7 @@ export class SubagentPersistence {
     recovery = false,
   ): SubagentPersistenceCandidate | null {
     const state = this.records.get(id);
-    if (!state || state.summary || !state.durableEligible) return null;
+    if (!state || state.summary) return null;
     if (state.sessionId && state.sessionId !== sessionId) return null;
     if (!recovery && state.dirtyRevision <= state.confirmedRevision) return null;
     return {
@@ -254,21 +245,6 @@ export class SubagentPersistence {
     state.summary = true;
     const removeIds = this.trackSummary(candidate.sessionId, candidate.id);
     return { evict: true, removeIds };
-  }
-
-  /**
-   * Spawn-queued cancellation has no durable row, but retains the historic
-   * bounded summary behavior. Unlike `confirmCheckpoint`, this is intentionally
-   * not persist-first because a fresh queued record is never serializable.
-   */
-  summarizeUndurable(id: string): SubagentPersistenceConfirmation {
-    const state = this.records.get(id);
-    if (!state || state.summary) return { evict: false, removeIds: [] };
-    state.summary = true;
-    return {
-      evict: true,
-      removeIds: this.trackSummary(state.sessionId ?? '', id),
-    };
   }
 
   clearSession(sessionId: string): void {

--- a/electron/tests/unit/subagent-ipc.test.ts
+++ b/electron/tests/unit/subagent-ipc.test.ts
@@ -1008,10 +1008,10 @@ describe('persistSubagentChains dirty tracking (U6)', () => {
 
   const confirmSpy = vi.fn();
   const managerOf = (...rawRecords: unknown[]) => {
-    const records = rawRecords as Array<{ id: string; sessionId: string | null; state: string; admitted?: boolean }>;
+    const records = rawRecords as Array<{ id: string; sessionId: string | null; state: string }>;
     const persistence = new SubagentPersistence(() => 25);
     for (const record of records) {
-      persistence.register(record.id, record.sessionId, { admitted: record.admitted !== false });
+      persistence.register(record.id, record.sessionId);
     }
     return {
       allRecords: () => records,
@@ -1066,26 +1066,28 @@ describe('persistSubagentChains dirty tracking (U6)', () => {
       .toEqual(['sub-b']);
   });
 
-  it('never upserts queued or pre-admission records (queued is runtime-only)', () => {
+  it('upserts queued and cancelled-while-queued records too (queued spawns own a durable row, #121)', () => {
     const admitted = runtimeRecord('sub-admitted', sid, { queuedAt: 5, startedAt: 9 });
     const queued = runtimeRecord('sub-queued', sid, {
-      state: 'queued', queuedAt: 5, startedAt: null, admitted: false,
+      state: 'queued', queuedAt: 5, startedAt: null,
     });
     const cancelledWhileQueued = runtimeRecord('sub-cancelled', sid, {
-      state: 'interrupted', queuedAt: 5, startedAt: null, admitted: false,
+      state: 'interrupted', queuedAt: 5, startedAt: null,
     });
     const manager = managerOf(admitted, queued, cancelledWhileQueued);
 
     persistSubagentChains(manager, sid);
     expect(sessionManagerStub.syncSubagentRecords).toHaveBeenCalledTimes(1);
     expect(sessionManagerStub.syncSubagentRecords.mock.calls[0][1].map((r: { id: string }) => r.id))
-      .toEqual(['sub-admitted']);
+      .toEqual(['sub-admitted', 'sub-queued', 'sub-cancelled']);
 
-    // Even a recovery flush must not write records that never reached admission.
+    // The successful checkpoint confirmed the terminal record (evicted to a
+    // summary), so a recovery flush rewrites only the non-summary rows —
+    // the confirmed durable row is never clobbered with the summary shape.
     persistSubagentChains(manager, sid, { recovery: true });
     expect(sessionManagerStub.syncSubagentRecords).toHaveBeenCalledTimes(2);
     expect(sessionManagerStub.syncSubagentRecords.mock.calls[1][1].map((r: { id: string }) => r.id))
-      .toEqual(['sub-admitted']);
+      .toEqual(['sub-admitted', 'sub-queued']);
   });
 
   it('treats recovery flushes as all records dirty', () => {

--- a/electron/tests/unit/subagent-persistence.test.ts
+++ b/electron/tests/unit/subagent-persistence.test.ts
@@ -166,7 +166,7 @@ afterEach(() => {
 describe('SubagentPersistence', () => {
   it('confirms only the captured terminal revision, preserving a resumed generation', () => {
     const persistence = new SubagentPersistence(() => 2);
-    persistence.register('sub-1', 'session-1', { admitted: true });
+    persistence.register('sub-1', 'session-1');
     persistence.markDirty('sub-1');
     const terminal = persistence.checkpointCandidate('sub-1', 'session-1', true)!;
 
@@ -180,8 +180,8 @@ describe('SubagentPersistence', () => {
 
   it('retains summaries FIFO and resets checkpoint eligibility when rehydrated', () => {
     const persistence = new SubagentPersistence(() => 1);
-    persistence.register('old', 'session-1', { admitted: true });
-    persistence.register('new', 'session-1', { admitted: true });
+    persistence.register('old', 'session-1');
+    persistence.register('new', 'session-1');
 
     const old = persistence.checkpointCandidate('old', 'session-1', true)!;
     expect(persistence.confirmCheckpoint(old)).toEqual({ evict: true, removeIds: [] });
@@ -196,7 +196,7 @@ describe('SubagentPersistence', () => {
 
   it('tracks confirmed sessions for recovery and clears every owned policy fact', () => {
     const persistence = new SubagentPersistence(() => 2);
-    persistence.register('sub-1', 'session-1', { admitted: true });
+    persistence.register('sub-1', 'session-1');
     persistence.confirmCheckpoint(persistence.checkpointCandidate('sub-1', 'session-1', false)!);
 
     expect(persistence.trackedSessions()).toEqual(['session-1']);
@@ -207,7 +207,7 @@ describe('SubagentPersistence', () => {
 
   it('rejects a terminal confirmation captured before the same id is rehydrated', () => {
     const persistence = new SubagentPersistence(() => 2);
-    persistence.register('sub-1', 'session-1', { admitted: true });
+    persistence.register('sub-1', 'session-1');
     persistence.markDirty('sub-1');
     const stale = persistence.checkpointCandidate('sub-1', 'session-1', true)!;
     expect(persistence.confirmCheckpoint(stale).evict).toBe(true);
@@ -223,24 +223,14 @@ describe('SubagentPersistence', () => {
       .toBe(current.revision);
   });
 
-  it('admits a fresh record to checkpoint eligibility only after admission', () => {
+  it('registers a fresh record as immediately checkpoint-eligible (queued spawns own a durable row)', () => {
     const persistence = new SubagentPersistence(() => 2);
-    persistence.register('sub-1', 'session-1', { admitted: false });
+    persistence.register('sub-1', 'session-1');
 
-    expect(persistence.checkpointCandidate('sub-1', 'session-1', false)).toBeNull();
-
-    persistence.markAdmitted('sub-1');
-
+    // A spawn parked in the admission queue must produce a durable row from
+    // its first checkpoint, or an app close while queued loses the record
+    // entirely (issue #121 path a).
     expect(persistence.checkpointCandidate('sub-1', 'session-1', false)).not.toBeNull();
-  });
-
-  it('uses the legacy empty-session FIFO for undurable queued cancellations', () => {
-    const persistence = new SubagentPersistence(() => 1);
-    persistence.register('old', null, { admitted: false });
-    expect(persistence.summarizeUndurable('old')).toEqual({ evict: true, removeIds: [] });
-
-    persistence.register('new', null, { admitted: false });
-    expect(persistence.summarizeUndurable('new')).toEqual({ evict: true, removeIds: ['old'] });
   });
 });
 
@@ -751,7 +741,7 @@ describe('SubagentCompactionController durable-write integration (R36)', () => {
       emptyChain: () => makeChain(SESSION_ID, `chain-${SUB_ID}`, []),
       onPrepareEvaluated: () => undefined,
     });
-    persistence.register(SUB_ID, SESSION_ID, { admitted: true });
+    persistence.register(SUB_ID, SESSION_ID);
     return { controller, record, historyBox, assembler, persistence, progress, dirtyCount: () => dirty };
   }
 

--- a/electron/tests/unit/subagent-restart-desync.test.ts
+++ b/electron/tests/unit/subagent-restart-desync.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Reproduction for issue #121 — subagent status desynchronized after app
+ * close/restart.
+ *
+ * Three claimed data-loss paths were audited against the report:
+ *  (a) a spawn still parked in the admission queue when the app closes never
+ *      becomes durable-eligible, so no flush path (checkpoint, terminal wave,
+ *      shutdown flushAll) can write its row — after restart the record simply
+ *      does not exist while the frozen transcript still says status "queued".
+ *  (b) the persistence breaker: after maxRetries+1 failed writes a session is
+ *      degraded and flush() early-returns — including inside flushAll() at
+ *      orderly shutdown, so a terminal status completed in-memory is never
+ *      written. The last good row says "running", which the restore migration
+ *      turns into "interrupted".
+ *  (c) hydration permanently caching empty results — NOT reproduced at HEAD:
+ *      SubagentHydrationReadiness evicts rejections and agentMissing results
+ *      (retain callback), and the send path re-runs hydration with a resolved
+ *      project runtime. Covered by subagent-hydration-readiness.test.ts.
+ *
+ * Both paths are fixed and these tests pin the fix end-to-end through the
+ * same collaborators production uses: SubagentManager, the persistence
+ * scheduler, the storage layer's restore migration, and manager.hydrate (the
+ * exact path build-prompt-context's mapSubagents reads via getStates after a
+ * restart).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { AgentTier, AgentType, type Agent } from '../../src/shared/types/agent';
+import { SubagentManager } from '../../src/main/agents/manager';
+import { SubagentState } from '../../src/main/agents/types';
+import { SubagentStatus } from '../../src/shared/types/subagent';
+import { createSubagentPersistenceScheduler } from '../../src/main/agents/persist-subagent-chains';
+import {
+  _clearDbCache,
+  loadSubagentRecords,
+  saveSession,
+  upsertSubagentRecords,
+  type StorageOptions,
+} from '../../src/main/session/storage';
+import type { Session } from '../../src/shared/types/session';
+import type { SubagentRecord } from '../../src/shared/types/subagent';
+
+vi.mock('electron', () => ({
+  webContents: {
+    getAllWebContents: () => [],
+    fromId: () => null,
+  },
+}));
+
+vi.mock('../../src/main/session/singleton', () => ({
+  getSessionManager: () => ({
+    getSession: vi.fn(() => ({ cwd: null })),
+    getActive: vi.fn(() => ({ cwd: null })),
+  }),
+}));
+
+vi.mock('../../src/main/project/runtime', () => ({
+  getProjectRuntimeRegistry: () => ({ get: vi.fn() }),
+}));
+
+vi.mock('../../src/main/providers', () => ({
+  getProviderRuntime: () => ({ resolveExecution: vi.fn() }),
+}));
+
+vi.mock('../../src/main/providers/accounting/store', () => ({
+  getProviderAccountingStore: () => ({}),
+}));
+
+vi.mock('../../src/main/providers/accounting/subagent-attribution-store', () => ({
+  getSubagentAttributionStore: () => ({ insert: vi.fn(), finalize: vi.fn() }),
+}));
+
+vi.mock('../../src/main/llm/orchestrator', () => ({
+  streamChat: vi.fn(),
+}));
+
+vi.mock('../../src/main/llm/build-prompt-context', () => ({
+  buildSystemPromptContext: vi.fn(async () => ({})),
+}));
+
+vi.mock('../../src/main/mcp/project-registry', () => ({
+  acquireProjectMCPManager: vi.fn(),
+  releaseProjectMCPManager: vi.fn(),
+}));
+
+const T0 = '2026-01-01T00:00:00.000Z';
+const SESSION_ID = 'cafe4211-4211-4211-8211-000000000121';
+
+const explorerAgent: Agent = {
+  name: 'explorer',
+  type: AgentType.SUBAGENT,
+  tier: AgentTier.SEED,
+  description: 'Explores and searches a codebase',
+  allowed_tools: ['read', 'grep', 'glob'],
+  allowed_skills: ['*'],
+};
+
+let tmpDir: string;
+let storageOpts: StorageOptions;
+
+function makeStoredRecord(status: SubagentStatus): SubagentRecord {
+  return {
+    id: `sub-issue-121-${status}`,
+    agent_name: 'explorer',
+    agent_type: 'subagent',
+    agent_tier: 'seed',
+    task: 'explore codebase',
+    status,
+    chain_id: `chain-issue-121-${status}`,
+    start_time: T0,
+    end_time: status === SubagentStatus.RUNNING ? null : T0,
+    result: status === SubagentStatus.COMPLETED ? 'found three modules' : null,
+    error: null,
+    parentChainIndex: 0,
+    closed: false,
+    chain: {
+      id: `chain-issue-121-${status}`,
+      sessionId: SESSION_ID,
+      messages: [],
+      status: 'completed',
+      selection: null,
+      modelLabel: null,
+      agentName: 'explorer',
+      agentType: 'subagent',
+      agentTier: 'seed',
+      subagentRecord: null,
+      startTime: T0,
+      endTime: T0,
+      errorDetail: null,
+      errorTitle: null,
+    },
+  };
+}
+
+function seedSession(): void {
+  const session: Session = {
+    id: SESSION_ID,
+    name: 'Issue 121 Repro',
+    selection: null,
+    modelLabel: null,
+    cwd: null,
+    chains: [],
+    activeChainId: null,
+    createdAt: T0,
+    updatedAt: T0,
+    subagentChains: [],
+    todoStore: { tasks: [] },
+    reasoningEffortOverride: null,
+    tierOverride: null,
+    permissionMode: null,
+  };
+  saveSession(session, storageOpts);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orchid-issue-121-repro-'));
+  storageOpts = {
+    dbPath: path.join(tmpDir, 'sessions.db'),
+    toolOutputCacheDir: path.join(tmpDir, 'cache', 'tool-output'),
+    webFetchCacheDir: path.join(tmpDir, 'cache', 'web-fetch'),
+  };
+});
+
+afterEach(() => {
+  _clearDbCache();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('issue #121 (a): queued-at-close spawn leaves no durable row', () => {
+  it('a spawn parked in the admission queue is included in the checkpoint candidate set', () => {
+    const manager = new SubagentManager();
+
+    // Saturate the active limits until one spawn parks in the queue. The
+    // runner is unset (unit-test convention), so admitted spawns stay PENDING
+    // and hold their admission slots.
+    let queuedId: string | null = null;
+    for (let i = 0; i < 64 && queuedId === null; i += 1) {
+      const record = manager.spawn(`probe-${i}`, 'explore things', explorerAgent, {
+        sessionId: SESSION_ID,
+      });
+      if (record.state === SubagentState.QUEUED) queuedId = record.id;
+    }
+    expect(queuedId).not.toBeNull();
+
+    // The delegate_to_subagent result froze this status into the transcript.
+    const queued = manager.getRecord(queuedId!);
+    expect(queued?.state).toBe(SubagentState.QUEUED);
+
+    // Every flush path — debounced checkpoint, terminal wave, and the shutdown
+    // flushAll — serializes exactly manager.checkpointCandidates(sessionId).
+    // Queued spawns register durably, so the row is written even if the app
+    // closes before admission.
+    const persistedIds = manager
+      .checkpointCandidates(SESSION_ID)
+      .map((candidate) => candidate.record.id);
+    expect(persistedIds).toContain(queuedId);
+
+    // A recovery flush (the missing-row contract) covers it too.
+    const recoveryIds = manager
+      .checkpointCandidates(SESSION_ID, { recovery: true })
+      .map((candidate) => candidate.record.id);
+    expect(recoveryIds).toContain(queuedId);
+  });
+
+  it('a queued row written before close restores as INTERRUPTED in the post-restart prompt states', () => {
+    seedSession();
+
+    // Spawn to saturation so one record parks in the admission queue, then
+    // write the checkpoint exactly like the shutdown flushAll does.
+    const manager = new SubagentManager();
+    let queued: ReturnType<SubagentManager['spawn']> | null = null;
+    for (let i = 0; i < 64 && queued === null; i += 1) {
+      const record = manager.spawn(`probe-${i}`, 'explore things', explorerAgent, {
+        sessionId: SESSION_ID,
+      });
+      if (record.state === SubagentState.QUEUED) queued = record;
+    }
+    expect(queued).not.toBeNull();
+
+    const candidates = manager.checkpointCandidates(SESSION_ID);
+    const domainRecords = candidates.map(({ record }) => manager.toDomainRecord(record));
+    upsertSubagentRecords(SESSION_ID, domainRecords, T0, storageOpts);
+
+    // App restarts: the row exists and the restore migration flips the queued
+    // status to interrupted (an app restart never resumes an admission queue).
+    const restored = loadSubagentRecords(SESSION_ID, undefined, storageOpts);
+    const restoredQueued = restored.find((record) => record.id === queued!.id);
+    expect(restoredQueued).toBeDefined();
+    expect(restoredQueued!.status).toBe(SubagentStatus.INTERRUPTED);
+
+    // Hydration materializes it into the fresh manager — the system-prompt
+    // source now reports an accurate terminal state instead of omitting the
+    // subagent while the frozen transcript still says status "queued".
+    const restarted = new SubagentManager();
+    restarted.hydrate([{
+      id: restoredQueued!.id,
+      agent: explorerAgent,
+      domain: restoredQueued!,
+      sessionId: SESSION_ID,
+      windowId: null,
+      cwd: null,
+    }]);
+    const states = restarted.getStates(SESSION_ID);
+    expect(states.find((state) => state.id === queued!.id)?.state)
+      .toBe(SubagentState.INTERRUPTED);
+  });
+});
+
+describe('issue #121 (b): degraded persistence breaker drops the shutdown flush', () => {
+  it('the shutdown flushAll bypasses the degraded breaker and writes terminal status', () => {
+    vi.useFakeTimers();
+    const write = vi.fn(() => {
+      throw new Error('simulated storage failure');
+    });
+    const scheduler = createSubagentPersistenceScheduler(write);
+
+    // Debounced checkpoint fires at t=2000 and fails (attempt 1), scheduling
+    // exponential retries at +100/+200/+400ms. The fourth failure exceeds
+    // maxRetries=3 and trips the breaker.
+    scheduler.markDirty(SESSION_ID);
+    vi.advanceTimersByTime(2000 + 100 + 200 + 400);
+    expect(scheduler.isDegraded(SESSION_ID)).toBe(true);
+    const attemptsWhenDegraded = write.mock.calls.length;
+    expect(attemptsWhenDegraded).toBe(4);
+
+    // Storage recovers (disk freed, DB rebuilt). Orderly shutdown runs
+    // flushSubagentPersistence() → scheduler.flushAll(), which forces the
+    // flush past the degraded breaker: the terminal status held in memory is
+    // written, and a success reopens the session.
+    write.mockImplementation(() => {});
+    scheduler.flushAll();
+    expect(write.mock.calls.length).toBe(attemptsWhenDegraded + 1);
+    expect(scheduler.isDegraded(SESSION_ID)).toBe(false);
+
+    scheduler.dispose();
+  });
+
+  it('a failing forced shutdown flush is final: logged, not counted, never rescheduled', () => {
+    vi.useFakeTimers();
+    const write = vi.fn(() => {
+      throw new Error('simulated storage failure');
+    });
+    const scheduler = createSubagentPersistenceScheduler(write, undefined, { maxRetries: 0 });
+
+    scheduler.markDirty(SESSION_ID);
+    vi.advanceTimersByTime(2000);
+    expect(scheduler.isDegraded(SESSION_ID)).toBe(true);
+    const attemptsWhenDegraded = write.mock.calls.length;
+    expect(attemptsWhenDegraded).toBe(1);
+
+    // Storage is still broken at shutdown. The forced flush attempts the
+    // write once, does not re-trip anything, and schedules no retry timer
+    // that could never fire in an exiting process.
+    scheduler.flushAll();
+    expect(write.mock.calls.length).toBe(attemptsWhenDegraded + 1);
+    vi.advanceTimersByTime(10_000);
+    expect(write.mock.calls.length).toBe(attemptsWhenDegraded + 1);
+
+    scheduler.dispose();
+  });
+
+  it('the RUNNING row left behind by the lost terminal write restores as INTERRUPTED in the prompt states', () => {
+    seedSession();
+
+    // Last good checkpoint before the terminal wave was dropped: status RUNNING.
+    const running = makeStoredRecord(SubagentStatus.RUNNING);
+    upsertSubagentRecords(SESSION_ID, [running], T0, storageOpts);
+
+    // App restarts: the read path migrates queued/pending/running → interrupted.
+    const restored = loadSubagentRecords(SESSION_ID, undefined, storageOpts);
+    expect(restored).toHaveLength(1);
+    expect(restored[0].status).toBe(SubagentStatus.INTERRUPTED);
+
+    // Session-open/send hydration materializes the row into the fresh manager
+    // (the exact call chain build-prompt-context.mapSubagents reads).
+    const manager = new SubagentManager();
+    manager.hydrate([{
+      id: restored[0].id,
+      agent: explorerAgent,
+      domain: restored[0],
+      sessionId: SESSION_ID,
+      windowId: null,
+      cwd: null,
+    }]);
+
+    const states = manager.getStates(SESSION_ID);
+    expect(states).toHaveLength(1);
+    // The subagent actually COMPLETED before the app closed.
+    expect(states[0].state).toBe(SubagentState.INTERRUPTED);
+  });
+
+  it('contrast: a persisted COMPLETED row restores as COMPLETED (the normal flow is correct)', () => {
+    seedSession();
+    upsertSubagentRecords(
+      SESSION_ID,
+      [makeStoredRecord(SubagentStatus.COMPLETED)],
+      T0,
+      storageOpts,
+    );
+
+    const restored = loadSubagentRecords(SESSION_ID, undefined, storageOpts);
+    expect(restored[0].status).toBe(SubagentStatus.COMPLETED);
+
+    const manager = new SubagentManager();
+    manager.hydrate([{
+      id: restored[0].id,
+      agent: explorerAgent,
+      domain: restored[0],
+      sessionId: SESSION_ID,
+      windowId: null,
+      cwd: null,
+    }]);
+    expect(manager.getStates(SESSION_ID)[0].state).toBe(SubagentState.COMPLETED);
+  });
+});

--- a/electron/tests/unit/subagent-runtime.test.ts
+++ b/electron/tests/unit/subagent-runtime.test.ts
@@ -939,9 +939,10 @@ describe('SubagentManager admission control (U7)', () => {
     expect(manager.getRunPromise(third.id)).toBeNull();
     expect(third.queuedAt).not.toBeNull();
     expect(third.startedAt).toBeNull();
-    // Queued records stay out of durable tracking until admission.
+    // Queued records own a durable row from spawn (issue #121): a close while
+    // parked in admission must still leave a record to hydrate after restart.
     expect(manager.checkpointCandidates('sess-admit').map((candidate) => candidate.record.id))
-      .not.toContain(third.id);
+      .toContain(third.id);
     expect(manager.getQueuePosition(third.id)).toBe(1);
     expect(gates).toHaveLength(2);
 
@@ -1399,7 +1400,7 @@ describe('SubagentManager terminal eviction and session purge (U9)', () => {
     expect(manager.getRecord(record.id)).toBeUndefined();
   });
 
-  it('cancelling a queued record evicts it to a retention-capped summary (review #15)', () => {
+  it('cancelling a queued record persists it as INTERRUPTED and evicts on row confirmation (#121)', () => {
     setConfig({ terminal_retention: 2, max_active_per_session: 1 });
     const sid = 'sess-queued-evict';
     // One admitted record holds the only run slot; later spawns park in queue.
@@ -1412,14 +1413,18 @@ describe('SubagentManager terminal eviction and session purge (U9)', () => {
       expect(record.state).toBe(SubagentState.QUEUED);
       expect(manager.cancelOne(record.id)).toBe(true);
       queuedIds.push(record.id);
-      // Cancelled while queued → evicted to a lean summary, not a full record.
-      expect(manager.isSummary(record.id)).toBe(true);
+      // Cancelled while queued → stays a full dirty INTERRUPTED record so the
+      // terminal wave can persist the row (no undurable eviction anymore).
+      expect(manager.isSummary(record.id)).toBe(false);
       expect(record.state).toBe(SubagentState.INTERRUPTED);
-      expect(record.chain?.messages).toEqual([]);
     }
 
-    // The retention FIFO caps them: oldest removed entirely, newest two kept.
+    // Confirming the written rows evicts them to lean summaries; the retention
+    // FIFO caps them: oldest removed entirely, newest two kept.
+    manager.confirmRecordsPersisted(sid, queuedIds);
     expect(manager.getRecord(queuedIds[0])).toBeUndefined();
+    expect(manager.isSummary(queuedIds[1])).toBe(true);
+    expect(manager.isSummary(queuedIds[2])).toBe(true);
     expect(manager.allRecords().filter((r) => r.sessionId === sid)
       .map((r) => r.id)).toEqual([active.id, queuedIds[1], queuedIds[2]]);
 
@@ -1977,7 +1982,7 @@ describe('SubagentManager follow-up resume (U4)', () => {
     expect(manager.getQueuePosition(target.id)).toBeNull();
   });
 
-  it('persistence eligibility: a resume-queued record keeps its durable row; a spawn-queued record is still skipped', async () => {
+  it('persistence eligibility: spawn-queued and resume-queued records both own a durable row (#121)', async () => {
     setLimits({ max_active_per_session: 1 });
     const gates: Array<() => void> = [];
     manager.setRunner(gateRunner(gates));
@@ -1995,7 +2000,7 @@ describe('SubagentManager follow-up resume (U4)', () => {
     const spawnQueued = manager.spawn('spawn-queued', 'x', testAgent, { sessionId: 'sess-elig' });
     expect(spawnQueued.state).toBe(SubagentState.QUEUED);
     expect(manager.checkpointCandidates('sess-elig').map((candidate) => candidate.record.id))
-      .not.toContain(spawnQueued.id);
+      .toContain(spawnQueued.id);
 
     manager.followUp(target.id, 'again');
     expect(target.state).toBe(SubagentState.QUEUED);

--- a/electron/tests/unit/subagent-snapshot-eviction.test.ts
+++ b/electron/tests/unit/subagent-snapshot-eviction.test.ts
@@ -557,8 +557,8 @@ describe('exact-revision checkpoint confirmation', () => {
   });
 });
 
-describe('records cancelled while queued never persist (P3 #15)', () => {
-  it('cancel-queued → FIFO-capped evicted summary; no durable row is written, even on recovery', () => {
+describe('records cancelled while queued persist an interrupted row (#121)', () => {
+  it('cancel-queued → durable INTERRUPTED row, then FIFO-capped summary after confirmation', () => {
     const sid = makeSession();
     configOverride.current = {
       ...defaults(),
@@ -580,25 +580,32 @@ describe('records cancelled while queued never persist (P3 #15)', () => {
       expect(record.state).toBe(SubagentState.QUEUED);
       expect(manager.cancelOne(record.id)).toBe(true);
       queuedIds.push(record.id);
-      // Cancelled while queued → evicted to a lean summary (chain emptied).
-      expect(manager.isSummary(record.id)).toBe(true);
-      expect(record.chain?.messages).toEqual([]);
+      // Cancelled while queued → stays a full dirty INTERRUPTED record so the
+      // terminal wave can write its durable row (issue #121 path a).
+      expect(manager.isSummary(record.id)).toBe(false);
+      expect(record.state).toBe(SubagentState.INTERRUPTED);
     }
 
-    // The retention FIFO capped the summaries: the oldest left allRecords.
+    // An app close right here would run the shutdown flush; the ordinary
+    // checkpoint writes every interrupted row — a restart can then hydrate
+    // accurate terminal statuses instead of dropping the records entirely.
+    persistSubagentChains(manager, sid);
+    for (const id of queuedIds) {
+      const raw = readRawRecordJson(sid, id);
+      expect(raw).toBeDefined();
+      expect(JSON.parse(raw!).status).toBe('interrupted');
+    }
+
+    // The successful checkpoint confirmed + evicted them to lean summaries,
+    // and the retention FIFO capped those: the oldest left allRecords.
     expect(manager.getRecord(queuedIds[0])).toBeUndefined();
     expect(manager.allRecords().filter((r) => r.sessionId === sid)).toHaveLength(3);
 
-    // Never-admitted records want no durable row — not from an ordinary
-    // checkpoint and not from a recovery flush (which treats every record as
-    // dirty but must still skip evicted summaries).
-    persistSubagentChains(manager, sid);
-    for (const id of queuedIds) {
-      expect(readRawRecordJson(sid, id)).toBeUndefined();
-    }
+    // A recovery flush re-serializes nothing for evicted summaries — the
+    // confirmed durable rows stay intact.
     persistSubagentChains(manager, sid, { recovery: true });
     for (const id of queuedIds) {
-      expect(readRawRecordJson(sid, id)).toBeUndefined();
+      expect(readRawRecordJson(sid, id)).toBeDefined();
     }
   });
 });


### PR DESCRIPTION
…(#121)

Two data-loss paths left subagent statuses desynchronized after an app restart, so the system prompt's subagent block went missing or stale and the model inferred statuses from the frozen transcript:

(a) A spawn parked in the admission queue when the app closed left no
    durable row (durableEligible was false until admission), so restart
    hydration had nothing to materialize. Queued spawns now register
    durably from spawn; a QUEUED row restores as INTERRUPTED through the
    existing restore migration. The undurable-queued carve-out is gone:
    cancelling while queued persists an INTERRUPTED row and evicts to a
    summary on row confirmation, the same path resume-queued follow-ups
    already used.

(b) The persistence breaker (3 failed writes) made flush() early-return
    for degraded sessions, including inside flushAll() at orderly
    shutdown — terminal statuses held only in memory were silently lost.
    The shutdown flushAll now forces the write past the breaker: a
    failure is final (logged, not counted, never rescheduled) and a
    success reopens the session.

Adds subagent-restart-desync.test.ts covering both fixes end-to-end (spawn → checkpoint → restart → restore migration → hydrate → getStates), and updates four suites that encoded the old undurable-queued contract.