### PR TITLE
fix(subagents): self-heal missed run seeds so subagent live streams never silently freeze

### DIFF
--- a/electron/src/main/agents/subagent-events.ts
+++ b/electron/src/main/agents/subagent-events.ts
@@ -57,11 +57,20 @@ const MAX_STALLED_CARRY_FLUSHES = 40;
 
 const lastDropWarnAt = new Map<string, number>();
 
+/**
+ * Upper bound on throttle bookkeeping keys (`ineligible:${sessionId}` /
+ * `stall-drop:${sessionId}`). Sessions are long-lived UUIDs and the store is
+ * never pruned by session lifecycle, so cap it: at capacity the whole map is
+ * cleared (worst case a hot key re-warns once, then throttles again).
+ */
+const MAX_DROP_WARN_KEYS = 128;
+
 /** Throttled drop warning: at most one per key per five seconds. */
 function warnDrop(key: string, message: string): void {
   const now = Date.now();
   const last = lastDropWarnAt.get(key) ?? 0;
   if (now - last < 5_000) return;
+  if (lastDropWarnAt.size >= MAX_DROP_WARN_KEYS) lastDropWarnAt.clear();
   lastDropWarnAt.set(key, now);
   console.warn(`[subagent-events] ${message}`);
 }

--- a/electron/src/main/agents/subagent-events.ts
+++ b/electron/src/main/agents/subagent-events.ts
@@ -55,6 +55,17 @@ const FLUSH_MAX_MS = 50;
  */
 const MAX_STALLED_CARRY_FLUSHES = 40;
 
+const lastDropWarnAt = new Map<string, number>();
+
+/** Throttled drop warning: at most one per key per five seconds. */
+function warnDrop(key: string, message: string): void {
+  const now = Date.now();
+  const last = lastDropWarnAt.get(key) ?? 0;
+  if (now - last < 5_000) return;
+  lastDropWarnAt.set(key, now);
+  console.warn(`[subagent-events] ${message}`);
+}
+
 function isAppendDelta(
   event: SubagentDeltaEvent,
 ): event is SubagentTextDeltaEvent | SubagentThinkingDeltaEvent {
@@ -189,6 +200,7 @@ export function createSubagentDeltaBatcher(
     };
     let normalCount = 0;
     let bytes = 0;
+    const droppedForSession = new Map<string, { count: number; types: Set<string> }>();
     for (const event of merged) {
       let eligible = eligibility.get(event.sessionId);
       if (eligible === undefined) {
@@ -197,7 +209,14 @@ export function createSubagentDeltaBatcher(
       }
       if (!eligible) {
         // Carry lifecycle handoffs in order for a later flush; drop content.
-        if (isLifecycleDelta(event)) deferred.push(event);
+        if (isLifecycleDelta(event)) {
+          deferred.push(event);
+        } else {
+          const entry = droppedForSession.get(event.sessionId) ?? { count: 0, types: new Set<string>() };
+          entry.count += 1;
+          entry.types.add(event.type);
+          droppedForSession.set(event.sessionId, entry);
+        }
         continue;
       }
       if (isLifecycleDelta(event)) {
@@ -217,6 +236,13 @@ export function createSubagentDeltaBatcher(
     }
     queue = deferred;
 
+    for (const [sessionId, { count, types }] of droppedForSession) {
+      warnDrop(`ineligible:${sessionId}`,
+        `dropped ${count} content delta(s) for session ${sessionId} with no eligible recipient ` +
+        `(types: ${[...types].join(', ')}); snapshots re-establish state but live streaming stays off ` +
+        `until the session regains a viewing client`);
+    }
+
     for (const [sessionId, events] of envelopes) {
       deliver({ sessionId, events });
     }
@@ -235,6 +261,11 @@ export function createSubagentDeltaBatcher(
         // budget, then drop the carry so the loop cannot run forever.
         stalledFlushes += 1;
         if (stalledFlushes > MAX_STALLED_CARRY_FLUSHES) {
+          for (const event of queue) {
+            warnDrop(`stall-drop:${event.sessionId}`,
+              `dropped carried ${event.type} delta for ${event.subagentId} ` +
+              `(session ${event.sessionId} stayed ineligible past the carry budget)`);
+          }
           queue = [];
           stalledFlushes = 0;
         } else {

--- a/electron/src/renderer/hooks/useSubagents.ts
+++ b/electron/src/renderer/hooks/useSubagents.ts
@@ -222,6 +222,12 @@ export function useSubagents(activeSessionId: string | null): UseSubagentsReturn
         hydrationBufferBytes: hydrationBufferBytesRef.current,
       });
       if (next !== before) commit(next);
+      // Deltas dropped for a missing/stale run seed mean the live stream is
+      // wedged: only a snapshot reseed can re-open it. One refresh per new
+      // hint keeps the view streaming without user action (view re-entry).
+      if (next.seedHints.size > before.seedHints.size && activeRef.current) {
+        void hydrate(activeRef.current);
+      }
       // A newly raised floor means buffered intermediates were discarded:
       // reseed from a snapshot whose revision meets the floor.
       if (next.reseedFloor !== null && next.reseedFloor !== before.reseedFloor && activeRef.current) {

--- a/electron/src/renderer/hooks/useSubagents.ts
+++ b/electron/src/renderer/hooks/useSubagents.ts
@@ -184,6 +184,18 @@ export function useSubagents(activeSessionId: string | null): UseSubagentsReturn
         sessionId, requestedId: requestedRef.current ?? previous, existingId: previous, existingSessionId: selectedSessionRef.current,
       }));
       setSelectedSessionId(sessionId);
+      // A seed that still leaves seed hints — a wrong-run delta replayed from
+      // the hydration buffer, or a stale snapshot omitting the run — was never
+      // observed by the onEvent growth check, so drive the bounded reseed
+      // here. At the limit, drop the hints: leaving them set would permanently
+      // block a fresh hint (and another heal) for a later run of the subagent.
+      if (next.seedHints.size > 0) {
+        if (reseedAttempts < RESEED_RETRY_LIMIT) {
+          void hydrate(sessionId, false, reseedAttempts + 1);
+        } else {
+          commit({ ...streamRef.current, seedHints: new Set() });
+        }
+      }
     } catch (error) {
       if (request === requestRef.current && activeRef.current === sessionId && streamRef.current.generation === generation) {
         commit(failSubagentSnapshot(streamRef.current, error instanceof Error ? error.message : String(error)));

--- a/electron/src/renderer/utils/subagent-stream.ts
+++ b/electron/src/renderer/utils/subagent-stream.ts
@@ -377,18 +377,22 @@ function applyDeltaEvents(
       high = event.sequence;
     }
     warnDroppedDeltas(subagentId, dropped, runId, knownRun);
+    const seedDrop = dropped.has('unseeded-run') || dropped.has('run-mismatch');
     // A run whose deltas were dropped for a missing/stale seed can only be
     // re-opened by a fresh `spawned` or a snapshot seed. Surface that need so
-    // the hook can refresh once instead of freezing the stream.
-    if (
-      (dropped.has('unseeded-run') || dropped.has('run-mismatch'))
-      && !state.seedHints.has(subagentId)
-      && state.records.some((item) => item.id === subagentId && !isSettled(item.status))
-    ) {
+    // the hook can refresh once instead of freezing the stream. Evaluated
+    // against the FINAL records: a terminal settling the row later in this
+    // same batch must not leave a stale hint behind.
+    const raiseSeedHint = (): void => {
+      if (!seedDrop || state.seedHints.has(subagentId)) return;
+      if (!records.some((item) => item.id === subagentId && !isSettled(item.status))) return;
       seedHints ??= new Set(state.seedHints);
       seedHints.add(subagentId);
+    };
+    if (applicable.length === 0) {
+      raiseSeedHint();
+      continue;
     }
-    if (applicable.length === 0) continue;
 
     if (runId !== undefined && runId !== knownRun) {
       runs ??= new Map(state.runs);
@@ -458,6 +462,7 @@ function applyDeltaEvents(
       live ??= new Map(state.live);
       live.set(subagentId, draft);
     }
+    raiseSeedHint();
   }
 
   if (records === state.records && live === null && highWater === null && runs === null && seedHints === null) {

--- a/electron/src/renderer/utils/subagent-stream.ts
+++ b/electron/src/renderer/utils/subagent-stream.ts
@@ -30,6 +30,14 @@ export interface SubagentStreamState {
    * overflow. Set (and only ever raised) on overflow; cleared on seed.
    */
   readonly reseedFloor: number | null;
+  /**
+   * Subagent ids whose latest deltas were dropped because the renderer holds
+   * no (or a stale) run seed. Grows only when a new id diverges; cleared by a
+   * snapshot seed. The hook reacts to growth with one snapshot refresh so a
+   * missed `spawned` self-heals instead of freezing the live stream until the
+   * user re-enters the view.
+   */
+  readonly seedHints: ReadonlySet<string>;
   readonly error: string | null;
   readonly generation: number;
 }
@@ -67,6 +75,7 @@ export function createSubagentStreamState(): SubagentStreamState {
     buffered: [],
     bufferedBytes: 0,
     reseedFloor: null,
+    seedHints: new Set(),
     error: null,
     generation: 0,
   };
@@ -88,6 +97,7 @@ export function bindSubagentSession(
     buffered: [],
     bufferedBytes: 0,
     reseedFloor: null,
+    seedHints: new Set(),
     error: null,
     generation: state.generation + 1,
   };
@@ -313,20 +323,27 @@ function applyDeltaEvents(
   let live: Map<string, SubagentLiveProjection> | null = null;
   let highWater: Map<string, number> | null = null;
   let runs: Map<string, string> | null = null;
+  let seedHints: Set<string> | null = null;
 
   for (const [subagentId, deltas] of bySubagent) {
     const knownRun = (runs ?? state.runs).get(subagentId);
     let high = (highWater ?? state.highWater).get(subagentId);
 
     const applicable: SubagentDeltaEvent[] = [];
+    const dropped = new Map<string, number>();
+    const drop = (reason: string): void => {
+      dropped.set(reason, (dropped.get(reason) ?? 0) + 1);
+    };
     let runId = knownRun;
     for (const event of deltas) {
       if ((event.type === 'spawned' || event.type === 'terminal') && event.record.id !== subagentId) {
+        drop('record-id-mismatch');
         continue;
       }
       // A status transition never settles a run — the terminal record is the
       // authoritative handoff — so a malformed terminal-valued status is dropped.
       if (event.type === 'status_changed' && isSettled(event.status)) {
+        drop('settled-status-changed');
         continue;
       }
       if (runId !== undefined) {
@@ -336,6 +353,7 @@ function applyDeltaEvents(
         // run's low sequence numbers are not dropped on later events.
         const isRotation = event.type === 'spawned' && event.runId !== runId;
         if (!isRotation && (event.runId !== runId || event.sequence <= (high ?? -1))) {
+          drop(event.runId !== runId ? 'run-mismatch' : 'sequence-regression');
           continue;
         }
       } else if (event.type === 'status_changed') {
@@ -343,16 +361,32 @@ function applyDeltaEvents(
         // when the run was never seeded (its spawned delta was dropped); it
         // never opens the run's live stream and never un-settles a terminal
         // row (a carried status can land after a snapshot already settled it).
-        if (!state.records.some((item) => item.id === subagentId && !isSettled(item.status))) continue;
+        if (!state.records.some((item) => item.id === subagentId && !isSettled(item.status))) {
+          drop('status-without-row');
+          continue;
+        }
       } else if (event.type !== 'spawned' && event.type !== 'terminal') {
         // Only a spawned seed can open an unknown run. A terminal is the
         // authoritative record handoff, so it applies regardless: replacing
         // the row settles a dropped-seed record instead of leaving it running.
+        drop('unseeded-run');
         continue;
       }
       applicable.push(event);
       if (event.type === 'spawned') runId = event.runId;
       high = event.sequence;
+    }
+    warnDroppedDeltas(subagentId, dropped, runId, knownRun);
+    // A run whose deltas were dropped for a missing/stale seed can only be
+    // re-opened by a fresh `spawned` or a snapshot seed. Surface that need so
+    // the hook can refresh once instead of freezing the stream.
+    if (
+      (dropped.has('unseeded-run') || dropped.has('run-mismatch'))
+      && !state.seedHints.has(subagentId)
+      && state.records.some((item) => item.id === subagentId && !isSettled(item.status))
+    ) {
+      seedHints ??= new Set(state.seedHints);
+      seedHints.add(subagentId);
     }
     if (applicable.length === 0) continue;
 
@@ -367,6 +401,7 @@ function applyDeltaEvents(
     let draft: LiveDraft | null =
       existing && existing.runId === runId ? draftFromProjection(existing) : null;
     let settled = false;
+    let skippedWithoutDraft = 0;
     for (const event of applicable) {
       if (event.type === 'spawned') {
         // Upsert: append on first spawn, replace on run rotation (the
@@ -406,7 +441,14 @@ function applyDeltaEvents(
             item.id === subagentId ? { ...item, status: promotedState } : item
           ));
         }
+      } else {
+        skippedWithoutDraft += 1;
       }
+    }
+    if (skippedWithoutDraft > 0) {
+      warnOncePerSecond(`subagent-stream:${subagentId}:no-draft`,
+        `[subagent-stream] dropped ${skippedWithoutDraft} content delta(s) for ${subagentId}: ` +
+        `no live projection for run ${String(runId)} (a snapshot seed or rotation spawned is needed to resume)`);
     }
 
     if (settled) {
@@ -418,7 +460,7 @@ function applyDeltaEvents(
     }
   }
 
-  if (records === state.records && live === null && highWater === null && runs === null) {
+  if (records === state.records && live === null && highWater === null && runs === null && seedHints === null) {
     return state;
   }
   return {
@@ -427,6 +469,7 @@ function applyDeltaEvents(
     live: live ?? state.live,
     highWater: highWater ?? state.highWater,
     runs: runs ?? state.runs,
+    seedHints: seedHints ?? state.seedHints,
   };
 }
 
@@ -472,7 +515,14 @@ export function applyDeltaBatch(
   batch: SubagentEvent,
   options: SubagentDeltaBatchOptions = {},
 ): SubagentStreamState {
-  if (state.sessionId !== batch.sessionId) return state;
+  if (state.sessionId !== batch.sessionId) {
+    warnOncePerSecond(
+      `subagent-stream:session-mismatch:${batch.sessionId}`,
+      `[subagent-stream] dropped a delta batch for session ${batch.sessionId} ` +
+      `while bound to ${String(state.sessionId)}`,
+    );
+    return state;
+  }
   if (state.hydration === 'loading') {
     return bufferDeltaEvents(
       state,
@@ -506,6 +556,7 @@ function seedSnapshotNow(state: SubagentStreamState, snapshot: SubagentSnapshot)
     buffered: [],
     bufferedBytes: 0,
     reseedFloor: null,
+    seedHints: new Set(),
     error: null,
   };
 }
@@ -527,4 +578,38 @@ export function seedSubagentSnapshot(
 
 export function failSubagentSnapshot(state: SubagentStreamState, error: string): SubagentStreamState {
   return { ...state, hydration: 'error', error, buffered: [], bufferedBytes: 0 };
+}
+
+// ── Drop observability ─────────────────────────────────────────────────────
+
+const lastWarnAt = new Map<string, number>();
+
+/** Throttle repeat warnings per key so a wedged stream logs at most once a second. */
+function warnOncePerSecond(key: string, message: string): void {
+  const now = Date.now();
+  const last = lastWarnAt.get(key) ?? 0;
+  if (now - last < 1000) return;
+  lastWarnAt.set(key, now);
+  console.warn(message);
+}
+
+/**
+ * Log (throttled, per subagent) why a flush's deltas were dropped. A single
+ * dropped `spawned` seed wedges that run's whole live stream — the renderer
+ * stays frozen until the next snapshot reseed (view re-entry, turn end) — so
+ * these otherwise-silent drops must be visible while debugging stalls.
+ */
+function warnDroppedDeltas(
+  subagentId: string,
+  dropped: ReadonlyMap<string, number>,
+  runId: string | undefined,
+  knownRun: string | undefined,
+): void {
+  if (dropped.size === 0) return;
+  const reasons = [...dropped.entries()].map(([reason, count]) => `${reason}×${count}`).join(', ');
+  warnOncePerSecond(
+    `subagent-stream:${subagentId}:${reasons}`,
+    `[subagent-stream] dropped deltas for ${subagentId} (${reasons}); ` +
+    `event runId=${String(runId)} renderer runId=${String(knownRun)}`,
+  );
 }

--- a/electron/tests/unit/use-subagents-live.test.ts
+++ b/electron/tests/unit/use-subagents-live.test.ts
@@ -1057,4 +1057,41 @@ describe('seed hints: self-healing a missed run seed', () => {
     expect(state.seedHints.size).toBe(0);
     expect(state.runs.get('one')).toBe('run-9');
   });
+
+  it('keeps the hint when a stale snapshot omits the run: the buffered replay re-raises it for the retry', () => {
+    let state = seeded(sessionA, 3, [record('one', 'running')]);
+    state = beginSubagentSnapshotRefresh(state, sessionA);
+    state = applyDeltaBatch(state, batch([textDelta(1, 'work', { runId: 'run-9' })]));
+    expect(state.buffered).toHaveLength(1);
+    // The landing snapshot omits the run's live projection (stale, or the run
+    // is not yet exported): the seed clears the hint set, but the buffered
+    // wrong-run delta replays against the unseeded run and re-raises it, so
+    // hydrate's post-seed check retries instead of wedging.
+    state = seedSubagentSnapshot(state, snapshot(sessionA, 4, [record('one', 'running')]));
+    expect(state.runs.has('one')).toBe(false);
+    expect([...state.seedHints]).toEqual(['one']);
+    // A fresh wrong-run delta for the same subagent does not grow the set
+    // (once per subagent): the retry path, not repeated hints, owns recovery.
+    const after = applyDeltaBatch(state, batch([textDelta(2, 'still', { runId: 'run-9' })]));
+    expect(after.seedHints.size).toBe(1);
+  });
+
+  it('leaves no stale hint when a terminal settles the row later in the same batch', () => {
+    let state = seeded(sessionA, 3, [record('one', 'running')], [projection({ subagentId: 'one', runId: 'run-1', sequence: 3 })]);
+    // The wrong-run content delta alone would raise a hint, but the terminal
+    // for the KNOWN run in the same envelope settles the row: the hint must
+    // not survive. (A terminal from the wrong run itself is dropped as a
+    // run-mismatch, so it can never be the settling event here.)
+    const done = { ...record('one', 'completed'), end_time: '2026-01-01T00:00:09.000Z' };
+    state = applyDeltaBatch(state, batch([
+      textDelta(4, 'wrong-run', { runId: 'run-2' }),
+      terminal('one', 'run-1', done, 5),
+    ]));
+    expect(state.records[0]).toBe(done);
+    expect(state.seedHints.size).toBe(0);
+    // The pure wedge (no terminal) still raises the hint.
+    let wedge = seeded(sessionA, 3, [record('one', 'running')], [projection({ subagentId: 'one', runId: 'run-1', sequence: 3 })]);
+    wedge = applyDeltaBatch(wedge, batch([textDelta(4, 'wrong-run', { runId: 'run-2' })]));
+    expect([...wedge.seedHints]).toEqual(['one']);
+  });
 });

--- a/electron/tests/unit/use-subagents-live.test.ts
+++ b/electron/tests/unit/use-subagents-live.test.ts
@@ -336,11 +336,20 @@ describe('subagent delta application', () => {
     expect(state.live.has('one')).toBe(false);
   });
 
-  it('drops sequence regressions, wrong runs, unknown runs, and mismatched seeds without state change', () => {
+  it('drops sequence regressions without state change; wrong-run drops raise a seed hint for a held row', () => {
     const state = seeded(sessionA, 3, [record('one', 'running')], [projection({ subagentId: 'one', sequence: 3 })]);
     expect(applyDeltaBatch(state, batch([textDelta(3, 'dup')]))).toBe(state);
     expect(applyDeltaBatch(state, batch([textDelta(2, 'old')]))).toBe(state);
-    expect(applyDeltaBatch(state, batch([textDelta(4, 'wrong-run', { runId: 'run-2' })]))).toBe(state);
+    // A run the renderer never seeded (missed rotation spawned) freezes the
+    // live stream; the drop now raises a seed hint so the hook can refresh.
+    const mismatched = applyDeltaBatch(state, batch([textDelta(4, 'wrong-run', { runId: 'run-2' })]));
+    expect(mismatched).not.toBe(state);
+    expect(mismatched.records).toBe(state.records);
+    expect(mismatched.live).toBe(state.live);
+    expect([...mismatched.seedHints]).toEqual(['one']);
+    // The hint is raised once per subagent: further wrong-run drops stay put.
+    expect(applyDeltaBatch(mismatched, batch([textDelta(5, 'still-wrong', { runId: 'run-2' })]))).toBe(mismatched);
+    // A subagent with no held row cannot be converged by a snapshot.
     expect(applyDeltaBatch(state, batch([textDelta(1, 'unknown', { subagentId: 'other' })]))).toBe(state);
 
     const mixed = applyDeltaBatch(state, batch([textDelta(2, 'stale'), textDelta(4, 'fresh')]));
@@ -921,12 +930,16 @@ describe('run rotation for resumed subagents', () => {
       textDelta(1, 'B', { runId: 'run-B', sessionRevision: 5 }),
     ]));
 
-    // A late text_delta carrying run A's runId is dropped without state change.
+    // A late text_delta carrying run A's runId is dropped without content
+    // change; the row is still running, so the drop raises a seed hint (the
+    // renderer cannot tell a superseded generation from a missed rotation).
     const before = state;
     state = applyDeltaBatch(state, batch([
       textDelta(3, 'stale A', { runId: 'run-A', sessionRevision: 6 }),
     ]));
-    expect(state).toBe(before);
+    expect(state.records).toBe(before.records);
+    expect(state.live).toBe(before.live);
+    expect([...state.seedHints]).toEqual(['one']);
     expect(state.live.get('one')?.segments).toEqual([{ kind: 'text', id: 'seg-text', content: 'B', startedAt: SEG_OPENED_AT, endedAt: null }]);
   });
 
@@ -993,5 +1006,55 @@ describe('run rotation for resumed subagents', () => {
     groups = groupSubagents(state.records);
     expect(groups.queued.map((item) => item.id)).toEqual(['one']);
     expect(groups.ended).toHaveLength(0);
+  });
+});
+
+describe('seed hints: self-healing a missed run seed', () => {
+  it('raises a hint for an unseeded run with a held row, then converges via snapshot seed', () => {
+    // The renderer holds a running row but never saw this run's spawned.
+    let state = seeded(sessionA, 3, [record('one', 'running')]);
+    state = applyDeltaBatch(state, batch([textDelta(1, 'work', { runId: 'run-9' })]));
+    expect(state.live.size).toBe(0);
+    expect([...state.seedHints]).toEqual(['one']);
+
+    // The hint directs one snapshot refresh; the fresh snapshot carries the
+    // live projection for the missed run and clears the hint.
+    state = seedSubagentSnapshot(
+      beginSubagentSnapshotRefresh(state, sessionA),
+      snapshot(sessionA, 4, [record('one', 'running')], [
+        projection({ subagentId: 'one', runId: 'run-9', sequence: 1, segments: [
+          { kind: 'text', id: 'seg-text', content: 'work', startedAt: SEG_OPENED_AT, endedAt: null },
+        ] }),
+      ]),
+    );
+    expect(state.seedHints.size).toBe(0);
+    expect(state.runs.get('one')).toBe('run-9');
+
+    // Post-seed content streams normally again.
+    state = applyDeltaBatch(state, batch([textDelta(2, ' more', { runId: 'run-9' })]));
+    expect(state.live.get('one')?.segments.at(-1)).toMatchObject({ content: 'work more' });
+  });
+
+  it('does not hint for a settled row or a subagent with no row', () => {
+    const settled = seeded(sessionA, 3, [{ ...record('one', 'completed'), end_time: '2026-01-01T00:00:09.000Z' }]);
+    expect(applyDeltaBatch(settled, batch([textDelta(4, 'late', { runId: 'run-2' })]))).toBe(settled);
+
+    const empty = seeded(sessionA, 3);
+    expect(applyDeltaBatch(empty, batch([textDelta(4, 'unknown', { subagentId: 'ghost' })]))).toBe(empty);
+  });
+
+  it('keeps buffered batches hint-free: hints are evaluated when the batch replays after the seed', () => {
+    let state = seeded(sessionA, 3, [record('one', 'running')]);
+    state = beginSubagentSnapshotRefresh(state, sessionA);
+    // While loading, the batch is buffered — no hint yet.
+    state = applyDeltaBatch(state, batch([textDelta(1, 'work', { runId: 'run-9' })]));
+    expect(state.seedHints.size).toBe(0);
+    expect(state.buffered).toHaveLength(1);
+    // The snapshot that lands carries the run: the buffered replay applies.
+    state = seedSubagentSnapshot(state, snapshot(sessionA, 4, [record('one', 'running')], [
+      projection({ subagentId: 'one', runId: 'run-9', sequence: 1 }),
+    ]));
+    expect(state.seedHints.size).toBe(0);
+    expect(state.runs.get('one')).toBe('run-9');
   });
 });

--- a/electron/tests/unit/use-subagents-seed-hint.test.tsx
+++ b/electron/tests/unit/use-subagents-seed-hint.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SubagentEvent, SubagentSnapshot } from '../../src/shared/types/ipc';
+import type {
+  SubagentDeltaEvent,
+  SubagentLiveProjection,
+  SubagentSummary,
+} from '../../src/shared/types/subagent';
+import { useSubagents } from '../../src/renderer/hooks/useSubagents';
+
+const sessionId = '11111111-1111-4111-8111-111111111111';
+
+const row: SubagentSummary = {
+  id: 'one',
+  agent_name: 'Explorer',
+  agent_type: 'explorer',
+  agent_tier: 'bloom',
+  agentRole: 'explorer',
+  task: 'Inspect the repository',
+  status: 'running',
+  chain_id: 'chain-one',
+  start_time: '2026-01-01T00:00:00.000Z',
+  end_time: null,
+  parentChainIndex: 0,
+  usage: null,
+};
+
+const runLive: SubagentLiveProjection = {
+  sessionId,
+  subagentId: 'one',
+  runId: 'run-9',
+  sequence: 1,
+  state: 'running',
+  segments: [],
+  toolCalls: [],
+  usage: null,
+  result: null,
+  error: null,
+  compactionProgress: null,
+};
+
+function snapshot(revision: number, live: SubagentLiveProjection[] = []): SubagentSnapshot {
+  return { sessionId, sessionRevision: revision, records: [row], live };
+}
+
+function wrongRunDelta(sequence: number): SubagentDeltaEvent {
+  return {
+    sessionId,
+    subagentId: 'one',
+    runId: 'run-9',
+    sequence,
+    sessionRevision: sequence,
+    type: 'text_delta',
+    segmentId: 'seg-text',
+    append: `work-${sequence}`,
+  };
+}
+
+function runDelta(sequence: number, append: string): SubagentDeltaEvent {
+  return {
+    sessionId,
+    subagentId: 'one',
+    runId: 'run-9',
+    sequence,
+    sessionRevision: sequence,
+    type: 'text_delta',
+    segmentId: 'seg-text',
+    append,
+  };
+}
+
+/** Snapshot mock resolving one manually-controlled deferred per call. */
+function createSnapshotQueue() {
+  const pending: Array<(value: SubagentSnapshot) => void> = [];
+  const snapshotFn = vi.fn(
+    () => new Promise<SubagentSnapshot>((resolve) => { pending.push(resolve); }),
+  );
+  const resolveNext = (value: SubagentSnapshot): void => {
+    const resolve = pending.shift();
+    if (resolve) resolve(value);
+  };
+  return { snapshotFn, resolveNext };
+}
+
+function installOrchid(snapshotFn: ReturnType<typeof createSnapshotQueue>['snapshotFn']): (event: SubagentEvent) => void {
+  let listener: ((event: SubagentEvent) => void) | null = null;
+  window.orchid = {
+    config: { get: vi.fn().mockResolvedValue({ subagents: { hydration_buffer_kb: 256 } }) },
+    session: { onSubagentsChanged: () => () => undefined },
+    subagents: {
+      snapshot: snapshotFn,
+      detail: vi.fn(),
+      onEvent: (cb: (event: SubagentEvent) => void) => {
+        listener = cb;
+        return () => { listener = null; };
+      },
+    },
+  } as never;
+  return (event) => { listener?.(event); };
+}
+
+describe('useSubagents seed-hint self-heal', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('retries the bounded reseed when a stale snapshot omits the hinted run', async () => {
+    const queue = createSnapshotQueue();
+    const emit = installOrchid(queue.snapshotFn);
+    const { result } = renderHook(() => useSubagents(sessionId));
+
+    // A wrong-run delta arrives while the initial hydrate is still loading:
+    // it buffers, then replays after the seed.
+    await waitFor(() => expect(queue.snapshotFn).toHaveBeenCalledTimes(1));
+    act(() => emit({ sessionId, events: [wrongRunDelta(1)] }));
+
+    // The landing snapshot omits the run: the replay re-raises the hint, and
+    // hydrate's post-seed check drives one retry.
+    await act(async () => { queue.resolveNext(snapshot(4)); });
+    await waitFor(() => expect(queue.snapshotFn).toHaveBeenCalledTimes(2));
+
+    // The retry's snapshot carries the run: seeded, hint cleared, streaming.
+    await act(async () => { queue.resolveNext(snapshot(5, [runLive])); });
+    await waitFor(() => expect(result.current.getLive('one')?.runId).toBe('run-9'));
+
+    // The dropped wrong-run text is gone by design (snapshots never carry
+    // it); post-seed content for the now-known run streams normally.
+    act(() => emit({ sessionId, events: [runDelta(2, ' more')] }));
+    await waitFor(() => expect(result.current.getLive('one')?.segments.at(-1)).toMatchObject({ content: ' more' }));
+    expect(queue.snapshotFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after the reseed budget and clears hints so a later run can re-heal', async () => {
+    const queue = createSnapshotQueue();
+    const emit = installOrchid(queue.snapshotFn);
+
+    const { result } = renderHook(() => useSubagents(sessionId));
+    await waitFor(() => expect(queue.snapshotFn).toHaveBeenCalledTimes(1));
+    // Each loading window buffers one fresh wrong-run delta, so every seed's
+    // replay re-raises the hint: initial + 3 retries = 4 snapshot calls.
+    for (let attempt = 1; attempt <= 4; attempt += 1) {
+      act(() => emit({ sessionId, events: [wrongRunDelta(attempt)] }));
+      await act(async () => { queue.resolveNext(snapshot(4 + attempt)); });
+      const expectedCalls = attempt + 1;
+      if (attempt < 4) {
+        await waitFor(() => expect(queue.snapshotFn).toHaveBeenCalledTimes(expectedCalls));
+      } else {
+        // The last attempt hits the budget: no further hydrate fires.
+        await act(async () => { await Promise.resolve(); });
+        expect(queue.snapshotFn).toHaveBeenCalledTimes(4);
+      }
+    }
+    expect(result.current.state.status).toBe('ready');
+    expect(result.current.getLive('one')).toBeNull();
+
+    // The exhausted hints were cleared: a fresh wrong-run delta re-raises one
+    // (observable as one more hydrate) instead of being swallowed by the
+    // once-per-subagent guard.
+    await act(async () => { await Promise.resolve(); });
+    expect(queue.snapshotFn).toHaveBeenCalledTimes(4);
+    act(() => emit({ sessionId, events: [wrongRunDelta(10)] }));
+    await waitFor(() => expect(queue.snapshotFn).toHaveBeenCalledTimes(5));
+    await act(async () => { queue.resolveNext(snapshot(10, [runLive])); });
+    await waitFor(() => expect(result.current.getLive('one')?.runId).toBe('run-9'));
+  });
+});


### PR DESCRIPTION
## Problem

A running subagent's live output can silently stop streaming — the transcript freezes during thinking/tool phases and only updates when the user exits and re-enters the subagent view, or when the current phase (or the whole run) ends. After that, streaming appears normal again until the next occurrence.

## Root cause

The renderer's delta reducer only opens a run's live stream from its one `spawned` delta (or a snapshot seed). If that single event is lost in flight, **every subsequent content delta of the run is dropped silently** by the `unseeded-run` / `run-mismatch` guards — thinking and tool events included — and nothing re-asserts the seed. The stream stays wedged until any snapshot lands (turn end, view re-entry — which is why re-entering the view "fixed" it: the detail request carries the authoritative live tail).

Compounding it, **every drop point along the pipeline was completely silent**: the renderer guards, the batcher's ineligible-session content drops, and its ~640 ms stall-budget carry drops. With nothing logged, the freeze looked like "the model is thinking" rather than a delivery gap.

What the diff can't show: each layer was verified convergent in isolation (reproduction driving the real assembler → projection store → batcher → reducer composition, plus a hook mount test across thinking/tool/refresh phases — all green). The failure needs the one-shot seed to be *lost*, which the transport's known transient windows (eligibility races, client-sweep gaps) can do.

## Fix

**Self-heal (the behavioral fix)** — `subagent-stream.ts` + `useSubagents.ts`: when deltas are dropped because the renderer holds no seed for a still-running row, the reducer raises a bounded `seedHints` set; the hook reacts to hint growth with one snapshot refresh that reseeds the run and resumes streaming automatically. No user action needed.

Bounds: raised at most once per subagent per seed epoch, cleared on seed, skipped for settled or row-less subagents, and not raised while hydration is buffering (the batch replays after the seed anyway). A missed seed now costs one snapshot round-trip instead of the whole run's liveness.

**Drop observability** — throttled warnings at every previously-silent hop:
- Renderer: per-guard drop reasons with counts and event-vs-renderer `runId` (`record-id-mismatch`, `settled-status-changed`, `run-mismatch`, `sequence-regression`, `unseeded-run`, `status-without-row`, plus content deltas arriving with no live draft).
- Main: batcher logs when content deltas are dropped for a session with no eligible recipient, and when a carried lifecycle delta is dropped past the stall budget.

If the symptom reproduces, the console now names the failing hop directly — `unseeded-run` + main-side eligibility drops point at the transport (candidate follow-up: raise the stall budget to the time-based ~2 s its comment already claims); `run-mismatch` alone points at a missed rotation `spawned`; nothing logged means the events never left main.

## Verification

- New regression tests: hint → snapshot seed → streaming resumes; no hint for settled/row-less subagents; buffered batches stay hint-free until post-seed replay.
- Updated the two tests that previously pinned wrong-run drops as pure state no-ops.
- Full unit suite: **347 files / 5283 tests green**; `tsc` (node + app configs) and `eslint` clean on all touched files.

## Notes

- `seedHints` follows the existing reseed-floor pattern (state flag → hook reacts → snapshot heals), so no new IPC surface was added.
- Follow-up candidates (not in scope): time-based stall budget for the carry, and a diagnostic push-event for transport drops so the renderer can react without console parsing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live subagent updates by automatically refreshing stale or missing run data instead of allowing streams to freeze.
  * Added clearer handling for dropped or mismatched subagent events, helping preserve current session state.
* **Diagnostics**
  * Added throttled warnings for dropped, delayed, or unprocessable subagent events to improve troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->